### PR TITLE
[feat] 마이페이지 내 전적 조회 화면 구현

### DIFF
--- a/src/app/api/members/me/battle-results/route.ts
+++ b/src/app/api/members/me/battle-results/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { MyBattleResultsResponse } from "@/shared/api/contracts";
+import {
+  fetchBackend,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
+
+function buildFallbackPageInfo(pageParam: string | null, sizeParam: string | null) {
+  const page = Number(pageParam ?? "0");
+  const size = Number(sizeParam ?? "20");
+
+  return {
+    page: Number.isFinite(page) ? page : 0,
+    size: Number.isFinite(size) ? size : 20,
+    totalElements: 0,
+    totalPages: 0,
+    hasNext: false,
+  };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const page = url.searchParams.get("page") ?? "0";
+  const size = url.searchParams.get("size") ?? "20";
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
+
+  if (!token) {
+    return NextResponse.json(
+      {
+        resultCode: "MEMBER_401",
+        msg: "로그인이 필요합니다.",
+        data: null,
+      } satisfies MyBattleResultsResponse,
+      { status: 401 },
+    );
+  }
+
+  try {
+    const response = await fetchBackend("/api/v1/members/me/battle-results", {
+      token,
+      searchParams: {
+        page,
+        size,
+      },
+    });
+
+    const body = await readJsonBody<MyBattleResultsResponse>(response.clone());
+
+    if (!response.ok) {
+      return NextResponse.json(
+        body ?? {
+          resultCode: String(response.status),
+          msg: await getErrorMessage(response),
+          data: null,
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(
+      body ?? {
+        resultCode: "200",
+        msg: "내 전적 조회 성공",
+        data: {
+          battleResults: [],
+          pageInfo: buildFallbackPageInfo(page, size),
+        },
+      },
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        resultCode: "MEMBER_503",
+        msg: "내 전적 조회에 실패했습니다.",
+        data: null,
+      } satisfies MyBattleResultsResponse,
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -3,11 +3,37 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import type { SessionResponse } from "@/shared/api/contracts";
-import { MetricCard, MetricGrid, PageHero, Panel, SimpleTable, StatusPill } from "@/shared/ui";
+import type {
+  MyBattleResultItem,
+  MyBattleResultsResponse,
+  PageInfo,
+  SessionResponse,
+} from "@/shared/api/contracts";
+import {
+  EmptyPanel,
+  MetricCard,
+  MetricGrid,
+  PageHero,
+  Panel,
+  StatusPill,
+} from "@/shared/ui";
+import { formatDateTime } from "@/shared/utils/format-date-time";
+
+const PAGE_SIZE = 20;
+
+const defaultPageInfo: PageInfo = {
+  page: 0,
+  size: PAGE_SIZE,
+  totalElements: 0,
+  totalPages: 0,
+  hasNext: false,
+};
 
 async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
+  const response = await fetch("/api/auth/session", {
+    cache: "no-store",
+    credentials: "include",
+  });
 
   if (!response.ok) {
     return {
@@ -19,28 +45,238 @@ async function readSession() {
   return (await response.json()) as SessionResponse;
 }
 
+async function readMyBattleResults(page: number, size: number) {
+  const response = await fetch(`/api/members/me/battle-results?page=${page}&size=${size}`, {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as MyBattleResultsResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
+function formatRank(rank: number) {
+  return `${rank}등`;
+}
+
+function formatScoreDelta(scoreDelta: number) {
+  const sign = scoreDelta > 0 ? "+" : "";
+  return `${sign}${scoreDelta}`;
+}
+
+function ScoreDeltaText({ scoreDelta }: { scoreDelta: number }) {
+  const toneClass =
+    scoreDelta > 0
+      ? "text-emerald-700"
+      : scoreDelta < 0
+        ? "text-rose-700"
+        : "text-zinc-600";
+
+  return <span className={`font-semibold ${toneClass}`}>{formatScoreDelta(scoreDelta)}</span>;
+}
+
+function ResultCard({ item }: { item: MyBattleResultItem }) {
+  return (
+    <Link
+      href={`/battle/results/${item.roomId}`}
+      className="block rounded-2xl border border-zinc-300 bg-zinc-50 p-5 transition hover:border-zinc-500 hover:bg-white"
+    >
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-zinc-500">
+            roomId {item.roomId} · problemId {item.problemId}
+          </p>
+          <h3 className="text-xl font-semibold tracking-tight text-zinc-950">
+            {item.problemTitle}
+          </h3>
+          <p className="text-sm text-zinc-600">{formatDateTime(item.playedAt)} 플레이</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusPill tone={item.solved ? "success" : "warn"}>
+            {item.solved ? "성공" : "미해결"}
+          </StatusPill>
+          <StatusPill tone={item.finalRank === 1 ? "success" : "default"}>
+            {formatRank(item.finalRank)}
+          </StatusPill>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 rounded-2xl border border-zinc-200 bg-white p-4 text-sm text-zinc-700 md:grid-cols-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+            최종 순위
+          </p>
+          <p className="mt-2 text-base font-semibold text-zinc-950">{formatRank(item.finalRank)}</p>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+            점수 변화
+          </p>
+          <p className="mt-2 text-base">
+            <ScoreDeltaText scoreDelta={item.scoreDelta} />
+          </p>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+            정답 처리 시각
+          </p>
+          <p className="mt-2 text-base font-medium text-zinc-950">
+            {item.finishTime ? formatDateTime(item.finishTime) : "기록 없음"}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function LoadingRows() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="animate-pulse rounded-2xl border border-zinc-300 bg-zinc-50 p-5"
+        >
+          <div className="h-3 w-32 rounded bg-zinc-200" />
+          <div className="mt-4 h-6 w-2/3 rounded bg-zinc-200" />
+          <div className="mt-3 h-4 w-40 rounded bg-zinc-200" />
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            <div className="h-20 rounded-2xl bg-white" />
+            <div className="h-20 rounded-2xl bg-white" />
+            <div className="h-20 rounded-2xl bg-white" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function MyPageScreen() {
   const [session, setSession] = useState<SessionResponse>({
     authenticated: false,
     member: null,
   });
+  const [battleResults, setBattleResults] = useState<MyBattleResultItem[]>([]);
+  const [pageInfo, setPageInfo] = useState(defaultPageInfo);
+  const [message, setMessage] = useState("내 전적을 불러오는 중입니다.");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
+    let active = true;
+
     void (async () => {
-      setSession(await readSession());
+      const nextSession = await readSession();
+
+      if (!active) {
+        return;
+      }
+
+      setSession(nextSession);
+
+      if (!nextSession.authenticated) {
+        setIsLoading(false);
+        setMessage("로그인 후 내 전적을 확인할 수 있습니다.");
+        return;
+      }
+
+      const { ok, status, payload } = await readMyBattleResults(0, PAGE_SIZE);
+
+      if (!active) {
+        return;
+      }
+
+      if (status === 401 || payload?.resultCode === "MEMBER_401") {
+        setSession({
+          authenticated: false,
+          member: null,
+        });
+        setBattleResults([]);
+        setPageInfo(defaultPageInfo);
+        setError(null);
+        setMessage(payload?.msg ?? "로그인이 필요합니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
+        setBattleResults([]);
+        setPageInfo(defaultPageInfo);
+        setError(payload?.msg ?? "내 전적을 불러오지 못했습니다.");
+        setMessage(payload?.msg ?? "내 전적 조회에 실패했습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      setBattleResults(payload.data.battleResults);
+      setPageInfo(payload.data.pageInfo);
+      setMessage(payload.msg);
+      setError(null);
+      setIsLoading(false);
     })();
+
+    return () => {
+      active = false;
+    };
   }, []);
+
+  async function handleLoadMore() {
+    if (!session.authenticated || !pageInfo.hasNext || isLoadingMore) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+
+    const nextPage = pageInfo.page + 1;
+    const { ok, status, payload } = await readMyBattleResults(nextPage, pageInfo.size);
+
+    if (status === 401 || payload?.resultCode === "MEMBER_401") {
+      setSession({
+        authenticated: false,
+        member: null,
+      });
+      setBattleResults([]);
+      setPageInfo(defaultPageInfo);
+      setError(null);
+      setMessage(payload?.msg ?? "로그인이 필요합니다.");
+      setIsLoadingMore(false);
+      return;
+    }
+
+    if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
+      setError(payload?.msg ?? "다음 전적을 불러오지 못했습니다.");
+      setIsLoadingMore(false);
+      return;
+    }
+
+    setBattleResults((current) => [...current, ...payload.data!.battleResults]);
+    setPageInfo(payload.data.pageInfo);
+    setMessage(payload.msg);
+    setError(null);
+    setIsLoadingMore(false);
+  }
+
+  const solvedCount = battleResults.filter((item) => item.solved).length;
+  const loadedCount = battleResults.length;
+  const currentPage = pageInfo.totalPages > 0 ? pageInfo.page + 1 : 0;
 
   return (
     <div className="space-y-8">
       <PageHero
         eyebrow="My Page"
         title="프로필과 전적 화면의 최소 운영 골격"
-        description="현재 백엔드에는 `/me`, 전적, 점수 그래프 계약이 아직 없습니다. 그래서 세션 쿠키에서 복원 가능한 식별 정보만 먼저 보여주고, 나머지는 실제 엔드포인트가 정리되면 연결할 자리로 남겨둡니다."
+        description="현재 백엔드에는 `/me`, 티어, 총점 API가 아직 없습니다. 그래서 세션 쿠키에서 복원 가능한 식별 정보는 먼저 보여주고, 내 전적 목록은 실제 API로 연결해 확인할 수 있도록 구성합니다."
         actions={
           <>
             <StatusPill tone={session.authenticated ? "success" : "warn"}>
-              {session.authenticated ? "로그인됨" : "로그인 필요"}
+              {session.authenticated ? "로그인 상태" : "로그인 필요"}
             </StatusPill>
             <StatusPill>Profile placeholder</StatusPill>
           </>
@@ -51,21 +287,29 @@ export default function MyPageScreen() {
         <MetricCard
           label="닉네임"
           value={session.member?.nickname ?? "게스트"}
-          hint="현재는 JWT payload 기준"
+          hint="현재 로그인 사용자 기준"
         />
         <MetricCard
           label="이메일"
           value={session.member?.email ?? "-"}
           hint="실제 members 조회 API 연동 전"
         />
-        <MetricCard label="티어" value="연결 전" hint="백엔드 프로필 API 필요" />
-        <MetricCard label="총점" value="연결 전" hint="전적/점수 API 필요" />
+        <MetricCard
+          label="티어"
+          value="연결 전"
+          hint="백엔드 프로필 API 필요"
+        />
+        <MetricCard
+          label="총점"
+          value="연결 전"
+          hint="전적/점수 API 필요"
+        />
       </MetricGrid>
 
       {session.authenticated ? (
         <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
           <Panel title="프로필 영역" description="현재 세션에서 바로 읽을 수 있는 정보">
-            <dl className="space-y-3 text-sm leading-7 text-zinc-700">
+            <div className="space-y-3 text-sm leading-7 text-zinc-700">
               <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
                 닉네임: {session.member?.nickname}
               </div>
@@ -75,21 +319,87 @@ export default function MyPageScreen() {
               <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
                 역할: {session.member?.role}
               </div>
-            </dl>
+              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
+                전적 상태: {error ?? message}
+              </div>
+            </div>
           </Panel>
 
-          <Panel title="전적 리스트 자리" description="실제 전적 API 연결 전 레이아웃만 확보">
-            <SimpleTable
-              headers={["날짜", "문제", "결과", "순위", "점수 변동"]}
-              rows={[
-                ["-", "전적 API 준비 전", "-", "-", "-"],
-                ["-", "결과 집계 API 준비 전", "-", "-", "-"],
-              ]}
-            />
+          <Panel
+            title="전적 리스트 자리"
+            description="실제 전적 API를 연결해 최신 전적을 확인할 수 있도록 구성합니다."
+          >
+            <div className="mb-4 grid gap-3 md:grid-cols-3">
+              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                  전체 전적
+                </p>
+                <p className="mt-2 text-lg font-semibold text-zinc-950">{pageInfo.totalElements}</p>
+              </div>
+              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                  현재 페이지
+                </p>
+                <p className="mt-2 text-lg font-semibold text-zinc-950">
+                  {currentPage > 0 ? `${currentPage} / ${pageInfo.totalPages}` : "-"}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                  로드된 전적
+                </p>
+                <p className="mt-2 text-lg font-semibold text-zinc-950">
+                  {loadedCount}개{session.authenticated ? ` / 해결 ${solvedCount}개` : ""}
+                </p>
+              </div>
+            </div>
+
+            {error ? (
+              <div className="mb-4 rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+                {error}
+              </div>
+            ) : null}
+
+            {isLoading ? (
+              <LoadingRows />
+            ) : battleResults.length === 0 ? (
+              <EmptyPanel
+                title="아직 전적이 없습니다"
+                description="배틀을 한 번 이상 완료하면 이곳에서 최근 전적을 확인할 수 있습니다."
+              />
+            ) : (
+              <div className="space-y-3">
+                {battleResults.map((item) => (
+                  <ResultCard key={`${item.roomId}-${item.problemId}`} item={item} />
+                ))}
+              </div>
+            )}
+
+            {!isLoading && battleResults.length > 0 ? (
+              <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-zinc-600">
+                  {loadedCount}개 로드됨 / 전체 {pageInfo.totalElements}개
+                </p>
+                {pageInfo.hasNext ? (
+                  <button
+                    type="button"
+                    onClick={handleLoadMore}
+                    disabled={isLoadingMore}
+                    className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                  >
+                    {isLoadingMore ? "불러오는 중..." : "다음 전적 더 보기"}
+                  </button>
+                ) : (
+                  <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                    마지막 페이지입니다.
+                  </div>
+                )}
+              </div>
+            ) : null}
           </Panel>
         </div>
       ) : (
-        <Panel title="로그인이 필요합니다" description="전적과 프로필은 보호 화면입니다.">
+        <Panel title="로그인이 필요합니다" description="내 전적 화면은 로그인한 사용자만 볼 수 있습니다.">
           <div className="flex flex-wrap gap-3">
             <Link
               href="/login?next=/mypage"

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -124,6 +124,32 @@ export interface BattleResultResponse {
   participants: BattleResultParticipant[];
 }
 
+export interface MyBattleResultItem {
+  roomId: number;
+  problemId: number;
+  problemTitle: string;
+  finalRank: number;
+  scoreDelta: number;
+  solved: boolean;
+  finishTime: string | null;
+  playedAt: string;
+}
+
+export interface PageInfo {
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+}
+
+export interface MyBattleResultsData {
+  battleResults: MyBattleResultItem[];
+  pageInfo: PageInfo;
+}
+
+export type MyBattleResultsResponse = RsData<MyBattleResultsData | null>;
+
 export interface RoomListResponse {
   roomId: number;
   status: string;


### PR DESCRIPTION
refs #9
closes #9

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 마이페이지에 <strong>내 전적 조회 API</strong>를 실제로 연결하고,
기존 마이페이지의 <strong>프로필 중심 UI 골격을 유지한 상태</strong>에서
전적 목록, 페이지네이션, 빈 상태/에러 상태를 함께 구성한 작업입니다.
</p>

<p>
구체적으로는
<code>GET /api/v1/members/me/battle-results?page=0&amp;size=20</code>
백엔드 API를 프론트 BFF로 중계하고,
마이페이지에서 로그인한 사용자의 종료된 배틀 전적만 최신순으로 조회해 보여주도록 구현했습니다.
</p>

<p>
또한 기존 마이페이지에서 사용하던 상단 요약 카드 구조를 유지하기 위해
<strong>닉네임 / 이메일 / 티어 / 총점</strong> 구성을 복원했고,
실제 API가 아직 없는 <strong>티어 / 총점</strong>은 placeholder 상태(<code>연결 전</code>)로 유지했습니다.
전적 개수, 현재 페이지, 로드된 전적 수 같은 전적 전용 정보는 상단 카드가 아니라 전적 패널 내부로 배치했습니다.
</p>

<hr />

<h3>1) 내 전적 조회 BFF 라우트 추가</h3>
<p>
프론트에서 직접 백엔드 인증 구조를 다루지 않도록
<code>src/app/api/members/me/battle-results/route.ts</code>를 새로 추가했습니다.
이 라우트는 프론트 쿠키에 저장된 accessToken을 읽어
백엔드 <code>/api/v1/members/me/battle-results</code>로 요청을 전달합니다.
</p>

<ul>
  <li>JWT accessToken 쿠키 기반 인증</li>
  <li><code>memberId</code> 파라미터 없이 현재 로그인 사용자 기준 조회</li>
  <li><code>page</code>, <code>size</code> 쿼리 전달</li>
  <li>비로그인 시 <code>MEMBER_401</code> 형태로 응답</li>
  <li>백엔드 오류 메시지를 최대한 그대로 전달</li>
</ul>

<pre><code class="language-ts">export async function GET(request: Request) {
  const url = new URL(request.url);
  const page = url.searchParams.get("page") ?? "0";
  const size = url.searchParams.get("size") ?? "20";

  const cookieStore = await cookies();
  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;

  if (!token) {
    return NextResponse.json(
      {
        resultCode: "MEMBER_401",
        msg: "로그인이 필요합니다.",
        data: null,
      },
      { status: 401 },
    );
  }

  const response = await fetchBackend("/api/v1/members/me/battle-results", {
    token,
    searchParams: { page, size },
  });

  ...
}</code></pre>

<p>
추가로, 백엔드가 비정상 응답을 주거나 body가 비어 있을 경우를 대비해
빈 <code>pageInfo</code>를 생성하는 fallback도 넣어두었습니다.
</p>

<hr />

<h3>2) 내 전적 전용 타입 추가</h3>
<p>
백엔드 응답이 <code>RsData</code> 래핑 구조이기 때문에,
프론트에서 안전하게 응답을 처리할 수 있도록
<code>src/shared/api/contracts.ts</code>에 전적 전용 타입을 추가했습니다.
</p>

<ul>
  <li><code>MyBattleResultItem</code></li>
  <li><code>PageInfo</code></li>
  <li><code>MyBattleResultsData</code></li>
  <li><code>MyBattleResultsResponse</code></li>
</ul>

<pre><code class="language-ts">export interface MyBattleResultItem {
  roomId: number;
  problemId: number;
  problemTitle: string;
  finalRank: number;
  scoreDelta: number;
  solved: boolean;
  finishTime: string | null;
  playedAt: string;
}

export interface PageInfo {
  page: number;
  size: number;
  totalElements: number;
  totalPages: number;
  hasNext: boolean;
}

export type MyBattleResultsResponse = RsData&lt;MyBattleResultsData | null&gt;;</code></pre>

<p>
이 타입을 기준으로 화면에서 전적 목록 렌더링, 에러 처리, 다음 페이지 로딩을 모두 일관되게 처리합니다.
</p>

<hr />

<h3>3) 마이페이지에서 실제 전적 목록 조회 흐름 구현</h3>
<p>
<code>src/features/my-page/screen.tsx</code>에서
기존 placeholder 성격의 마이페이지를 실제 전적 조회 화면으로 확장했습니다.
</p>

<p>
초기 진입 시 흐름은 다음과 같습니다.
</p>

<pre><code class="language-text">/mypage 진입
   ↓
/api/auth/session 조회
   ↓
비로그인 → 로그인 유도 UI 표시
   ↓
로그인 상태 → /api/members/me/battle-results?page=0&amp;size=20 호출
   ↓
성공 시 battleResults + pageInfo 저장
   ↓
전적 목록 렌더링
</code></pre>

<p>
클라이언트 fetch에는 쿠키가 함께 전송되도록
<code>credentials: "include"</code>를 명시했습니다.
</p>

<pre><code class="language-ts">const response = await fetch(`/api/members/me/battle-results?page=${page}&amp;size=${size}`, {
  cache: "no-store",
  credentials: "include",
});</code></pre>

<hr />

<h3>4) 전적 목록 UI 구성</h3>
<p>
전적 row는 단순한 표가 아니라 카드형 리스트로 구성해
문제 제목이 가장 먼저 눈에 띄도록 정리했습니다.
각 카드에는 아래 정보를 노출합니다.
</p>

<ul>
  <li>문제 제목 (<code>problemTitle</code>)</li>
  <li>배틀방 ID / 문제 ID</li>
  <li>최종 순위 (<code>1등</code>, <code>2등</code> 형태)</li>
  <li>점수 변화량 (<code>+70</code>, <code>+100</code> 형태)</li>
  <li>성공 여부 배지 (<code>성공</code> / <code>미해결</code>)</li>
  <li>플레이 시각 (<code>playedAt</code>)</li>
  <li>정답 처리 시각 (<code>finishTime</code>, 없으면 <code>기록 없음</code>)</li>
</ul>

<pre><code class="language-ts">function ResultCard({ item }: { item: MyBattleResultItem }) {
  return (
    &lt;Link href={`/battle/results/${item.roomId}`}&gt;
      ...
      &lt;h3&gt;{item.problemTitle}&lt;/h3&gt;
      &lt;StatusPill tone={item.solved ? "success" : "warn"}&gt;
        {item.solved ? "성공" : "미해결"}
      &lt;/StatusPill&gt;
      ...
      &lt;ScoreDeltaText scoreDelta={item.scoreDelta} /&gt;
    &lt;/Link&gt;
  );
}</code></pre>

<p>
각 전적 row는 기존 결과 상세 페이지로 바로 이동할 수 있도록
<code>/battle/results/{roomId}</code> 링크를 연결했습니다.
</p>

<hr />

<h3>5) 페이지네이션 처리</h3>
<p>
백엔드의 <code>pageInfo.hasNext</code>를 기준으로
“다음 전적 더 보기” 버튼을 노출하도록 구현했습니다.
</p>

<ul>
  <li>최초 요청은 <code>page=0</code>, <code>size=20</code></li>
  <li>다음 버튼 클릭 시 <code>page + 1</code> 요청</li>
  <li>새 페이지 결과를 기존 목록 뒤에 append</li>
  <li>마지막 페이지면 버튼 대신 안내 문구 표시</li>
</ul>

<pre><code class="language-ts">async function handleLoadMore() {
  if (!session.authenticated || !pageInfo.hasNext || isLoadingMore) {
    return;
  }

  const nextPage = pageInfo.page + 1;
  const { ok, status, payload } = await readMyBattleResults(nextPage, pageInfo.size);

  ...
  setBattleResults((current) =&gt; [...current, ...payload.data!.battleResults]);
  setPageInfo(payload.data.pageInfo);
}</code></pre>

<p>
전적 패널 하단에는
<code>{loadedCount}개 로드됨 / 전체 {pageInfo.totalElements}개</code>
형태의 보조 정보도 함께 노출합니다.
</p>

<hr />

<h3>6) 로딩 / 빈 상태 / 에러 상태 처리</h3>
<p>
이번 PR에서는 목록 화면에서 필요한 상태를 모두 분리해 처리했습니다.
</p>

<h4>로딩 상태</h4>
<ul>
  <li>초기 조회 중에는 skeleton 형태의 <code>LoadingRows</code> 렌더링</li>
</ul>

<h4>빈 상태</h4>
<ul>
  <li><code>battleResults.length === 0</code>이면
    <code>아직 전적이 없습니다</code> empty state 표시</li>
</ul>

<h4>비로그인 상태</h4>
<ul>
  <li><code>MEMBER_401</code> 또는 세션 없음이면 로그인 유도 패널 표시</li>
  <li><code>/login?next=/mypage</code>로 이동 가능</li>
</ul>

<h4>일반 에러 상태</h4>
<ul>
  <li><code>MEMBER_400</code>, 503, 기타 실패는 전적 패널 내부에서 에러 메시지 노출</li>
</ul>

<p>
즉 페이지 전체를 깨뜨리지 않고,
전적 패널 안에서 상태가 구분되도록 구성한 것이 이번 작업의 핵심입니다.
</p>

<hr />

<h3>7) 마이페이지 원래 UI 골격 복원</h3>
<p>
기존 마이페이지는 “프로필 + 전적” 골격이 분명한 화면이었는데,
전적 API를 붙이는 과정에서 페이지 전체가 전적 전용 화면처럼 보이지 않도록
원래 톤을 다시 유지했습니다.
</p>

<ul>
  <li>Hero 제목을 <code>프로필과 전적 화면의 최소 운영 골격</code>으로 유지</li>
  <li>상단 4카드는 <strong>닉네임 / 이메일 / 티어 / 총점</strong> 구성을 유지</li>
  <li>티어 / 총점은 아직 API가 없으므로 <code>연결 전</code> placeholder 유지</li>
  <li>프로필 패널은 세션 정보 중심 역할 유지</li>
  <li>전적 관련 숫자는 상단 카드가 아니라 전적 패널 내부에 배치</li>
</ul>

<p>
즉 이번 작업은 “마이페이지를 전적 화면으로 갈아엎는 것”이 아니라,
<strong>기존 마이페이지 틀 안에 실제 전적 기능을 자연스럽게 넣는 작업</strong>으로 정리했습니다.
</p>

<hr />

<h3>8) 전적 패널 내부 요약 정보 추가</h3>
<p>
상단 카드에서는 원래 프로필 중심 정보를 유지하고,
전적 전용 정보는 오른쪽 패널 내부에서 따로 보여주도록 구성했습니다.
</p>

<ul>
  <li><code>전체 전적</code></li>
  <li><code>현재 페이지</code></li>
  <li><code>로드된 전적</code></li>
</ul>

<p>
여기서 <code>로드된 전적</code>은
전체 누적 solved 수가 아니라
<strong>현재 화면에 불러온 전적 목록 개수</strong>를 의미합니다.
예를 들어 전적 10개를 불러왔고 그중 4개가 <code>solved=true</code>이면,
화면에는 <code>10개 / 해결 4개</code> 형태로 보이게 됩니다.
</p>

<hr />

<h3>9) 변경 파일</h3>
<ul>
  <li><code>src/app/api/members/me/battle-results/route.ts</code> 추가</li>
  <li><code>src/shared/api/contracts.ts</code> 수정</li>
  <li><code>src/features/my-page/screen.tsx</code> 수정</li>
</ul>

<hr />