### PR TITLE
[feat] 메인 매칭 흐름을 matches/me 기준으로 재구성

### DIFF
--- a/src/app/api/matches/me/route.ts
+++ b/src/app/api/matches/me/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { MatchStatusResponse } from "@/shared/api/contracts";
+import {
+  fetchBackend,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
+
+  if (!token) {
+    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  try {
+    const response = await fetchBackend("/api/v1/matches/me", { token });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    const body = await readJsonBody<MatchStatusResponse>(response);
+    return NextResponse.json(
+      body ?? {
+        status: "IDLE",
+        roomId: null,
+      } satisfies MatchStatusResponse,
+    );
+  } catch {
+    return NextResponse.json(
+      { message: "매칭 상태 조회에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/queue/cancel/route.ts
+++ b/src/app/api/queue/cancel/route.ts
@@ -10,7 +10,6 @@ import {
 import {
   FRONTEND_ACCESS_TOKEN_COOKIE,
   getSessionMemberFromToken,
-  parseMatchedRoomId,
 } from "@/shared/auth/session";
 
 function unauthorizedResponse() {
@@ -52,7 +51,6 @@ export async function DELETE() {
       category: body?.category ?? "",
       difficulty: body?.difficulty ?? "",
       waitingCount: body?.waitingCount ?? 0,
-      matchedRoomId: body?.message ? parseMatchedRoomId(body.message) : null,
     };
 
     return NextResponse.json(result);

--- a/src/app/api/queue/join/route.ts
+++ b/src/app/api/queue/join/route.ts
@@ -14,7 +14,6 @@ import {
 import {
   FRONTEND_ACCESS_TOKEN_COOKIE,
   getSessionMemberFromToken,
-  parseMatchedRoomId,
 } from "@/shared/auth/session";
 
 function unauthorizedResponse() {
@@ -64,7 +63,6 @@ export async function POST(request: Request) {
             category: queueState.category ?? payload.category,
             difficulty: queueState.difficulty ?? payload.difficulty,
             waitingCount: queueState.waitingCount,
-            matchedRoomId: null,
           } satisfies QueueStatusResponse,
           { status: 409 },
         );
@@ -97,7 +95,6 @@ export async function POST(request: Request) {
       category: body?.category ?? payload.category,
       difficulty: body?.difficulty ?? payload.difficulty,
       waitingCount: body?.waitingCount ?? 0,
-      matchedRoomId: body?.message ? parseMatchedRoomId(body.message) : null,
     };
 
     return NextResponse.json(result);

--- a/src/features/home/data.ts
+++ b/src/features/home/data.ts
@@ -1,40 +1,6 @@
 import type { Difficulty } from "@/shared/api/contracts";
 
-export type MatchTicketStatus = "MATCH_FOUND" | "ACCEPTED" | "READY_TO_ENTER";
-
-export interface MatchTicketState {
-  ticketId: string;
-  roomId: number;
-  category: string;
-  difficulty: string;
-  maxPlayers: number;
-  acceptedMemberIds: number[];
-  deadlineAt: string;
-  status: MatchTicketStatus;
-}
-
-export type ReadyCheckMessage =
-  | {
-      type: "MATCH_FOUND";
-      ticket: MatchTicketState;
-    }
-  | {
-      type: "ACCEPTED";
-      ticketId: string;
-      roomId: number;
-      memberId: number;
-      acceptedMemberIds: number[];
-      maxPlayers: number;
-    }
-  | {
-      type: "DECLINED";
-      ticketId: string;
-      memberId: number;
-      acceptedMemberIds: number[];
-    };
-
-export const READY_CHECK_TIMEOUT_MS = 15_000;
-export const READY_CHECK_CHANNEL = "algo-battle-ready-check";
+export const SEARCH_POLL_INTERVAL_MS = 1_000;
 
 export const queueCategories: Array<{
   value:
@@ -96,39 +62,6 @@ export function getQueueCategoryLabel(category: string | null) {
   return queueCategories.find((item) => item.value === category)?.label ?? category;
 }
 
-export function createMatchTicket(params: {
-  roomId: number;
-  category: string;
-  difficulty: string;
-  maxPlayers?: number;
-}) {
-  const maxPlayers = params.maxPlayers ?? 4;
-
-  return {
-    ticketId: `ticket-${params.roomId}`,
-    roomId: params.roomId,
-    category: params.category,
-    difficulty: params.difficulty,
-    maxPlayers,
-    acceptedMemberIds: [],
-    deadlineAt: new Date(Date.now() + READY_CHECK_TIMEOUT_MS).toISOString(),
-    status: "MATCH_FOUND",
-  } satisfies MatchTicketState;
-}
-
-export function acceptMatchTicket(ticket: MatchTicketState, memberId: number) {
-  const acceptedMemberIds = ticket.acceptedMemberIds.includes(memberId)
-    ? ticket.acceptedMemberIds
-    : [...ticket.acceptedMemberIds, memberId];
-
-  return {
-    ...ticket,
-    acceptedMemberIds,
-    status:
-      acceptedMemberIds.length >= ticket.maxPlayers ? "READY_TO_ENTER" : "ACCEPTED",
-  } satisfies MatchTicketState;
-}
-
 export function formatClock(totalSeconds: number) {
   const safeSeconds = Math.max(0, totalSeconds);
   const minutes = Math.floor(safeSeconds / 60);
@@ -143,8 +76,4 @@ export function getElapsedSeconds(startedAt: string | null, now: number) {
   }
 
   return Math.floor((now - new Date(startedAt).getTime()) / 1000);
-}
-
-export function getCountdownSeconds(deadlineAt: string, now: number) {
-  return Math.max(0, Math.ceil((new Date(deadlineAt).getTime() - now) / 1000));
 }

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -1,86 +1,58 @@
 "use client";
 
-import type { QueueStateResponse } from "@/shared/api/contracts";
 import { StatusPill } from "@/shared/ui";
 
-import type { MatchTicketState } from "./data";
 import { formatClock } from "./data";
 
 interface QueueModalProps {
+  isOpen: boolean;
   categoryLabel: string;
   difficultyLabel: string;
   error: string | null;
   feedback: string;
-  hasAccepted: boolean;
   isPending: boolean;
   queueElapsedSeconds: number;
-  queueState: QueueStateResponse;
-  readyCountdownSeconds: number;
-  ticket: MatchTicketState | null;
-  onAccept: () => void;
+  waitingCount: number;
   onCancel: () => void;
-  onDecline: () => void;
 }
 
 export default function QueueModal({
+  isOpen,
   categoryLabel,
   difficultyLabel,
   error,
   feedback,
-  hasAccepted,
   isPending,
   queueElapsedSeconds,
-  queueState,
-  readyCountdownSeconds,
-  ticket,
-  onAccept,
+  waitingCount,
   onCancel,
-  onDecline,
 }: QueueModalProps) {
-  const isOpen = queueState.inQueue || ticket !== null;
-
   if (!isOpen) {
     return null;
   }
-
-  const isReadyCheck = ticket !== null;
-  const acceptedCount = ticket?.acceptedMemberIds.length ?? 0;
-  const maxPlayers = ticket?.maxPlayers ?? 4;
-  const isReadyToEnter = ticket?.status === "READY_TO_ENTER";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 p-4">
       <div className="w-full max-w-xl rounded-[2rem] border border-zinc-300 bg-white p-6 shadow-2xl">
         <div className="flex flex-wrap items-center gap-2">
-          <StatusPill tone={isReadyCheck ? "success" : "warn"}>
-            {isReadyCheck ? "매칭 수락" : "큐 대기 중"}
-          </StatusPill>
+          <StatusPill tone="warn">큐 대기 중</StatusPill>
           <StatusPill>{categoryLabel}</StatusPill>
           <StatusPill>{difficultyLabel}</StatusPill>
-          <StatusPill>
-            {isReadyCheck ? `${acceptedCount} / ${maxPlayers}` : `${queueState.waitingCount} / 4`}
-          </StatusPill>
+          <StatusPill>{waitingCount} / 4</StatusPill>
         </div>
 
         <div className="mt-6 flex items-center gap-4">
-          <div
-            className={`flex size-16 shrink-0 items-center justify-center rounded-full border-4 text-sm font-semibold ${
-              isReadyCheck
-                ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-                : "animate-spin border-zinc-300 border-t-zinc-950 bg-zinc-50 text-transparent"
-            }`}
-          >
-            {isReadyCheck ? formatClock(readyCountdownSeconds) : ""}
+          <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-300 border-t-zinc-950 bg-zinc-50 text-transparent">
+            .
           </div>
 
           <div>
             <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
-              {isReadyCheck ? "매칭이 성사됐습니다" : "큐를 찾는 중입니다"}
+              큐를 찾는 중입니다
             </h2>
             <p className="mt-2 text-sm leading-7 text-zinc-600">
-              {isReadyCheck
-                ? "지정된 시간 안에 모두 수락하면 배틀룸으로 이동합니다. 한 명이라도 수락하지 않으면 남은 인원은 다시 대기열로 돌아갑니다."
-                : "메인 화면 위에서 롤 큐처럼 현재 대기 상태를 유지합니다. 매칭이 잡히면 준비 완료 모달로 전환됩니다."}
+              메인 화면 위에서 롤 큐처럼 현재 대기 상태를 유지합니다.
+              `/matches/me`가 `MATCHED`를 반환하면 즉시 배틀룸으로 이동합니다.
             </p>
           </div>
         </div>
@@ -106,55 +78,28 @@ export default function QueueModal({
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
               현재 인원
             </p>
-            <p className="mt-2 font-medium text-zinc-950">
-              {isReadyCheck ? `${acceptedCount} / ${maxPlayers}` : `${queueState.waitingCount} / 4`}
-            </p>
+            <p className="mt-2 font-medium text-zinc-950">{waitingCount} / 4</p>
           </div>
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-              {isReadyCheck ? "수락 제한 시간" : "큐 상태"}
+              큐 상태
             </p>
-            <p className="mt-2 font-medium text-zinc-950">
-              {isReadyCheck ? formatClock(readyCountdownSeconds) : "검색 중"}
-            </p>
+            <p className="mt-2 font-medium text-zinc-950">검색 중</p>
           </div>
         </div>
 
         <div className="mt-6 grid gap-3 sm:grid-cols-2">
-          {isReadyCheck ? (
-            <>
-              <button
-                type="button"
-                onClick={onAccept}
-                disabled={hasAccepted || isReadyToEnter}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
-              >
-                {isReadyToEnter ? "전원 수락 완료" : hasAccepted ? "준비 완료" : "준비 완료"}
-              </button>
-              <button
-                type="button"
-                onClick={onDecline}
-                disabled={hasAccepted || isReadyToEnter || isPending}
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-              >
-                수락 안 함
-              </button>
-            </>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={onCancel}
-                disabled={isPending}
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-              >
-                큐 취소
-              </button>
-              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
-                수락 모달이 뜨면 15초 안에 확인해야 합니다.
-              </div>
-            </>
-          )}
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+          >
+            큐 취소
+          </button>
+          <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+            취소 버튼은 백엔드 매칭 상태가 `SEARCHING`일 때만 노출됩니다.
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -7,24 +7,27 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import type {
   ApiErrorResponse,
   Difficulty,
+  MatchStatusResponse,
   QueueStateResponse,
   QueueStatusResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
-import { ApiCallout, MetricCard, MetricGrid, PageHero, Panel, StatusPill } from "@/shared/ui";
+import {
+  ApiCallout,
+  MetricCard,
+  MetricGrid,
+  PageHero,
+  Panel,
+  StatusPill,
+} from "@/shared/ui";
 
 import {
-  acceptMatchTicket,
-  createMatchTicket,
   dashboardMenus,
   difficultyOptions,
-  getCountdownSeconds,
   getElapsedSeconds,
   getQueueCategoryLabel,
   queueCategories,
-  READY_CHECK_CHANNEL,
-  type MatchTicketState,
-  type ReadyCheckMessage,
+  SEARCH_POLL_INTERVAL_MS,
 } from "./data";
 import QueueModal from "./queue-modal";
 
@@ -33,6 +36,11 @@ const defaultQueueState: QueueStateResponse = {
   category: null,
   difficulty: null,
   waitingCount: 0,
+};
+
+const defaultMatchState: MatchStatusResponse = {
+  status: "IDLE",
+  roomId: null,
 };
 
 async function readSession() {
@@ -52,20 +60,20 @@ async function readQueueState() {
   const response = await fetch("/api/queue/me", { cache: "no-store" });
 
   if (!response.ok) {
-    return defaultQueueState;
+    return null;
   }
 
   return (await response.json()) as QueueStateResponse;
 }
 
-function broadcastReadyCheckMessage(message: ReadyCheckMessage) {
-  if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
-    return;
+async function readMatchState() {
+  const response = await fetch("/api/matches/me", { cache: "no-store" });
+
+  if (!response.ok) {
+    return null;
   }
 
-  const channel = new BroadcastChannel(READY_CHECK_CHANNEL);
-  channel.postMessage(message);
-  channel.close();
+  return (await response.json()) as MatchStatusResponse;
 }
 
 export default function HomeScreen() {
@@ -75,31 +83,16 @@ export default function HomeScreen() {
     member: null,
   });
   const [queueState, setQueueState] = useState(defaultQueueState);
+  const [matchState, setMatchState] = useState(defaultMatchState);
   const [category, setCategory] = useState<(typeof queueCategories)[number]["value"]>("dp");
   const [difficulty, setDifficulty] = useState<Difficulty>("EASY");
   const [queueStartedAt, setQueueStartedAt] = useState<string | null>(null);
-  const [matchTicket, setMatchTicket] = useState<MatchTicketState | null>(null);
   const [feedback, setFeedback] = useState("메인에서 바로 매칭을 시작하는 구조를 기본값으로 둡니다.");
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(0);
   const [isPending, startTransition] = useTransition();
 
-  const sessionRef = useRef(session);
-  const queueStateRef = useRef(queueState);
-  const matchTicketRef = useRef(matchTicket);
-  const suppressQueueDropNoticeRef = useRef(false);
-
-  useEffect(() => {
-    sessionRef.current = session;
-  }, [session]);
-
-  useEffect(() => {
-    queueStateRef.current = queueState;
-  }, [queueState]);
-
-  useEffect(() => {
-    matchTicketRef.current = matchTicket;
-  }, [matchTicket]);
+  const redirectingRoomIdRef = useRef<number | null>(null);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -116,219 +109,106 @@ export default function HomeScreen() {
       const nextSession = await readSession();
       setSession(nextSession);
 
-      if (nextSession.authenticated) {
-        const nextQueueState = await readQueueState();
-        setQueueState(nextQueueState);
+      if (!nextSession.authenticated) {
+        setQueueState(defaultQueueState);
+        setMatchState(defaultMatchState);
+        setQueueStartedAt(null);
+        return;
+      }
 
-        if (nextQueueState.inQueue) {
-          setQueueStartedAt(new Date().toISOString());
-        }
+      const [nextQueueState, nextMatchState] = await Promise.all([
+        readQueueState(),
+        readMatchState(),
+      ]);
 
-        if (nextQueueState.inQueue && nextQueueState.category === "RANDOM") {
-          setError(
-            "이전 요청으로 전체(무작위) 큐에 들어가 있습니다. 큐를 취소한 뒤 구체 카테고리로 다시 시작해주세요.",
-          );
-        }
+      const resolvedMatchState = nextMatchState ?? defaultMatchState;
+      const resolvedQueueState =
+        nextQueueState ??
+        (resolvedMatchState.status === "SEARCHING"
+          ? {
+              ...defaultQueueState,
+              inQueue: true,
+            }
+          : defaultQueueState);
 
-        if (nextQueueState.inQueue && nextQueueState.category === "GRAPH") {
-          setError(
-            "이전 요청으로 GRAPH 큐에 들어가 있습니다. 큐를 취소한 뒤 새 그래프 카테고리로 다시 시작해주세요.",
-          );
-        }
+      setQueueState(resolvedQueueState);
+      setMatchState(resolvedMatchState);
+
+      if (resolvedMatchState.status === "MATCHED" && resolvedMatchState.roomId !== null) {
+        redirectingRoomIdRef.current = resolvedMatchState.roomId;
+        setError(null);
+        setFeedback(`roomId ${resolvedMatchState.roomId} 배틀룸으로 이동합니다.`);
+        router.push(`/battle/rooms/${resolvedMatchState.roomId}`);
+        return;
+      }
+
+      if (resolvedMatchState.status === "SEARCHING" || resolvedQueueState.inQueue) {
+        setQueueStartedAt((current) => current ?? new Date().toISOString());
+        setFeedback("플레이어를 찾는 중입니다. /matches/me가 MATCHED를 반환하면 배틀룸으로 이동합니다.");
       }
     })();
-  }, []);
+  }, [router]);
 
   useEffect(() => {
-    if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
+    if (!session.authenticated || matchState.status !== "SEARCHING") {
       return;
     }
 
-    const channel = new BroadcastChannel(READY_CHECK_CHANNEL);
+    let active = true;
 
-    const handleMessage = (event: MessageEvent<ReadyCheckMessage>) => {
-      const message = event.data;
-      const currentSession = sessionRef.current;
-      const currentQueueState = queueStateRef.current;
-      const currentTicket = matchTicketRef.current;
+    const poll = async () => {
+      const nextMatchState = await readMatchState();
 
-      if (!currentSession.member) {
+      if (!active || !nextMatchState) {
         return;
       }
 
-      if (message.type === "MATCH_FOUND") {
-        if (currentTicket?.ticketId === message.ticket.ticketId) {
-          return;
-        }
-
-        const isSameQueue =
-          currentQueueState.inQueue &&
-          currentQueueState.category === message.ticket.category &&
-          currentQueueState.difficulty === message.ticket.difficulty;
-
-        if (!isSameQueue) {
-          return;
-        }
-
-        suppressQueueDropNoticeRef.current = true;
-        setQueueState(defaultQueueState);
-        setMatchTicket(message.ticket);
+      if (nextMatchState.status === "MATCHED" && nextMatchState.roomId !== null) {
+        setMatchState(nextMatchState);
+        redirectingRoomIdRef.current = nextMatchState.roomId;
         setError(null);
-        setFeedback("매칭이 성사됐습니다. 15초 안에 준비 완료를 눌러주세요.");
+        setFeedback(`roomId ${nextMatchState.roomId} 배틀룸으로 이동합니다.`);
+        router.push(`/battle/rooms/${nextMatchState.roomId}`);
         return;
       }
 
-      if (!currentTicket || currentTicket.ticketId !== message.ticketId) {
-        return;
-      }
+      if (nextMatchState.status === "SEARCHING") {
+        setMatchState(nextMatchState);
 
-      if (message.type === "ACCEPTED") {
-        const nextTicket = {
-          ...currentTicket,
-          acceptedMemberIds: message.acceptedMemberIds,
-          status:
-            message.acceptedMemberIds.length >= message.maxPlayers
-              ? "READY_TO_ENTER"
-              : "ACCEPTED",
-        } satisfies MatchTicketState;
-
-        setMatchTicket(nextTicket);
-        setError(null);
-        setFeedback(
-          nextTicket.status === "READY_TO_ENTER"
-            ? "전원 수락 완료. 배틀룸으로 이동합니다."
-            : `${message.acceptedMemberIds.length}/${message.maxPlayers}명이 준비 완료했습니다.`,
-        );
-        return;
-      }
-
-      if (message.type === "DECLINED") {
-        const selfMemberId = currentSession.member.memberId;
-        const selfAccepted = currentTicket.acceptedMemberIds.includes(selfMemberId);
-        const selfDeclined = message.memberId === selfMemberId;
-
-        setMatchTicket(null);
-        setError(null);
-
-        if (selfDeclined || !selfAccepted) {
-          setQueueState(defaultQueueState);
-          setQueueStartedAt(null);
-          setFeedback("수락을 완료하지 않아 큐에서 제외되었습니다.");
-          return;
-        }
-
-        // TODO(front-backend): 서버에서 ready-check 실패 후 남은 인원을 다시 큐에 넣고 waitingCount를 내려줘야 한다.
-        setQueueState({
-          inQueue: true,
-          category: currentTicket.category,
-          difficulty: currentTicket.difficulty,
-          waitingCount: message.acceptedMemberIds.length,
-        });
-        setQueueStartedAt(new Date().toISOString());
-        setFeedback("한 명이 수락하지 않아 남은 인원으로 다시 큐를 찾습니다.");
-      }
-    };
-
-    channel.addEventListener("message", handleMessage);
-
-    return () => {
-      channel.removeEventListener("message", handleMessage);
-      channel.close();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!session.authenticated || !queueState.inQueue || matchTicket) {
-      return;
-    }
-
-    const intervalId = window.setInterval(() => {
-      void (async () => {
         const nextQueueState = await readQueueState();
 
-        if (!nextQueueState.inQueue) {
-          if (suppressQueueDropNoticeRef.current) {
-            suppressQueueDropNoticeRef.current = false;
-          } else {
-            setError(
-              "큐는 종료됐지만 ready-check 정보는 아직 프론트 브로드캐스트 임시 구조에 의존합니다. 백엔드에 내 매칭 방 조회 API가 붙으면 이 경로는 교체됩니다.",
-            );
-            setFeedback("큐 상태가 종료되었습니다.");
-          }
+        if (!active) {
+          return;
         }
 
-        setQueueState(nextQueueState);
-      })();
-    }, 3000);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [matchTicket, queueState.inQueue, session.authenticated]);
-
-  useEffect(() => {
-    if (!matchTicket || matchTicket.status === "READY_TO_ENTER") {
-      return;
-    }
-
-    const remainingSeconds = getCountdownSeconds(matchTicket.deadlineAt, now);
-
-    if (remainingSeconds > 0 || !session.member) {
-      return;
-    }
-
-    const memberId = session.member.memberId;
-
-    const timeoutId = window.setTimeout(() => {
-      const selfAccepted = matchTicket.acceptedMemberIds.includes(memberId);
-
-      setMatchTicket(null);
-      setError(null);
-
-      if (selfAccepted) {
-        // TODO(front-backend): 수락 제한 시간이 지나면 서버가 남은 인원을 다시 큐에 올리고 새 ticket을 만들어줘야 한다.
-        setQueueState({
-          inQueue: true,
-          category: matchTicket.category,
-          difficulty: matchTicket.difficulty,
-          waitingCount: matchTicket.acceptedMemberIds.length,
-        });
-        setQueueStartedAt(new Date().toISOString());
-        setFeedback("한 명이 확인하지 않아 남은 인원으로 다시 큐를 찾습니다.");
+        setQueueState(
+          nextQueueState ??
+            ({
+              ...defaultQueueState,
+              inQueue: true,
+            } satisfies QueueStateResponse),
+        );
+        setQueueStartedAt((current) => current ?? new Date().toISOString());
         return;
       }
 
+      setMatchState(nextMatchState);
       setQueueState(defaultQueueState);
       setQueueStartedAt(null);
-      setFeedback("수락 시간이 지나 큐에서 제외되었습니다.");
-    }, 0);
+      setFeedback("큐 상태가 종료되었습니다.");
+    };
+
+    void poll();
+
+    const intervalId = window.setInterval(() => {
+      void poll();
+    }, SEARCH_POLL_INTERVAL_MS);
 
     return () => {
-      window.clearTimeout(timeoutId);
+      active = false;
+      window.clearInterval(intervalId);
     };
-  }, [matchTicket, now, session.member]);
-
-  useEffect(() => {
-    if (
-      !matchTicket ||
-      matchTicket.status !== "READY_TO_ENTER" ||
-      !session.member ||
-      !matchTicket.acceptedMemberIds.includes(session.member.memberId)
-    ) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setFeedback(`roomId ${matchTicket.roomId} 배틀룸으로 이동합니다.`);
-      setMatchTicket(null);
-      setQueueStartedAt(null);
-      router.push(`/battle/rooms/${matchTicket.roomId}`);
-    }, 700);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [matchTicket, router, session.member]);
+  }, [matchState.status, router, session.authenticated]);
 
   function handleProtectedMove(href: string) {
     if (!session.authenticated) {
@@ -352,13 +232,12 @@ export default function HomeScreen() {
       return;
     }
 
-    if (queueState.inQueue || matchTicket) {
-      setFeedback("이미 큐 또는 수락 모달이 진행 중입니다.");
+    if (matchState.status === "SEARCHING") {
+      setFeedback("이미 큐가 진행 중입니다.");
       return;
     }
 
     setError(null);
-    setQueueStartedAt(new Date().toISOString());
 
     startTransition(() => {
       void (async () => {
@@ -373,33 +252,30 @@ export default function HomeScreen() {
           }),
         });
 
-        if (!response.ok) {
-          const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-          setQueueStartedAt(null);
-          setError(payload?.message ?? "큐 참가 요청에 실패했습니다.");
+        const payload = (await response.json().catch(() => null)) as
+          | QueueStatusResponse
+          | ApiErrorResponse
+          | null;
+
+        if (response.status === 409 && payload && "category" in payload) {
+          setQueueState({
+            inQueue: true,
+            category: payload.category,
+            difficulty: payload.difficulty,
+            waitingCount: payload.waitingCount,
+          });
+          setMatchState({
+            status: "SEARCHING",
+            roomId: null,
+          });
+          setQueueStartedAt((current) => current ?? new Date().toISOString());
+          setFeedback(payload.message);
           return;
         }
 
-        const payload = (await response.json()) as QueueStatusResponse;
-        setFeedback(payload.message);
-
-        if (payload.matchedRoomId) {
-          const nextTicket = createMatchTicket({
-            roomId: payload.matchedRoomId,
-            category: payload.category,
-            difficulty: payload.difficulty,
-          });
-
-          suppressQueueDropNoticeRef.current = true;
-          setQueueState(defaultQueueState);
-          setMatchTicket(nextTicket);
-          setFeedback("매칭이 성사됐습니다. 15초 안에 준비 완료를 눌러주세요.");
-
-          // TODO(front-backend): /api/matchmaking/me 또는 내 매칭 방 조회 API가 생기면 이 브로드캐스트 임시 동기화를 제거한다.
-          broadcastReadyCheckMessage({
-            type: "MATCH_FOUND",
-            ticket: nextTicket,
-          });
+        if (!response.ok || !payload || !("category" in payload)) {
+          setQueueStartedAt(null);
+          setError(payload && "message" in payload ? payload.message : "큐 참가 요청에 실패했습니다.");
           return;
         }
 
@@ -409,13 +285,32 @@ export default function HomeScreen() {
           difficulty: payload.difficulty,
           waitingCount: payload.waitingCount,
         });
+        setMatchState({
+          status: "SEARCHING",
+          roomId: null,
+        });
+        setQueueStartedAt(new Date().toISOString());
+        setFeedback(payload.message);
+
+        const nextMatchState = await readMatchState();
+
+        if (nextMatchState?.status === "MATCHED" && nextMatchState.roomId !== null) {
+          setMatchState(nextMatchState);
+          redirectingRoomIdRef.current = nextMatchState.roomId;
+          setError(null);
+          setFeedback(`roomId ${nextMatchState.roomId} 배틀룸으로 이동합니다.`);
+          router.push(`/battle/rooms/${nextMatchState.roomId}`);
+        }
       })();
     });
   }
 
   function handleCancelMatch() {
+    if (matchState.status !== "SEARCHING") {
+      return;
+    }
+
     setError(null);
-    suppressQueueDropNoticeRef.current = true;
 
     startTransition(() => {
       void (async () => {
@@ -423,70 +318,25 @@ export default function HomeScreen() {
           method: "DELETE",
         });
 
+        const payload = (await response.json().catch(() => null)) as
+          | QueueStatusResponse
+          | ApiErrorResponse
+          | null;
+
         if (!response.ok) {
-          const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-          setError(payload?.message ?? "큐 취소 요청에 실패했습니다.");
+          setError(payload && "message" in payload ? payload.message : "큐 취소 요청에 실패했습니다.");
           return;
         }
 
-        const payload = (await response.json()) as QueueStatusResponse;
-        setFeedback(payload.message);
         setQueueState(defaultQueueState);
+        setMatchState(defaultMatchState);
         setQueueStartedAt(null);
+        setFeedback(payload && "message" in payload ? payload.message : "큐 취소가 완료되었습니다.");
       })();
     });
   }
 
-  function handleAcceptMatch() {
-    if (!matchTicket || !session.member) {
-      return;
-    }
-
-    const nextTicket = acceptMatchTicket(matchTicket, session.member.memberId);
-    setMatchTicket(nextTicket);
-    setError(null);
-    setFeedback(
-      nextTicket.status === "READY_TO_ENTER"
-        ? "전원 수락 완료. 배틀룸으로 이동합니다."
-        : `${nextTicket.acceptedMemberIds.length}/${nextTicket.maxPlayers}명이 준비 완료했습니다.`,
-    );
-
-    // TODO(front-backend): POST /api/matchmaking/{ticketId}/accept 응답으로 acceptedCount, deadlineAt, roomId를 받아야 한다.
-    broadcastReadyCheckMessage({
-      type: "ACCEPTED",
-      ticketId: nextTicket.ticketId,
-      roomId: nextTicket.roomId,
-      memberId: session.member.memberId,
-      acceptedMemberIds: nextTicket.acceptedMemberIds,
-      maxPlayers: nextTicket.maxPlayers,
-    });
-  }
-
-  function handleDeclineMatch() {
-    if (!matchTicket || !session.member) {
-      return;
-    }
-
-    setMatchTicket(null);
-    setQueueState(defaultQueueState);
-    setQueueStartedAt(null);
-    setError(null);
-    setFeedback("수락을 거절해 큐에서 제외되었습니다.");
-
-    // TODO(front-backend): POST /api/matchmaking/{ticketId}/decline 후 서버가 남은 인원을 다시 큐에 넣어야 한다.
-    broadcastReadyCheckMessage({
-      type: "DECLINED",
-      ticketId: matchTicket.ticketId,
-      memberId: session.member.memberId,
-      acceptedMemberIds: matchTicket.acceptedMemberIds.filter(
-        (memberId) => memberId !== session.member?.memberId,
-      ),
-    });
-  }
-
   function handleLogout() {
-    suppressQueueDropNoticeRef.current = true;
-
     startTransition(() => {
       void (async () => {
         await fetch("/api/auth/logout", { method: "POST" });
@@ -495,49 +345,38 @@ export default function HomeScreen() {
           member: null,
         });
         setQueueState(defaultQueueState);
+        setMatchState(defaultMatchState);
         setQueueStartedAt(null);
-        setMatchTicket(null);
+        redirectingRoomIdRef.current = null;
         setFeedback("로그아웃되었습니다.");
         router.refresh();
       })();
     });
   }
 
-  const activeCategoryLabel = getQueueCategoryLabel(
-    matchTicket?.category ?? queueState.category ?? category,
-  );
-  const activeDifficultyLabel = matchTicket?.difficulty ?? queueState.difficulty ?? difficulty;
-  const hasAccepted = Boolean(
-    matchTicket && session.member && matchTicket.acceptedMemberIds.includes(session.member.memberId),
-  );
+  const isSearching = session.authenticated && matchState.status === "SEARCHING";
+  const waitingCount = Math.max(queueState.waitingCount, isSearching ? 1 : 0);
+  const activeCategoryLabel = getQueueCategoryLabel(queueState.category ?? category);
+  const activeDifficultyLabel = queueState.difficulty ?? difficulty;
   const queueElapsedSeconds = getElapsedSeconds(queueStartedAt, now);
-  const readyCountdownSeconds = matchTicket ? getCountdownSeconds(matchTicket.deadlineAt, now) : 0;
-  const queueStatusValue = matchTicket
-    ? matchTicket.status === "READY_TO_ENTER"
-      ? "입장 준비 완료"
-      : "수락 확인 중"
-    : queueState.inQueue
-      ? "대기 중"
-      : "대기 전";
-  const queueStatusHint = matchTicket
-    ? `${matchTicket.acceptedMemberIds.length}/${matchTicket.maxPlayers} 수락`
-    : queueState.inQueue
-      ? `${queueState.waitingCount}명 대기`
-      : "메인에서 바로 시작";
+  const queueStatusValue = isSearching ? "대기 중" : "대기 전";
+  const queueStatusHint = isSearching
+    ? `${waitingCount}명 대기`
+    : "메인에서 바로 시작";
 
   return (
     <div className="space-y-8">
       <PageHero
         eyebrow="Main"
-        title="메인에서 큐를 잡고, 수락 확인 뒤 배틀룸으로 이동"
-        description="비로그인 사용자는 서비스 구조를 볼 수 있고, 실제 매칭 시작이나 보호 화면 진입 시 `/login`으로 이동합니다. 로그인 후에는 메인에서 큐 대기, 수락 모달, 배틀룸 진입까지 이어집니다."
+        title="메인에서 큐를 잡고, 매칭 성사 뒤 배틀룸으로 이동"
+        description="비로그인 사용자는 서비스 구조를 볼 수 있고, 실제 매칭 시작이나 보호 화면 진입 시 `/login`으로 이동합니다. 로그인 후에는 메인에서 큐 대기, `/matches/me` 폴링, 배틀룸 진입까지 이어집니다."
         actions={
           <>
             <StatusPill tone={session.authenticated ? "success" : "warn"}>
               {session.authenticated ? "로그인 상태" : "게스트 상태"}
             </StatusPill>
-            <StatusPill>4 player queue</StatusPill>
-            <StatusPill>Ready check</StatusPill>
+            <StatusPill>4인 매칭</StatusPill>
+            <StatusPill>매칭 상태 폴링</StatusPill>
           </>
         }
       />
@@ -609,7 +448,7 @@ export default function HomeScreen() {
         <MetricCard
           label="카테고리"
           value={activeCategoryLabel}
-          hint="같은 조건의 4명이 모이면 수락 모달 표시"
+          hint="같은 조건의 4명이 모이면 즉시 방을 배정합니다."
         />
         <MetricCard
           label="난이도"
@@ -619,7 +458,10 @@ export default function HomeScreen() {
       </MetricGrid>
 
       <div className="grid gap-6 xl:grid-cols-[0.85fr_1.3fr_0.85fr]">
-        <Panel title="사이드 메뉴" description="팀이 페이지별로 나눠 작업할 수 있도록 진입점을 분리합니다.">
+        <Panel
+          title="사이드 메뉴"
+          description="팀이 페이지별로 나눠 작업할 수 있도록 진입점을 분리합니다."
+        >
           <div className="space-y-3">
             {dashboardMenus.map((menu) => {
               const href =
@@ -694,23 +536,25 @@ export default function HomeScreen() {
               </div>
             </fieldset>
 
-            <div className="grid gap-3 md:grid-cols-2">
+            <div className="flex flex-wrap gap-3">
               <button
                 type="button"
                 onClick={handleStartMatch}
-                disabled={isPending || queueState.inQueue || matchTicket !== null}
+                disabled={isPending || isSearching}
                 className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
               >
-                {isPending ? "처리 중..." : queueState.inQueue || matchTicket ? "큐 진행 중" : "매칭 시작"}
+                {isSearching ? "큐 진행 중" : isPending ? "처리 중..." : "매칭 시작"}
               </button>
-              <button
-                type="button"
-                onClick={handleCancelMatch}
-                disabled={isPending || !queueState.inQueue}
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-              >
-                큐 취소
-              </button>
+              {isSearching ? (
+                <button
+                  type="button"
+                  onClick={handleCancelMatch}
+                  disabled={isPending}
+                  className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                >
+                  큐 취소
+                </button>
+              ) : null}
             </div>
 
             <div
@@ -737,13 +581,9 @@ export default function HomeScreen() {
               최근 score 추이: API 준비 전
             </div>
             <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              {matchTicket
-                ? `현재 상태: ${matchTicket.acceptedMemberIds.length}/${matchTicket.maxPlayers} 수락 / ${activeCategoryLabel} / ${activeDifficultyLabel}`
-                : `현재 큐: ${
-                    queueState.inQueue
-                      ? `${getQueueCategoryLabel(queueState.category)} / ${queueState.difficulty} / ${queueState.waitingCount}명 대기`
-                      : "대기 중 아님"
-                  }`}
+              {isSearching
+                ? `현재 큐: ${activeCategoryLabel} / ${activeDifficultyLabel} / ${waitingCount}명 대기`
+                : `현재 큐: 대기 중 아님`}
             </div>
           </div>
         </Panel>
@@ -753,7 +593,7 @@ export default function HomeScreen() {
         title="현재 연결 포인트"
         description="메인과 인증 흐름에서 이미 실제 API로 연결된 지점"
       >
-        <div className="grid gap-4 lg:grid-cols-3">
+        <div className="grid gap-4 lg:grid-cols-4">
           <ApiCallout
             method="POST"
             path="/api/auth/login"
@@ -769,23 +609,24 @@ export default function HomeScreen() {
             path="/api/queue/me"
             note="현재 로그인 사용자의 큐 상태를 메인 진입 시 바로 조회한다."
           />
+          <ApiCallout
+            method="GET"
+            path="/api/matches/me"
+            note="매칭 성사 여부와 roomId는 이 API를 폴링해서 확인한다."
+          />
         </div>
       </Panel>
 
       <QueueModal
+        isOpen={isSearching}
         categoryLabel={activeCategoryLabel}
         difficultyLabel={activeDifficultyLabel}
         error={error}
         feedback={feedback}
-        hasAccepted={hasAccepted}
         isPending={isPending}
         queueElapsedSeconds={queueElapsedSeconds}
-        queueState={queueState}
-        readyCountdownSeconds={readyCountdownSeconds}
-        ticket={matchTicket}
-        onAccept={handleAcceptMatch}
+        waitingCount={waitingCount}
         onCancel={handleCancelMatch}
-        onDecline={handleDeclineMatch}
       />
     </div>
   );

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -55,7 +55,11 @@ export interface QueueStatusResponse {
   category: string;
   difficulty: string;
   waitingCount: number;
-  matchedRoomId: number | null;
+}
+
+export interface MatchStatusResponse {
+  status: "IDLE" | "SEARCHING" | "MATCHED";
+  roomId: number | null;
 }
 
 export interface ParticipantInfo {

--- a/src/shared/auth/session.ts
+++ b/src/shared/auth/session.ts
@@ -66,14 +66,3 @@ export function extractAccessTokenFromSetCookie(
 
   return decodeURIComponent(matched[1]);
 }
-
-export function parseMatchedRoomId(message: string): number | null {
-  const matched = message.match(/roomId=(\d+)/);
-
-  if (!matched?.[1]) {
-    return null;
-  }
-
-  const roomId = Number(matched[1]);
-  return Number.isFinite(roomId) ? roomId : null;
-}


### PR DESCRIPTION
refs #6
closes #6

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈의 매칭 흐름을 백엔드 매칭 구조에 맞게 재구성했습니다.
기존에는 <code>/queue/join</code> 응답 메시지 문자열에서 <code>roomId</code>를 파싱하고,
프론트 로컬 ready-check 상태를 별도로 굴리는 임시 구조가 섞여 있었습니다.
</p>

<p>
이번 변경에서는 <strong><code>/matches/me</code>를 매칭 상태와 roomId의 source of truth로 고정</strong>하고,
<strong><code>/queue/me</code>는 대기열 표시용(waitingCount, category, difficulty)으로만 사용</strong>하도록 역할을 분리했습니다.
또한 기존 홈 UI와 한국어 톤은 유지한 상태에서 매칭 로직만 백엔드 계약에 맞게 교체했습니다.
</p>

<h3>핵심 변경 요약</h3>
<pre><code class="language-text">매칭 시작 버튼 클릭
      ↓
POST /api/queue/join
      ↓
GET /api/matches/me 폴링 시작 (1초 간격)
      ↓
status == SEARCHING
  → 대기 UI 유지
  → GET /api/queue/me 로 waitingCount 갱신
      ↓
status == MATCHED, roomId 존재
  → 폴링 중단
  → 즉시 /battle/rooms/{roomId} 로 이동
      ↓
방 화면에서 기존 /battle/rooms/{roomId}/join 흐름 수행
</code></pre>

<hr />

<h3>1) <code>/api/matches/me</code> BFF 추가</h3>
<p>
백엔드의 <code>GET /api/v1/matches/me</code>를 프론트에서 안전하게 호출할 수 있도록
Next API 라우트 <code>src/app/api/matches/me/route.ts</code>를 새로 추가했습니다.
</p>

<ul>
  <li>JWT 쿠키 기반으로 인증 처리</li>
  <li><code>userId</code> 쿼리 파라미터 없이 호출</li>
  <li>응답 타입은 <code>MatchStatusResponse</code>로 정리</li>
  <li>토큰이 없으면 401, 백엔드 호출 실패 시 503 처리</li>
</ul>

<pre><code class="language-ts">{
  status: "IDLE" | "SEARCHING" | "MATCHED",
  roomId: number | null
}</code></pre>

<p>
이제 프론트는 이 응답만으로
<strong>현재 내가 큐 대기 중인지</strong>,
<strong>이미 방이 배정됐는지</strong>,
<strong>배정됐다면 roomId가 무엇인지</strong>
를 판별할 수 있습니다.
</p>

<hr />

<h3>2) 매칭 상태 source of truth를 <code>/matches/me</code>로 고정</h3>
<p>
기존에는 <code>/queue/join</code> 응답의 <code>message</code> 문자열에서 <code>roomId</code>를 파싱하는 보조 로직이 있었습니다.
하지만 백엔드 계약상 roomId의 source of truth는 <code>/matches/me</code>이므로, 이 구조를 제거했습니다.
</p>

<ul>
  <li><code>src/shared/auth/session.ts</code>의 <code>parseMatchedRoomId()</code> 제거</li>
  <li><code>src/app/api/queue/join/route.ts</code>에서 <code>matchedRoomId</code> 생성 제거</li>
  <li><code>src/app/api/queue/cancel/route.ts</code>에서도 동일 제거</li>
  <li><code>QueueStatusResponse</code>에서 <code>matchedRoomId</code> 제거</li>
  <li><code>MatchStatusResponse</code> 타입 추가</li>
</ul>

<p>
즉, 이제 프론트는
<code>/queue/join</code>이나 <code>/queue/me</code> 응답으로 방 이동을 판단하지 않고,
반드시 <code>/matches/me</code> 결과만 보고 이동합니다.
</p>

<hr />

<h3>3) 홈 매칭 상태 머신을 <code>IDLE / SEARCHING / MATCHED</code> 기준으로 단순화</h3>
<p>
기존 홈 화면에는 ready-check 임시 상태가 별도로 있었습니다.
예를 들면 <code>MATCH_FOUND</code>, <code>ACCEPTED</code>, <code>READY_TO_ENTER</code> 같은 로컬 상태와
수락 타이머, 수락/거절 버튼, BroadcastChannel 기반 동기화가 같이 들어 있었습니다.
</p>

<p>
이번 PR에서는 이를 제거하고, 백엔드 상태 의미에 맞는 단순한 상태 머신으로 정리했습니다.
</p>

<pre><code class="language-text">IDLE
  - 큐 미참여 상태
  - 시작 버튼만 노출

SEARCHING
  - queue/join 이후 /matches/me 가 SEARCHING
  - 대기 모달 노출
  - cancel 버튼 노출
  - waitingCount 갱신

MATCHED
  - /matches/me 가 MATCHED + roomId 반환
  - 즉시 폴링 중단
  - 즉시 방 이동
</code></pre>

<p>
프론트가 자체적으로 “매칭 수락 여부”를 관리하지 않도록 하면서,
백엔드의 큐/방 배정 구조와 1:1로 맞도록 조정한 것이 핵심입니다.
</p>

<hr />

<h3>4) <code>queue/join</code> 이후 폴링 시작 시점과 중단 시점 정리</h3>
<p>
매칭 시작 버튼을 누르면 먼저 <code>POST /api/queue/join</code>을 호출합니다.
성공하면 프론트 상태를 <code>SEARCHING</code>으로 전환하고
<code>/matches/me</code> 폴링을 시작합니다.
</p>

<ul>
  <li>폴링 간격: <code>1초</code></li>
  <li><code>/matches/me.status === "SEARCHING"</code>이면 대기 유지</li>
  <li><code>/matches/me.status === "MATCHED"</code>이고 <code>roomId</code>가 있으면 즉시 이동</li>
  <li>이동 직후 폴링 중단</li>
</ul>

<p>
또한 초기 진입 시에도 세션이 있으면
<code>/queue/me</code>와 <code>/matches/me</code>를 함께 읽어,
새로고침 후에도 현재 큐 상태나 이미 매칭된 방 상태를 복원할 수 있도록 했습니다.
</p>

<hr />

<h3>5) <code>/queue/me</code>는 대기 UI 표시 전용으로만 사용</h3>
<p>
이번 변경에서 <code>/queue/me</code>의 역할은 “현재 대기열 표시”로 한정했습니다.
즉, 화면에서 <code>1 / 4</code>, <code>2 / 4</code>, <code>3 / 4</code>처럼 보이는 숫자를 갱신하는 용도입니다.
</p>

<ul>
  <li><code>waitingCount</code> 표시</li>
  <li>현재 큐의 <code>category</code>, <code>difficulty</code> 표시</li>
  <li>새로고침 이후 현재 어떤 큐에 들어가 있는지 UI 복원</li>
</ul>

<p>
중요한 점은, <code>/queue/me</code>의 <code>inQueue</code> 값만으로는 방 이동 여부를 판단하지 않는다는 것입니다.
백엔드에서 4인 매칭이 성사되면 유저는 대기열에서 빠지고 방이 배정되므로,
이 시점의 최종 판정은 항상 <code>/matches/me</code>가 담당해야 합니다.
</p>

<hr />

<h3>6) MATCHED 이후 즉시 방 이동 처리</h3>
<p>
기존에는 프론트에서 “매칭 성사 → 준비 완료 수락 → 전원 수락 시 방 이동” 순서를 자체적으로 만들고 있었습니다.
하지만 현재 백엔드 구조에서는 매칭이 성사되면 이미 roomId가 존재하므로,
프론트는 추가 수락 단계를 만들지 않고 바로 방으로 이동해야 합니다.
</p>

<ul>
  <li><code>/matches/me</code>가 <code>MATCHED</code> 반환</li>
  <li><code>roomId</code> 확인</li>
  <li>즉시 <code>/battle/rooms/{roomId}</code>로 라우팅</li>
  <li>이후 방 화면에서 기존 <code>/battle/rooms/{roomId}/join</code> 흐름 수행</li>
</ul>

<p>
즉, 이번 PR의 범위는
<strong>홈에서 방까지 정확하게 연결해 주는 것</strong>이고,
방 내부 READY → PLAYING 전환과 WebSocket 기반 게임 시작 처리는 기존 배틀룸 흐름을 그대로 사용합니다.
</p>

<hr />

<h3>7) cancel 버튼 노출 조건을 SEARCHING 상태로 제한</h3>
<p>
백엔드 계약상 cancel은 큐에서 기다리는 동안에만 의미가 있습니다.
따라서 이번 PR에서는 cancel 버튼을 <code>SEARCHING</code> 상태에서만 보이도록 정리했습니다.
</p>

<ul>
  <li><code>IDLE</code>: cancel 버튼 숨김</li>
  <li><code>SEARCHING</code>: cancel 버튼 노출</li>
  <li><code>MATCHED</code>: cancel 버튼 제거, 방 이동 진행</li>
</ul>

<p>
이를 통해 “이미 방이 생성된 뒤에도 프론트에서 취소를 시도하는” 어색한 상태를 방지했습니다.
</p>

<hr />

<h3>8) 기존 ready-check / BroadcastChannel 임시 구조 제거</h3>
<p>
이번 PR에서 제거한 대표적인 임시 구조는 다음과 같습니다.
</p>

<ul>
  <li><code>BroadcastChannel</code> 기반 ready-check 동기화</li>
  <li><code>MATCH_FOUND / ACCEPTED / READY_TO_ENTER</code> 로컬 티켓 상태</li>
  <li>15초 수락 제한 시간 카운트다운</li>
  <li>수락/거절 버튼과 로컬 acceptedMemberIds 관리</li>
</ul>

<p>
이 구조는 같은 브라우저 문맥 안에서만 동작하는 임시 로직이었고,
실제 백엔드 매칭 상태와도 분리되어 있어 roomId와 상태 전이를 일관되게 다루기 어려웠습니다.
이번 변경으로 홈 매칭 로직은 백엔드 상태를 그대로 반영하는 방식으로 단순화되었습니다.
</p>

<hr />

<h3>9) 큐 대기 모달을 “검색 중” 중심 UI로 단순화</h3>
<p>
<code>src/features/home/queue-modal.tsx</code>는 ready-check 모달이 아니라
큐 대기 모달 역할만 하도록 정리했습니다.
</p>

<ul>
  <li>현재 카테고리 / 난이도 / waitingCount 표시</li>
  <li>큐 대기 시간 표시</li>
  <li>상태는 “검색 중”으로 고정</li>
  <li>SEARCHING 상태에서만 취소 버튼 제공</li>
</ul>

<p>
즉, 기존 홈 UI의 구조는 유지하되,
모달의 역할을 “대기 상태 표시”로 명확히 좁혔습니다.
</p>

<hr />

<h3>10) 변경 파일</h3>
<ul>
  <li><code>src/app/api/matches/me/route.ts</code> 추가</li>
  <li><code>src/app/api/queue/join/route.ts</code> 수정</li>
  <li><code>src/app/api/queue/cancel/route.ts</code> 수정</li>
  <li><code>src/shared/api/contracts.ts</code> 수정</li>
  <li><code>src/shared/auth/session.ts</code> 수정</li>
  <li><code>src/features/home/data.ts</code> 수정</li>
  <li><code>src/features/home/queue-modal.tsx</code> 수정</li>
  <li><code>src/features/home/screen.tsx</code> 수정</li>
</ul>

<hr />
