### PR TITLE
feat: 메인 홈 매칭 흐름을 v2 ready-check 기준으로 전환

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1406,6 +1406,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1479,6 +1480,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2004,6 +2006,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2290,6 +2293,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2873,6 +2877,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3046,6 +3051,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4737,6 +4743,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -5241,6 +5248,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5250,6 +5258,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5998,6 +6007,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6160,6 +6170,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/matches/[matchId]/accept/route.ts
+++ b/src/app/api/matches/[matchId]/accept/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-import type { QueueStateResponse } from "@/shared/api/contracts";
+import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
   fetchBackend,
   getErrorMessage,
@@ -9,17 +9,18 @@ import {
 } from "@/shared/api/backend";
 import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
-const DEFAULT_REQUIRED_COUNT = 4;
-
-const inactiveQueueState: QueueStateResponse = {
-  inQueue: false,
-  category: null,
-  difficulty: null,
-  waitingCount: 0,
-  requiredCount: DEFAULT_REQUIRED_COUNT,
+const defaultMatchState: MatchStateResponse = {
+  status: "IDLE",
+  readyCheck: null,
+  room: null,
+  message: null,
 };
 
-export async function GET() {
+export async function POST(
+  _request: Request,
+  context: RouteContext<"/api/matches/[matchId]/accept">,
+) {
+  const { matchId } = await context.params;
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
 
@@ -28,7 +29,10 @@ export async function GET() {
   }
 
   try {
-    const response = await fetchBackend("/api/v2/queue/me", { token });
+    const response = await fetchBackend(`/api/v2/matches/${matchId}/accept`, {
+      method: "POST",
+      token,
+    });
 
     if (!response.ok) {
       return NextResponse.json(
@@ -37,19 +41,11 @@ export async function GET() {
       );
     }
 
-    const body = await readJsonBody<QueueStateResponse>(response);
-
-    return NextResponse.json(
-      body
-        ? {
-            ...body,
-            requiredCount: body.requiredCount ?? DEFAULT_REQUIRED_COUNT,
-          }
-        : inactiveQueueState,
-    );
+    const body = await readJsonBody<MatchStateResponse>(response);
+    return NextResponse.json(body ?? defaultMatchState);
   } catch {
     return NextResponse.json(
-      { message: "대기열 상태 조회에 실패했습니다." },
+      { message: "매칭 수락 요청에 실패했습니다." },
       { status: 503 },
     );
   }

--- a/src/app/api/matches/[matchId]/decline/route.ts
+++ b/src/app/api/matches/[matchId]/decline/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-import type { QueueStateResponse } from "@/shared/api/contracts";
+import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
   fetchBackend,
   getErrorMessage,
@@ -9,17 +9,18 @@ import {
 } from "@/shared/api/backend";
 import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
-const DEFAULT_REQUIRED_COUNT = 4;
-
-const inactiveQueueState: QueueStateResponse = {
-  inQueue: false,
-  category: null,
-  difficulty: null,
-  waitingCount: 0,
-  requiredCount: DEFAULT_REQUIRED_COUNT,
+const defaultMatchState: MatchStateResponse = {
+  status: "IDLE",
+  readyCheck: null,
+  room: null,
+  message: null,
 };
 
-export async function GET() {
+export async function POST(
+  _request: Request,
+  context: RouteContext<"/api/matches/[matchId]/decline">,
+) {
+  const { matchId } = await context.params;
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
 
@@ -28,7 +29,10 @@ export async function GET() {
   }
 
   try {
-    const response = await fetchBackend("/api/v2/queue/me", { token });
+    const response = await fetchBackend(`/api/v2/matches/${matchId}/decline`, {
+      method: "POST",
+      token,
+    });
 
     if (!response.ok) {
       return NextResponse.json(
@@ -37,19 +41,11 @@ export async function GET() {
       );
     }
 
-    const body = await readJsonBody<QueueStateResponse>(response);
-
-    return NextResponse.json(
-      body
-        ? {
-            ...body,
-            requiredCount: body.requiredCount ?? DEFAULT_REQUIRED_COUNT,
-          }
-        : inactiveQueueState,
-    );
+    const body = await readJsonBody<MatchStateResponse>(response);
+    return NextResponse.json(body ?? defaultMatchState);
   } catch {
     return NextResponse.json(
-      { message: "대기열 상태 조회에 실패했습니다." },
+      { message: "매칭 거절 요청에 실패했습니다." },
       { status: 503 },
     );
   }

--- a/src/app/api/matches/me/route.ts
+++ b/src/app/api/matches/me/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-import type { MatchStatusResponse } from "@/shared/api/contracts";
+import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
   fetchBackend,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
 import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
+
+const defaultMatchState: MatchStateResponse = {
+  status: "IDLE",
+  readyCheck: null,
+  room: null,
+  message: null,
+};
 
 export async function GET() {
   const cookieStore = await cookies();
@@ -18,7 +25,7 @@ export async function GET() {
   }
 
   try {
-    const response = await fetchBackend("/api/v1/matches/me", { token });
+    const response = await fetchBackend("/api/v2/matches/me", { token });
 
     if (!response.ok) {
       return NextResponse.json(
@@ -27,13 +34,8 @@ export async function GET() {
       );
     }
 
-    const body = await readJsonBody<MatchStatusResponse>(response);
-    return NextResponse.json(
-      body ?? {
-        status: "IDLE",
-        roomId: null,
-      } satisfies MatchStatusResponse,
-    );
+    const body = await readJsonBody<MatchStateResponse>(response);
+    return NextResponse.json(body ?? defaultMatchState);
   } catch {
     return NextResponse.json(
       { message: "매칭 상태 조회에 실패했습니다." },

--- a/src/app/api/queue/cancel/route.ts
+++ b/src/app/api/queue/cancel/route.ts
@@ -7,29 +7,22 @@ import {
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import {
-  FRONTEND_ACCESS_TOKEN_COOKIE,
-  getSessionMemberFromToken,
-} from "@/shared/auth/session";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
-function unauthorizedResponse() {
-  return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-}
+const DEFAULT_REQUIRED_COUNT = 4;
 
 export async function DELETE() {
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
 
-  if (!token || !member) {
-    return unauthorizedResponse();
+  if (!token) {
+    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 
   try {
-    const response = await fetchBackend("/api/v1/queue/cancel", {
+    const response = await fetchBackend("/api/v2/queue/cancel", {
       method: "DELETE",
       token,
-      searchParams: { userId: member.memberId },
     });
 
     if (!response.ok) {
@@ -39,24 +32,18 @@ export async function DELETE() {
       );
     }
 
-    const body = await readJsonBody<{
-      message: string;
-      category: string;
-      difficulty: string;
-      waitingCount: number;
-    }>(response);
+    const body = await readJsonBody<QueueStatusResponse>(response);
 
-    const result: QueueStatusResponse = {
-      message: body?.message ?? "매칭 대기열에서 취소되었습니다.",
+    return NextResponse.json({
+      message: body?.message ?? "매칭 대기열에서 취소됐습니다.",
       category: body?.category ?? "",
       difficulty: body?.difficulty ?? "",
       waitingCount: body?.waitingCount ?? 0,
-    };
-
-    return NextResponse.json(result);
+      requiredCount: body?.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+    } satisfies QueueStatusResponse);
   } catch {
     return NextResponse.json(
-      { message: "큐 취소 요청에 실패했습니다." },
+      { message: "매칭 취소 요청에 실패했습니다." },
       { status: 503 },
     );
   }

--- a/src/app/api/queue/join/route.ts
+++ b/src/app/api/queue/join/route.ts
@@ -1,32 +1,22 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-import type {
-  QueueJoinRequest,
-  QueueStateResponse,
-  QueueStatusResponse,
-} from "@/shared/api/contracts";
+import type { QueueJoinRequest, QueueStatusResponse } from "@/shared/api/contracts";
 import {
   fetchBackend,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import {
-  FRONTEND_ACCESS_TOKEN_COOKIE,
-  getSessionMemberFromToken,
-} from "@/shared/auth/session";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
-function unauthorizedResponse() {
-  return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-}
+const DEFAULT_REQUIRED_COUNT = 4;
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
 
-  if (!token || !member) {
-    return unauthorizedResponse();
+  if (!token) {
+    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 
   let payload: QueueJoinRequest;
@@ -34,45 +24,13 @@ export async function POST(request: Request) {
   try {
     payload = (await request.json()) as QueueJoinRequest;
   } catch {
-    return NextResponse.json({ message: "잘못된 매칭 요청입니다." }, { status: 400 });
-  }
-
-  if (payload.category === "RANDOM") {
-    return NextResponse.json(
-      {
-        message:
-          "현재 백엔드 매칭은 실제 카테고리 태그만 지원합니다. 전체(무작위) 대신 구체 카테고리를 선택해주세요.",
-      },
-      { status: 400 },
-    );
+    return NextResponse.json({ message: "잘못된 요청 본문입니다." }, { status: 400 });
   }
 
   try {
-    const queueStateResponse = await fetchBackend("/api/v1/queue/me", {
-      token,
-      searchParams: { userId: member.memberId },
-    });
-
-    if (queueStateResponse.ok) {
-      const queueState = await readJsonBody<QueueStateResponse>(queueStateResponse);
-
-      if (queueState?.inQueue) {
-        return NextResponse.json(
-          {
-            message: `이미 ${queueState.category}/${queueState.difficulty} 큐에 참가 중입니다.`,
-            category: queueState.category ?? payload.category,
-            difficulty: queueState.difficulty ?? payload.difficulty,
-            waitingCount: queueState.waitingCount,
-          } satisfies QueueStatusResponse,
-          { status: 409 },
-        );
-      }
-    }
-
-    const response = await fetchBackend("/api/v1/queue/join", {
+    const response = await fetchBackend("/api/v2/queue/join", {
       method: "POST",
       token,
-      searchParams: { userId: member.memberId },
       body: payload,
     });
 
@@ -83,24 +41,18 @@ export async function POST(request: Request) {
       );
     }
 
-    const body = await readJsonBody<{
-      message: string;
-      category: string;
-      difficulty: string;
-      waitingCount: number;
-    }>(response);
+    const body = await readJsonBody<QueueStatusResponse>(response);
 
-    const result: QueueStatusResponse = {
+    return NextResponse.json({
       message: body?.message ?? "매칭 대기열에 참가했습니다.",
       category: body?.category ?? payload.category,
       difficulty: body?.difficulty ?? payload.difficulty,
-      waitingCount: body?.waitingCount ?? 0,
-    };
-
-    return NextResponse.json(result);
+      waitingCount: body?.waitingCount ?? 1,
+      requiredCount: body?.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+    } satisfies QueueStatusResponse);
   } catch {
     return NextResponse.json(
-      { message: "큐 참가 요청에 실패했습니다." },
+      { message: "매칭 참가 요청에 실패했습니다." },
       { status: 503 },
     );
   }

--- a/src/features/home/data.ts
+++ b/src/features/home/data.ts
@@ -1,25 +1,18 @@
 import type { Difficulty } from "@/shared/api/contracts";
 
 export const SEARCH_POLL_INTERVAL_MS = 1_000;
+export const DEFAULT_REQUIRED_COUNT = 4;
 
-export const queueCategories: Array<{
-  value:
-    | "RANDOM"
-    | "dp"
-    | "graphs"
-    | "strings"
-    | "greedy"
-    | "implementation";
-  label: string;
-  disabled?: boolean;
-}> = [
-  { value: "RANDOM", label: "전체 (무작위, 준비 중)", disabled: true },
+export const queueCategories = [
+  { value: "RANDOM", label: "전체 (무작위 준비 중)", disabled: true },
   { value: "dp", label: "DP" },
   { value: "graphs", label: "그래프" },
   { value: "strings", label: "문자열" },
   { value: "greedy", label: "그리디" },
   { value: "implementation", label: "구현" },
 ] as const;
+
+export type QueueCategoryValue = (typeof queueCategories)[number]["value"];
 
 export const difficultyOptions: Array<{ value: Difficulty; label: string }> = [
   { value: "EASY", label: "Easy" },
@@ -29,26 +22,26 @@ export const difficultyOptions: Array<{ value: Difficulty; label: string }> = [
 
 export const dashboardMenus = [
   {
-    title: "대시보드",
-    description: "현재 큐 상태와 핵심 진입점을 한 화면에서 확인합니다.",
+    title: "메인 대시보드",
+    description: "현재 매칭 상태와 화면 구조를 메인에서 바로 확인합니다.",
     href: "/",
     requiresAuth: false,
   },
   {
-    title: "전적 조회",
-    description: "프로필, 점수, 티어 변화는 마이페이지에서 확인합니다.",
+    title: "내 전적 조회",
+    description: "프로필, 전적, 점수 변화는 마이페이지에서 확인합니다.",
     href: "/mypage",
     requiresAuth: true,
   },
   {
     title: "복습 일정",
-    description: "현재는 화면만 잡고 실제 일정 계약은 추후 연결합니다.",
+    description: "현재는 화면만 열어두고 실제 일정 계약은 추후 연결합니다.",
     href: "/mypage",
     requiresAuth: true,
   },
   {
-    title: "관전",
-    description: "진행 중인 방 목록과 관전 상세 화면으로 이동합니다.",
+    title: "관전 목록",
+    description: "진행 중인 방 목록과 관전 화면으로 이동합니다.",
     href: "/spectate",
     requiresAuth: true,
   },
@@ -60,6 +53,30 @@ export function getQueueCategoryLabel(category: string | null) {
   }
 
   return queueCategories.find((item) => item.value === category)?.label ?? category;
+}
+
+export function getReadyDecisionLabel(decision: "PENDING" | "ACCEPTED" | "DECLINED") {
+  if (decision === "ACCEPTED") {
+    return "수락";
+  }
+
+  if (decision === "DECLINED") {
+    return "거절";
+  }
+
+  return "대기";
+}
+
+export function getReadyDecisionTone(decision: "PENDING" | "ACCEPTED" | "DECLINED") {
+  if (decision === "ACCEPTED") {
+    return "success" as const;
+  }
+
+  if (decision === "DECLINED") {
+    return "danger" as const;
+  }
+
+  return "warn" as const;
 }
 
 export function formatClock(totalSeconds: number) {
@@ -76,4 +93,12 @@ export function getElapsedSeconds(startedAt: string | null, now: number) {
   }
 
   return Math.floor((now - new Date(startedAt).getTime()) / 1000);
+}
+
+export function getRemainingSeconds(deadline: string | null, now: number) {
+  if (!deadline) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor((new Date(deadline).getTime() - now) / 1000));
 }

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -1,106 +1,368 @@
 "use client";
 
+import type { ReadyCheckState } from "@/shared/api/contracts";
 import { StatusPill } from "@/shared/ui";
 
-import { formatClock } from "./data";
+import {
+  formatClock,
+  getReadyDecisionLabel,
+  getReadyDecisionTone,
+} from "./data";
+
+type QueueModalMode = "SEARCHING" | "READY_CHECK" | "ROOM_READY" | "TERMINAL" | null;
 
 interface QueueModalProps {
-  isOpen: boolean;
+  mode: QueueModalMode;
   categoryLabel: string;
   difficultyLabel: string;
+  currentUserId: number | null;
+  roomId: number | null;
   error: string | null;
   feedback: string;
   isPending: boolean;
   queueElapsedSeconds: number;
   waitingCount: number;
+  requiredCount: number;
+  readyCheck: ReadyCheckState | null;
+  countdownSeconds: number;
+  terminalMessage: string | null;
   onCancel: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
+  onRetryRoomEntry: () => void;
+  onCloseTerminal: () => void;
+}
+
+function SectionTitle({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+        {label}
+      </p>
+      <p className="mt-2 font-medium text-zinc-950">{value}</p>
+    </div>
+  );
 }
 
 export default function QueueModal({
-  isOpen,
+  mode,
   categoryLabel,
   difficultyLabel,
+  currentUserId,
+  roomId,
   error,
   feedback,
   isPending,
   queueElapsedSeconds,
   waitingCount,
+  requiredCount,
+  readyCheck,
+  countdownSeconds,
+  terminalMessage,
   onCancel,
+  onAccept,
+  onDecline,
+  onRetryRoomEntry,
+  onCloseTerminal,
 }: QueueModalProps) {
-  if (!isOpen) {
+  if (!mode) {
     return null;
   }
 
+  const modalTone =
+    mode === "TERMINAL"
+      ? "danger"
+      : mode === "ROOM_READY"
+        ? "success"
+        : "warn";
+  const modalStatus =
+    mode === "SEARCHING"
+      ? "매칭 대기 중"
+      : mode === "READY_CHECK"
+        ? "수락 확인 중"
+        : mode === "ROOM_READY"
+          ? "방 입장 준비 완료"
+          : "매칭 종료";
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 p-4">
-      <div className="w-full max-w-xl rounded-[2rem] border border-zinc-300 bg-white p-6 shadow-2xl">
+      <div className="w-full max-w-2xl rounded-[2rem] border border-zinc-300 bg-white p-6 shadow-2xl">
         <div className="flex flex-wrap items-center gap-2">
-          <StatusPill tone="warn">큐 대기 중</StatusPill>
+          <StatusPill tone={modalTone}>{modalStatus}</StatusPill>
           <StatusPill>{categoryLabel}</StatusPill>
           <StatusPill>{difficultyLabel}</StatusPill>
-          <StatusPill>{waitingCount} / 4</StatusPill>
+          {mode === "SEARCHING" ? (
+            <StatusPill>{waitingCount} / {requiredCount}</StatusPill>
+          ) : null}
+          {readyCheck ? (
+            <StatusPill>
+              {readyCheck.acceptedCount} / {readyCheck.requiredCount}
+            </StatusPill>
+          ) : null}
         </div>
 
-        <div className="mt-6 flex items-center gap-4">
-          <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-300 border-t-zinc-950 bg-zinc-50 text-transparent">
-            .
-          </div>
+        {mode === "SEARCHING" ? (
+          <>
+            <div className="mt-6 flex items-center gap-4">
+              <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-300 border-t-zinc-950 bg-zinc-50 text-transparent">
+                .
+              </div>
 
-          <div>
-            <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
-              큐를 찾는 중입니다
-            </h2>
-            <p className="mt-2 text-sm leading-7 text-zinc-600">
-              메인 화면 위에서 롤 큐처럼 현재 대기 상태를 유지합니다.
-              `/matches/me`가 `MATCHED`를 반환하면 즉시 배틀룸으로 이동합니다.
-            </p>
-          </div>
-        </div>
+              <div>
+                <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+                  상대를 찾고 있습니다
+                </h2>
+                <p className="mt-2 text-sm leading-7 text-zinc-600">
+                  ready-check 전까지는 대기열 인원만 표시합니다.
+                  네 명이 채워져서 큐에서 빠지면 자동으로 수락 화면으로 전환됩니다.
+                </p>
+              </div>
+            </div>
 
-        <div
-          className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
-            error
-              ? "border-rose-300 bg-rose-50 text-rose-900"
-              : "border-zinc-300 bg-zinc-50 text-zinc-700"
-          }`}
-        >
-          {error ?? feedback}
-        </div>
+            <div
+              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
+                error
+                  ? "border-rose-300 bg-rose-50 text-rose-900"
+                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+              }`}
+            >
+              {error ?? feedback}
+            </div>
 
-        <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-              경과 시간
-            </p>
-            <p className="mt-2 font-medium text-zinc-950">{formatClock(queueElapsedSeconds)}</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-              현재 인원
-            </p>
-            <p className="mt-2 font-medium text-zinc-950">{waitingCount} / 4</p>
-          </div>
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-              큐 상태
-            </p>
-            <p className="mt-2 font-medium text-zinc-950">검색 중</p>
-          </div>
-        </div>
+            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+              <SectionTitle label="경과 시간" value={formatClock(queueElapsedSeconds)} />
+              <SectionTitle
+                label="현재 인원"
+                value={`${waitingCount} / ${requiredCount}`}
+              />
+              <SectionTitle label="현재 상태" value="큐 대기 중" />
+            </div>
 
-        <div className="mt-6 grid gap-3 sm:grid-cols-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isPending}
-            className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-          >
-            큐 취소
-          </button>
-          <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
-            취소 버튼은 백엔드 매칭 상태가 `SEARCHING`일 때만 노출됩니다.
-          </div>
-        </div>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={onCancel}
+                disabled={isPending}
+                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+              >
+                매칭 취소
+              </button>
+              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+                cancel 버튼은 SEARCHING 단계에서만 노출됩니다.
+              </div>
+            </div>
+          </>
+        ) : null}
+
+        {mode === "READY_CHECK" ? (
+          <>
+            <div className="mt-6">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+                매칭이 성사되었습니다
+              </h2>
+              <p className="mt-2 text-sm leading-7 text-zinc-600">
+                수락 여부를 확인하는 단계입니다. 마지막 수락이 완료되면 방이 만들어지고
+                자동으로 입장 절차를 시작합니다.
+              </p>
+            </div>
+
+            <div
+              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
+                error
+                  ? "border-rose-300 bg-rose-50 text-rose-900"
+                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+              }`}
+            >
+              {error ?? feedback}
+            </div>
+
+            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+              <SectionTitle
+                label="수락 현황"
+                value={
+                  readyCheck
+                    ? `${readyCheck.acceptedCount} / ${readyCheck.requiredCount}`
+                    : "확인 중"
+                }
+              />
+              <SectionTitle label="남은 시간" value={formatClock(countdownSeconds)} />
+              <SectionTitle
+                label="내 상태"
+                value={readyCheck?.acceptedByMe ? "수락 완료" : "응답 대기"}
+              />
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-zinc-300 bg-white p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm font-medium text-zinc-950">참가자 상태</p>
+                {readyCheck ? (
+                  <p className="text-xs text-zinc-500">matchId {readyCheck.matchId}</p>
+                ) : null}
+              </div>
+
+              <div className="mt-4 space-y-3">
+                {readyCheck?.participants?.length ? (
+                  readyCheck.participants.map((participant) => (
+                    <div
+                      key={`${participant.userId}-${participant.nickname}`}
+                      className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3"
+                    >
+                      <div>
+                        <p className="font-medium text-zinc-950">
+                          {participant.nickname}
+                          {participant.userId === currentUserId ? " (나)" : ""}
+                        </p>
+                        <p className="mt-1 text-xs text-zinc-500">
+                          userId {participant.userId}
+                        </p>
+                      </div>
+                      <StatusPill tone={getReadyDecisionTone(participant.decision)}>
+                        {getReadyDecisionLabel(participant.decision)}
+                      </StatusPill>
+                    </div>
+                  ))
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-zinc-300 px-4 py-6 text-center text-sm text-zinc-500">
+                    참가자 상태를 불러오는 중입니다.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={onDecline}
+                disabled={isPending || !readyCheck}
+                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+              >
+                매칭 거절
+              </button>
+              <button
+                type="button"
+                onClick={onAccept}
+                disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
+                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+              >
+                {readyCheck?.acceptedByMe ? "이미 수락했습니다" : "매칭 수락"}
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {mode === "ROOM_READY" ? (
+          <>
+            <div className="mt-6">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+                방이 준비되었습니다
+              </h2>
+              <p className="mt-2 text-sm leading-7 text-zinc-600">
+                전원이 수락해서 방 입장 준비가 끝났습니다. 기존 battle room join API로
+                연결하는 중입니다.
+              </p>
+            </div>
+
+            <div
+              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
+                error
+                  ? "border-rose-300 bg-rose-50 text-rose-900"
+                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+              }`}
+            >
+              {error ?? feedback}
+            </div>
+
+            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+              <SectionTitle
+                label="roomId"
+                value={roomId !== null ? String(roomId) : "확인 중"}
+              />
+              <SectionTitle
+                label="수락 현황"
+                value={
+                  readyCheck
+                    ? `${readyCheck.acceptedCount} / ${readyCheck.requiredCount}`
+                    : "확인 중"
+                }
+              />
+              <SectionTitle label="현재 상태" value="방 입장 시도 중" />
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={onRetryRoomEntry}
+                disabled={isPending}
+                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+              >
+                방 입장 다시 시도
+              </button>
+              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+                join 성공 시 battle room 화면으로 이동합니다.
+              </div>
+            </div>
+          </>
+        ) : null}
+
+        {mode === "TERMINAL" ? (
+          <>
+            <div className="mt-6">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+                매칭이 종료되었습니다
+              </h2>
+              <p className="mt-2 text-sm leading-7 text-zinc-600">
+                서버 상태는 종료 상태를 유지할 수 있으므로, 현재 화면에서는 한 번 안내한 뒤
+                로컬 UI를 초기화합니다.
+              </p>
+            </div>
+
+            <div className="mt-6 rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+              {terminalMessage ?? error ?? feedback}
+            </div>
+
+            {readyCheck?.participants?.length ? (
+              <div className="mt-6 rounded-2xl border border-zinc-300 bg-white p-4">
+                <p className="text-sm font-medium text-zinc-950">종료 시점 참가자 상태</p>
+                <div className="mt-4 space-y-3">
+                  {readyCheck.participants.map((participant) => (
+                    <div
+                      key={`${participant.userId}-${participant.nickname}`}
+                      className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3"
+                    >
+                      <p className="font-medium text-zinc-950">
+                        {participant.nickname}
+                        {participant.userId === currentUserId ? " (나)" : ""}
+                      </p>
+                      <StatusPill tone={getReadyDecisionTone(participant.decision)}>
+                        {getReadyDecisionLabel(participant.decision)}
+                      </StatusPill>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={onCloseTerminal}
+                disabled={isPending}
+                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+              >
+                확인하고 닫기
+              </button>
+              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+                닫은 뒤에는 메인에서 다시 매칭을 시작할 수 있습니다.
+              </div>
+            </div>
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -2,12 +2,12 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type {
   ApiErrorResponse,
   Difficulty,
-  MatchStatusResponse,
+  MatchStateResponse,
   QueueStateResponse,
   QueueStatusResponse,
   SessionResponse,
@@ -23,28 +23,50 @@ import {
 
 import {
   dashboardMenus,
+  DEFAULT_REQUIRED_COUNT,
   difficultyOptions,
   getElapsedSeconds,
   getQueueCategoryLabel,
+  getRemainingSeconds,
   queueCategories,
   SEARCH_POLL_INTERVAL_MS,
+  type QueueCategoryValue,
 } from "./data";
 import QueueModal from "./queue-modal";
+
+type ModalMode = "SEARCHING" | "READY_CHECK" | "ROOM_READY" | "TERMINAL" | null;
+type PollStage = "IDLE" | "QUEUE" | "MATCH";
+type BusyAction =
+  | "start"
+  | "cancel"
+  | "accept"
+  | "decline"
+  | "join-room"
+  | "logout"
+  | null;
+
+const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
   category: null,
   difficulty: null,
   waitingCount: 0,
+  requiredCount: DEFAULT_REQUIRED_COUNT,
 };
 
-const defaultMatchState: MatchStatusResponse = {
+const defaultMatchState: MatchStateResponse = {
   status: "IDLE",
-  roomId: null,
+  readyCheck: null,
+  room: null,
+  message: null,
 };
 
 async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
+  const response = await fetch("/api/auth/session", {
+    cache: "no-store",
+    credentials: "include",
+  });
 
   if (!response.ok) {
     return {
@@ -57,7 +79,10 @@ async function readSession() {
 }
 
 async function readQueueState() {
-  const response = await fetch("/api/queue/me", { cache: "no-store" });
+  const response = await fetch("/api/queue/me", {
+    cache: "no-store",
+    credentials: "include",
+  });
 
   if (!response.ok) {
     return null;
@@ -67,13 +92,71 @@ async function readQueueState() {
 }
 
 async function readMatchState() {
-  const response = await fetch("/api/matches/me", { cache: "no-store" });
+  const response = await fetch("/api/matches/me", {
+    cache: "no-store",
+    credentials: "include",
+  });
 
   if (!response.ok) {
     return null;
   }
 
-  return (await response.json()) as MatchStatusResponse;
+  return (await response.json()) as MatchStateResponse;
+}
+
+async function postMatchDecision(matchId: number, action: "accept" | "decline") {
+  const response = await fetch(`/api/matches/${matchId}/${action}`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | MatchStateResponse
+    | ApiErrorResponse
+    | null;
+
+  return { response, payload };
+}
+
+async function requestBattleRoomJoin(roomId: number) {
+  const response = await fetch(`/api/battle/rooms/${roomId}/join`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+
+  return { response, payload };
+}
+
+function isQueueStatusResponse(
+  payload: QueueStatusResponse | ApiErrorResponse | null,
+): payload is QueueStatusResponse {
+  return (
+    payload !== null &&
+    "category" in payload &&
+    "difficulty" in payload &&
+    "waitingCount" in payload
+  );
+}
+
+function isMatchStateResponse(
+  payload: MatchStateResponse | ApiErrorResponse | null,
+): payload is MatchStateResponse {
+  return payload !== null && "status" in payload;
+}
+
+function getApiErrorMessage(
+  payload: QueueStatusResponse | MatchStateResponse | ApiErrorResponse | null,
+  fallback: string,
+) {
+  if (payload && "message" in payload && typeof payload.message === "string") {
+    return payload.message;
+  }
+
+  return fallback;
 }
 
 export default function HomeScreen() {
@@ -84,15 +167,107 @@ export default function HomeScreen() {
   });
   const [queueState, setQueueState] = useState(defaultQueueState);
   const [matchState, setMatchState] = useState(defaultMatchState);
-  const [category, setCategory] = useState<(typeof queueCategories)[number]["value"]>("dp");
+  const [category, setCategory] = useState<QueueCategoryValue>("dp");
   const [difficulty, setDifficulty] = useState<Difficulty>("EASY");
   const [queueStartedAt, setQueueStartedAt] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState("메인에서 바로 매칭을 시작하는 구조를 기본값으로 둡니다.");
+  const [feedback, setFeedback] = useState(DEFAULT_FEEDBACK);
   const [error, setError] = useState<string | null>(null);
-  const [now, setNow] = useState(0);
-  const [isPending, startTransition] = useTransition();
+  const [terminalMessage, setTerminalMessage] = useState<string | null>(null);
+  const [modalMode, setModalMode] = useState<ModalMode>(null);
+  const [pollStage, setPollStage] = useState<PollStage>("IDLE");
+  const [busyAction, setBusyAction] = useState<BusyAction>(null);
+  const [now, setNow] = useState(Date.now());
 
-  const redirectingRoomIdRef = useRef<number | null>(null);
+  const joiningRoomIdRef = useRef<number | null>(null);
+
+  const resetFlow = useCallback((nextFeedback = DEFAULT_FEEDBACK) => {
+    setQueueState(defaultQueueState);
+    setMatchState(defaultMatchState);
+    setQueueStartedAt(null);
+    setTerminalMessage(null);
+    setModalMode(null);
+    setPollStage("IDLE");
+    setError(null);
+    setFeedback(nextFeedback);
+    joiningRoomIdRef.current = null;
+  }, []);
+
+  const applyMatchSnapshot = useCallback((nextMatchState: MatchStateResponse) => {
+    setMatchState(nextMatchState);
+    setQueueState(defaultQueueState);
+    setQueueStartedAt(null);
+    setError(null);
+
+    if (nextMatchState.status === "ACCEPT_PENDING") {
+      setTerminalMessage(null);
+      setModalMode("READY_CHECK");
+      setPollStage("MATCH");
+      setFeedback(nextMatchState.message ?? "매칭이 성사되었습니다. 수락 여부를 선택해주세요.");
+      return;
+    }
+
+    if (nextMatchState.status === "ROOM_READY") {
+      setTerminalMessage(null);
+      setModalMode("ROOM_READY");
+      setPollStage("IDLE");
+      setFeedback(nextMatchState.message ?? "전원이 수락했습니다. 배틀룸으로 입장합니다.");
+      return;
+    }
+
+    if (nextMatchState.status === "EXPIRED" || nextMatchState.status === "CANCELLED") {
+      const nextMessage =
+        nextMatchState.message ??
+        (nextMatchState.status === "EXPIRED"
+          ? "수락 시간이 만료되었습니다."
+          : "다른 참가자가 매칭을 거절했습니다.");
+
+      setTerminalMessage(nextMessage);
+      setModalMode("TERMINAL");
+      setPollStage("IDLE");
+      setFeedback(nextMessage);
+      return;
+    }
+
+    setTerminalMessage(null);
+    setModalMode(null);
+    setPollStage("IDLE");
+    setFeedback(DEFAULT_FEEDBACK);
+  }, []);
+
+  const attemptRoomEntry = useCallback(
+    async (roomId: number) => {
+      if (joiningRoomIdRef.current === roomId) {
+        return;
+      }
+
+      joiningRoomIdRef.current = roomId;
+      setBusyAction("join-room");
+      setError(null);
+      setFeedback("배틀룸으로 입장하는 중입니다.");
+
+      let succeeded = false;
+
+      try {
+        const { response, payload } = await requestBattleRoomJoin(roomId);
+
+        if (!response.ok) {
+          setError(getApiErrorMessage(payload, "방 입장에 실패했습니다."));
+          setFeedback("room join에 실패했습니다. 다시 시도해주세요.");
+          return;
+        }
+
+        succeeded = true;
+        router.push(`/battle/rooms/${roomId}`);
+      } finally {
+        setBusyAction((current) => (current === "join-room" ? null : current));
+
+        if (!succeeded && joiningRoomIdRef.current === roomId) {
+          joiningRoomIdRef.current = null;
+        }
+      }
+    },
+    [router],
+  );
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -105,14 +280,19 @@ export default function HomeScreen() {
   }, []);
 
   useEffect(() => {
+    let active = true;
+
     void (async () => {
       const nextSession = await readSession();
+
+      if (!active) {
+        return;
+      }
+
       setSession(nextSession);
 
       if (!nextSession.authenticated) {
-        setQueueState(defaultQueueState);
-        setMatchState(defaultMatchState);
-        setQueueStartedAt(null);
+        resetFlow();
         return;
       }
 
@@ -121,82 +301,77 @@ export default function HomeScreen() {
         readMatchState(),
       ]);
 
-      const resolvedMatchState = nextMatchState ?? defaultMatchState;
-      const resolvedQueueState =
-        nextQueueState ??
-        (resolvedMatchState.status === "SEARCHING"
-          ? {
-              ...defaultQueueState,
-              inQueue: true,
-            }
-          : defaultQueueState);
-
-      setQueueState(resolvedQueueState);
-      setMatchState(resolvedMatchState);
-
-      if (resolvedMatchState.status === "MATCHED" && resolvedMatchState.roomId !== null) {
-        redirectingRoomIdRef.current = resolvedMatchState.roomId;
-        setError(null);
-        setFeedback(`roomId ${resolvedMatchState.roomId} 배틀룸으로 이동합니다.`);
-        router.push(`/battle/rooms/${resolvedMatchState.roomId}`);
+      if (!active) {
         return;
       }
 
-      if (resolvedMatchState.status === "SEARCHING" || resolvedQueueState.inQueue) {
+      if (nextQueueState?.inQueue) {
+        setQueueState(nextQueueState);
+        setMatchState(defaultMatchState);
         setQueueStartedAt((current) => current ?? new Date().toISOString());
-        setFeedback("플레이어를 찾는 중입니다. /matches/me가 MATCHED를 반환하면 배틀룸으로 이동합니다.");
+        setTerminalMessage(null);
+        setModalMode("SEARCHING");
+        setPollStage("QUEUE");
+        setError(null);
+        setFeedback("대기열에서 상대를 찾고 있습니다.");
+        return;
       }
+
+      if (nextMatchState && nextMatchState.status !== "IDLE") {
+        applyMatchSnapshot(nextMatchState);
+        return;
+      }
+
+      resetFlow();
     })();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    return () => {
+      active = false;
+    };
+  }, [applyMatchSnapshot, resetFlow]);
 
   useEffect(() => {
-    if (!session.authenticated || matchState.status !== "SEARCHING") {
+    if (!session.authenticated || pollStage !== "QUEUE") {
       return;
     }
 
     let active = true;
 
     const poll = async () => {
+      const nextQueueState = await readQueueState();
+
+      if (!active || !nextQueueState) {
+        return;
+      }
+
+      if (nextQueueState.inQueue) {
+        setQueueState(nextQueueState);
+        setModalMode("SEARCHING");
+        setError(null);
+        setFeedback("대기열에서 상대를 찾고 있습니다.");
+        return;
+      }
+
+      setQueueState(nextQueueState);
+      setQueueStartedAt(null);
+      setModalMode("READY_CHECK");
+      setPollStage("MATCH");
+      setError(null);
+      setFeedback("ready-check 세션을 확인하는 중입니다.");
+
       const nextMatchState = await readMatchState();
 
       if (!active || !nextMatchState) {
         return;
       }
 
-      if (nextMatchState.status === "MATCHED" && nextMatchState.roomId !== null) {
-        setMatchState(nextMatchState);
-        redirectingRoomIdRef.current = nextMatchState.roomId;
-        setError(null);
-        setFeedback(`roomId ${nextMatchState.roomId} 배틀룸으로 이동합니다.`);
-        router.push(`/battle/rooms/${nextMatchState.roomId}`);
+      if (nextMatchState.status === "IDLE") {
+        setMatchState(defaultMatchState);
+        setFeedback("ready-check 세션을 확인하는 중입니다.");
         return;
       }
 
-      if (nextMatchState.status === "SEARCHING") {
-        setMatchState(nextMatchState);
-
-        const nextQueueState = await readQueueState();
-
-        if (!active) {
-          return;
-        }
-
-        setQueueState(
-          nextQueueState ??
-            ({
-              ...defaultQueueState,
-              inQueue: true,
-            } satisfies QueueStateResponse),
-        );
-        setQueueStartedAt((current) => current ?? new Date().toISOString());
-        return;
-      }
-
-      setMatchState(nextMatchState);
-      setQueueState(defaultQueueState);
-      setQueueStartedAt(null);
-      setFeedback("큐 상태가 종료되었습니다.");
+      applyMatchSnapshot(nextMatchState);
     };
 
     void poll();
@@ -209,8 +384,54 @@ export default function HomeScreen() {
       active = false;
       window.clearInterval(intervalId);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [matchState.status, session.authenticated]);
+  }, [applyMatchSnapshot, pollStage, session.authenticated]);
+
+  useEffect(() => {
+    if (!session.authenticated || pollStage !== "MATCH") {
+      return;
+    }
+
+    let active = true;
+
+    const poll = async () => {
+      const nextMatchState = await readMatchState();
+
+      if (!active || !nextMatchState) {
+        return;
+      }
+
+      if (nextMatchState.status === "IDLE") {
+        setMatchState(defaultMatchState);
+        setModalMode("READY_CHECK");
+        setError(null);
+        setFeedback("ready-check 세션을 확인하는 중입니다.");
+        return;
+      }
+
+      applyMatchSnapshot(nextMatchState);
+    };
+
+    void poll();
+
+    const intervalId = window.setInterval(() => {
+      void poll();
+    }, SEARCH_POLL_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, [applyMatchSnapshot, pollStage, session.authenticated]);
+
+  useEffect(() => {
+    const roomId = matchState.room?.roomId ?? null;
+
+    if (!session.authenticated || modalMode !== "ROOM_READY" || roomId === null) {
+      return;
+    }
+
+    void attemptRoomEntry(roomId);
+  }, [attemptRoomEntry, matchState.room?.roomId, modalMode, session.authenticated]);
 
   function handleProtectedMove(href: string) {
     if (!session.authenticated) {
@@ -221,164 +442,218 @@ export default function HomeScreen() {
     router.push(href);
   }
 
-  function handleStartMatch() {
+  async function handleStartMatch() {
     if (!session.authenticated) {
       router.push("/login?next=/");
       return;
     }
 
     if (category === "RANDOM") {
-      setError(
-        "현재 백엔드 문제 선정은 전체(무작위)를 지원하지 않습니다. 구체 카테고리를 선택해주세요.",
-      );
+      setError("현재는 구체적인 카테고리만 매칭할 수 있습니다.");
       return;
     }
 
-    if (matchState.status === "SEARCHING") {
-      setFeedback("이미 큐가 진행 중입니다.");
+    if (modalMode && modalMode !== "TERMINAL") {
+      setError("이미 진행 중인 매칭 흐름이 있습니다.");
       return;
     }
 
+    setBusyAction("start");
     setError(null);
+    setTerminalMessage(null);
 
-    startTransition(() => {
-      void (async () => {
-        const response = await fetch("/api/queue/join", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            category,
-            difficulty,
-          }),
-        });
+    try {
+      const response = await fetch("/api/queue/join", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          category,
+          difficulty,
+        }),
+      });
 
-        const payload = (await response.json().catch(() => null)) as
-          | QueueStatusResponse
-          | ApiErrorResponse
-          | null;
+      const payload = (await response.json().catch(() => null)) as
+        | QueueStatusResponse
+        | ApiErrorResponse
+        | null;
 
-        if (response.status === 409 && payload && "category" in payload) {
-          setQueueState({
-            inQueue: true,
-            category: payload.category,
-            difficulty: payload.difficulty,
-            waitingCount: payload.waitingCount,
-          });
-          setMatchState({
-            status: "SEARCHING",
-            roomId: null,
-          });
-          setQueueStartedAt((current) => current ?? new Date().toISOString());
-          setFeedback(payload.message);
-          return;
-        }
-
-        if (!response.ok || !payload || !("category" in payload)) {
-          setQueueStartedAt(null);
-          setError(payload && "message" in payload ? payload.message : "큐 참가 요청에 실패했습니다.");
-          return;
-        }
-
+      if ((response.ok || response.status === 409) && isQueueStatusResponse(payload)) {
         setQueueState({
           inQueue: true,
           category: payload.category,
           difficulty: payload.difficulty,
           waitingCount: payload.waitingCount,
+          requiredCount: payload.requiredCount ?? DEFAULT_REQUIRED_COUNT,
         });
-        setMatchState({
-          status: "SEARCHING",
-          roomId: null,
-        });
+        setMatchState(defaultMatchState);
         setQueueStartedAt(new Date().toISOString());
+        setModalMode("SEARCHING");
+        setPollStage("QUEUE");
         setFeedback(payload.message);
+        return;
+      }
 
-        const nextMatchState = await readMatchState();
-
-        if (nextMatchState?.status === "MATCHED" && nextMatchState.roomId !== null) {
-          setMatchState(nextMatchState);
-          redirectingRoomIdRef.current = nextMatchState.roomId;
-          setError(null);
-          setFeedback(`roomId ${nextMatchState.roomId} 배틀룸으로 이동합니다.`);
-          router.push(`/battle/rooms/${nextMatchState.roomId}`);
-        }
-      })();
-    });
+      setError(getApiErrorMessage(payload, "매칭 참가 요청에 실패했습니다."));
+    } finally {
+      setBusyAction(null);
+    }
   }
 
-  function handleCancelMatch() {
-    if (matchState.status !== "SEARCHING") {
+  async function handleCancelMatch() {
+    if (modalMode !== "SEARCHING") {
       return;
     }
 
+    setBusyAction("cancel");
     setError(null);
 
-    startTransition(() => {
-      void (async () => {
-        const response = await fetch("/api/queue/cancel", {
-          method: "DELETE",
-        });
+    try {
+      const response = await fetch("/api/queue/cancel", {
+        method: "DELETE",
+        cache: "no-store",
+        credentials: "include",
+      });
 
-        const payload = (await response.json().catch(() => null)) as
-          | QueueStatusResponse
-          | ApiErrorResponse
-          | null;
+      const payload = (await response.json().catch(() => null)) as
+        | QueueStatusResponse
+        | ApiErrorResponse
+        | null;
 
-        if (!response.ok) {
-          setError(payload && "message" in payload ? payload.message : "큐 취소 요청에 실패했습니다.");
-          return;
-        }
+      if (!response.ok) {
+        setError(getApiErrorMessage(payload, "매칭 취소 요청에 실패했습니다."));
+        return;
+      }
 
-        setQueueState(defaultQueueState);
-        setMatchState(defaultMatchState);
-        setQueueStartedAt(null);
-        setFeedback(payload && "message" in payload ? payload.message : "큐 취소가 완료되었습니다.");
-      })();
-    });
+      resetFlow(getApiErrorMessage(payload, "매칭 대기열에서 취소됐습니다."));
+    } finally {
+      setBusyAction(null);
+    }
   }
 
-  function handleLogout() {
-    startTransition(() => {
-      void (async () => {
-        await fetch("/api/auth/logout", { method: "POST" });
-        setSession({
-          authenticated: false,
-          member: null,
-        });
-        setQueueState(defaultQueueState);
-        setMatchState(defaultMatchState);
-        setQueueStartedAt(null);
-        redirectingRoomIdRef.current = null;
-        setFeedback("로그아웃되었습니다.");
-        router.refresh();
-      })();
-    });
+  async function handleAcceptMatch() {
+    const matchId = matchState.readyCheck?.matchId;
+
+    if (!matchId) {
+      return;
+    }
+
+    setBusyAction("accept");
+    setError(null);
+
+    try {
+      const { response, payload } = await postMatchDecision(matchId, "accept");
+
+      if (!response.ok || !isMatchStateResponse(payload)) {
+        setError(getApiErrorMessage(payload, "매칭 수락 요청에 실패했습니다."));
+        return;
+      }
+
+      applyMatchSnapshot(payload);
+    } finally {
+      setBusyAction(null);
+    }
   }
 
-  const isSearching = session.authenticated && matchState.status === "SEARCHING";
-  const waitingCount = Math.max(queueState.waitingCount, isSearching ? 1 : 0);
+  async function handleDeclineMatch() {
+    const matchId = matchState.readyCheck?.matchId;
+
+    if (!matchId) {
+      return;
+    }
+
+    setBusyAction("decline");
+    setError(null);
+
+    try {
+      const { response, payload } = await postMatchDecision(matchId, "decline");
+
+      if (!response.ok || !isMatchStateResponse(payload)) {
+        setError(getApiErrorMessage(payload, "매칭 거절 요청에 실패했습니다."));
+        return;
+      }
+
+      applyMatchSnapshot(payload);
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  function handleCloseTerminal() {
+    resetFlow("종료 상태를 정리했습니다. 메인에서 다시 매칭을 시작할 수 있습니다.");
+  }
+
+  async function handleLogout() {
+    setBusyAction("logout");
+
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+      setSession({
+        authenticated: false,
+        member: null,
+      });
+      resetFlow("로그아웃했습니다.");
+      router.refresh();
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const isBusy = busyAction !== null;
+  const waitingCount = queueState.inQueue ? Math.max(queueState.waitingCount, 1) : 0;
+  const requiredCount =
+    queueState.requiredCount ||
+    matchState.readyCheck?.requiredCount ||
+    DEFAULT_REQUIRED_COUNT;
   const activeCategoryLabel = getQueueCategoryLabel(queueState.category ?? category);
   const activeDifficultyLabel = queueState.difficulty ?? difficulty;
   const queueElapsedSeconds = getElapsedSeconds(queueStartedAt, now);
-  const queueStatusValue = isSearching ? "대기 중" : "대기 전";
-  const queueStatusHint = isSearching
-    ? `${waitingCount}명 대기`
-    : "메인에서 바로 시작";
+  const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
+  const acceptedCount = matchState.readyCheck?.acceptedCount ?? 0;
+  const roomId = matchState.room?.roomId ?? null;
+
+  const flowStatusValue =
+    modalMode === "SEARCHING"
+      ? "대기 중"
+      : modalMode === "READY_CHECK"
+        ? "수락 대기"
+        : modalMode === "ROOM_READY"
+          ? "방 준비 완료"
+          : modalMode === "TERMINAL"
+            ? "종료 안내"
+            : "대기 없음";
+
+  const flowStatusHint =
+    modalMode === "SEARCHING"
+      ? `${waitingCount} / ${requiredCount}명 대기`
+      : modalMode === "READY_CHECK"
+        ? `${acceptedCount} / ${requiredCount}명 수락`
+        : modalMode === "ROOM_READY"
+          ? roomId !== null
+            ? `roomId ${roomId}`
+            : "roomId 확인 중"
+          : modalMode === "TERMINAL"
+            ? "종료 후 로컬 상태 초기화"
+            : "메인에서 바로 시작";
 
   return (
     <div className="space-y-8">
       <PageHero
         eyebrow="Main"
-        title="메인에서 큐를 잡고, 매칭 성사 뒤 배틀룸으로 이동"
-        description="비로그인 사용자는 서비스 구조를 볼 수 있고, 실제 매칭 시작이나 보호 화면 진입 시 `/login`으로 이동합니다. 로그인 후에는 메인에서 큐 대기, `/matches/me` 폴링, 배틀룸 진입까지 이어집니다."
+        title="프로필을 보고, ready-check까지 이어지는 메인 홈"
+        description="메인 홈에서 category와 difficulty를 고른 뒤 매칭을 시작합니다. v2 흐름에서는 먼저 queue/me를 polling하고, 큐에서 빠진 뒤에는 matches/me로 전환해 수락 여부와 room 준비 상태를 확인합니다."
         actions={
           <>
             <StatusPill tone={session.authenticated ? "success" : "warn"}>
               {session.authenticated ? "로그인 상태" : "게스트 상태"}
             </StatusPill>
-            <StatusPill>4인 매칭</StatusPill>
-            <StatusPill>매칭 상태 폴링</StatusPill>
+            <StatusPill>ready-check v2</StatusPill>
+            <StatusPill>HTTP polling</StatusPill>
           </>
         }
       />
@@ -392,8 +667,8 @@ export default function HomeScreen() {
             </h2>
             <p className="mt-2 text-sm text-zinc-600">
               {session.authenticated
-                ? `${session.member?.nickname}님, 메인에서 바로 매칭을 시작할 수 있습니다.`
-                : "로그인 전에도 메인 구조는 볼 수 있지만, 실제 큐 참가 시 로그인으로 이동합니다."}
+                ? `${session.member?.nickname}님은 메인 홈에서 바로 매칭을 시작할 수 있습니다.`
+                : "비로그인 상태에서는 메인 구조만 볼 수 있고, 실제 매칭 시작 시 로그인으로 이동합니다."}
             </p>
           </div>
 
@@ -403,7 +678,7 @@ export default function HomeScreen() {
                 {session.member?.nickname ?? "게스트"}
               </p>
               <p className="text-zinc-500">
-                {session.member?.role ?? "로그인 필요"} / 티어 API 준비 전
+                {session.member?.role ?? "로그인 필요"} / 전적 API 연동 중
               </p>
             </div>
             {session.authenticated ? (
@@ -418,7 +693,7 @@ export default function HomeScreen() {
                 <button
                   type="button"
                   onClick={handleLogout}
-                  disabled={isPending}
+                  disabled={isBusy}
                   className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
                 >
                   로그아웃
@@ -445,12 +720,16 @@ export default function HomeScreen() {
       </div>
 
       <MetricGrid>
-        <MetricCard label="큐 상태" value={queueStatusValue} hint={queueStatusHint} />
-        <MetricCard label="매칭 인원" value="4명" hint="현재 MVP는 4인 고정" />
+        <MetricCard label="현재 상태" value={flowStatusValue} hint={flowStatusHint} />
+        <MetricCard
+          label="매칭 인원"
+          value={`${requiredCount}명`}
+          hint="현재 MVP는 4인 ready-check 기준"
+        />
         <MetricCard
           label="카테고리"
           value={activeCategoryLabel}
-          hint="같은 조건의 4명이 모이면 즉시 방을 배정합니다."
+          hint="큐 대기 중에는 queue/me 기준으로 표시합니다."
         />
         <MetricCard
           label="난이도"
@@ -461,8 +740,8 @@ export default function HomeScreen() {
 
       <div className="grid gap-6 xl:grid-cols-[0.85fr_1.3fr_0.85fr]">
         <Panel
-          title="사이드 메뉴"
-          description="팀이 페이지별로 나눠 작업할 수 있도록 진입점을 분리합니다."
+          title="서비스 메뉴"
+          description="주요 페이지별 작업 동선을 한곳에서 바로 열 수 있도록 진입점을 둡니다."
         >
           <div className="space-y-3">
             {dashboardMenus.map((menu) => {
@@ -489,16 +768,14 @@ export default function HomeScreen() {
 
         <Panel
           title="매칭 설정 영역"
-          description="메인의 가장 중요한 기능은 카테고리와 난이도를 고르고 큐를 잡는 것입니다."
+          description="메인 홈의 가장 중요한 기능은 카테고리와 난이도를 고른 뒤 바로 매칭을 시작하는 것입니다."
         >
           <div className="space-y-6">
             <label className="block space-y-2">
               <span className="text-sm font-medium text-zinc-700">알고리즘 카테고리</span>
               <select
                 value={category}
-                onChange={(event) =>
-                  setCategory(event.target.value as (typeof queueCategories)[number]["value"])
-                }
+                onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
                 className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
               >
                 {queueCategories.map((item) => (
@@ -509,7 +786,7 @@ export default function HomeScreen() {
               </select>
             </label>
             <p className="text-sm leading-6 text-zinc-500">
-              현재 백엔드 출제기는 실제 태그 카테고리만 지원합니다. `전체(무작위)`는 준비 중으로 둡니다.
+              현재는 실제 출제 가능한 카테고리만 사용하고, 전체(무작위)는 준비 중으로 둡니다.
             </p>
 
             <fieldset className="space-y-3">
@@ -541,20 +818,28 @@ export default function HomeScreen() {
             <div className="flex flex-wrap gap-3">
               <button
                 type="button"
-                onClick={handleStartMatch}
-                disabled={isPending || isSearching}
+                onClick={() => {
+                  void handleStartMatch();
+                }}
+                disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
                 className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
               >
-                {isSearching ? "큐 진행 중" : isPending ? "처리 중..." : "매칭 시작"}
+                {modalMode === "SEARCHING"
+                  ? "매칭 진행 중"
+                  : busyAction === "start"
+                    ? "처리 중..."
+                    : "매칭 시작"}
               </button>
-              {isSearching ? (
+              {modalMode === "SEARCHING" ? (
                 <button
                   type="button"
-                  onClick={handleCancelMatch}
-                  disabled={isPending}
+                  onClick={() => {
+                    void handleCancelMatch();
+                  }}
+                  disabled={isBusy}
                   className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
                 >
-                  큐 취소
+                  매칭 취소
                 </button>
               ) : null}
             </div>
@@ -566,69 +851,103 @@ export default function HomeScreen() {
                   : "border-zinc-300 bg-zinc-50 text-zinc-700"
               }`}
             >
-              {error ?? feedback}
+              {error ?? terminalMessage ?? feedback}
             </div>
           </div>
         </Panel>
 
         <Panel
           title="개인 통계 요약"
-          description="메인에서는 보조 정보로만 두고, 실제 통계 API가 생기면 마이페이지와 같이 연결합니다."
+          description="메인에서는 보조 정보만 보여주고, 실제 전적과 점수 API는 마이페이지에서 더 자세히 확인합니다."
         >
           <div className="space-y-3 text-sm">
             <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              내 승률: API 준비 전
+              티어/총점: API 연결 전
             </div>
             <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              최근 score 추이: API 준비 전
+              현재 단계: {flowStatusValue}
             </div>
             <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              {isSearching
+              {modalMode === "SEARCHING"
                 ? `현재 큐: ${activeCategoryLabel} / ${activeDifficultyLabel} / ${waitingCount}명 대기`
-                : `현재 큐: 대기 중 아님`}
+                : modalMode === "READY_CHECK"
+                  ? `ready-check: ${acceptedCount} / ${requiredCount}명 수락`
+                  : modalMode === "ROOM_READY"
+                    ? `방 입장 준비: roomId ${roomId ?? "확인 중"}`
+                    : "현재는 대기 중이 아닙니다."}
             </div>
           </div>
         </Panel>
       </div>
 
       <Panel
-        title="현재 연결 포인트"
-        description="메인과 인증 흐름에서 이미 실제 API로 연결된 지점"
+        title="현재 연결 사인"
+        description="메인과 인접한 흐름에서 이번 단계에 실제로 붙여 둔 API 경로들입니다."
       >
-        <div className="grid gap-4 lg:grid-cols-4">
-          <ApiCallout
-            method="POST"
-            path="/api/auth/login"
-            note="프론트 BFF가 백엔드 로그인 응답의 accessToken 쿠키를 프론트 도메인으로 중계한다."
-          />
+        <div className="grid gap-4 lg:grid-cols-3">
           <ApiCallout
             method="POST"
             path="/api/queue/join"
-            note="JWT subject를 userId로 읽어 백엔드 `/api/v1/queue/join`으로 전달한다."
+            note="큐 참가 후에는 응답 메시지를 고정 상태로 쓰지 않고, queue/me polling으로 실제 대기 상태를 그립니다."
           />
           <ApiCallout
             method="GET"
             path="/api/queue/me"
-            note="현재 로그인 사용자의 큐 상태를 메인 진입 시 바로 조회한다."
+            note="SEARCHING 단계 전용입니다. waitingCount와 requiredCount를 이용해 1/4, 2/4 같은 대기 UI를 만듭니다."
           />
           <ApiCallout
             method="GET"
             path="/api/matches/me"
-            note="매칭 성사 여부와 roomId는 이 API를 폴링해서 확인한다."
+            note="queue/me에서 inQueue=false가 되면 이쪽으로 전환해 ready-check, room 준비, 종료 상태를 확인합니다."
+          />
+          <ApiCallout
+            method="POST"
+            path="/api/matches/[matchId]/accept"
+            note="내 decision을 ACCEPTED로 바꾸고, 마지막 수락이면 ROOM_READY까지 이어집니다."
+          />
+          <ApiCallout
+            method="POST"
+            path="/api/matches/[matchId]/decline"
+            note="한 명이라도 거절하면 세션 전체가 CANCELLED로 바뀌고 종료 안내를 보여줍니다."
+          />
+          <ApiCallout
+            method="POST"
+            path="/api/battle/rooms/{roomId}/join"
+            note="ROOM_READY가 되면 기존 battle room join API를 재사용해서 실제 방으로 입장합니다."
           />
         </div>
       </Panel>
 
       <QueueModal
-        isOpen={isSearching}
+        mode={modalMode}
         categoryLabel={activeCategoryLabel}
         difficultyLabel={activeDifficultyLabel}
+        currentUserId={session.member?.memberId ?? null}
+        roomId={roomId}
         error={error}
         feedback={feedback}
-        isPending={isPending}
+        isPending={isBusy}
         queueElapsedSeconds={queueElapsedSeconds}
         waitingCount={waitingCount}
-        onCancel={handleCancelMatch}
+        requiredCount={requiredCount}
+        readyCheck={matchState.readyCheck}
+        countdownSeconds={countdownSeconds}
+        terminalMessage={terminalMessage}
+        onCancel={() => {
+          void handleCancelMatch();
+        }}
+        onAccept={() => {
+          void handleAcceptMatch();
+        }}
+        onDecline={() => {
+          void handleDeclineMatch();
+        }}
+        onRetryRoomEntry={() => {
+          if (roomId !== null) {
+            void attemptRoomEntry(roomId);
+          }
+        }}
+        onCloseTerminal={handleCloseTerminal}
       />
     </div>
   );

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -48,6 +48,7 @@ export interface QueueStateResponse {
   category: string | null;
   difficulty: string | null;
   waitingCount: number;
+  requiredCount: number;
 }
 
 export interface QueueStatusResponse {
@@ -55,11 +56,33 @@ export interface QueueStatusResponse {
   category: string;
   difficulty: string;
   waitingCount: number;
+  requiredCount: number;
 }
 
-export interface MatchStatusResponse {
-  status: "IDLE" | "SEARCHING" | "MATCHED";
-  roomId: number | null;
+export interface ReadyCheckParticipant {
+  userId: number;
+  nickname: string;
+  decision: "PENDING" | "ACCEPTED" | "DECLINED";
+}
+
+export interface ReadyCheckState {
+  matchId: number;
+  acceptedCount: number;
+  requiredCount: number;
+  acceptedByMe: boolean;
+  deadline: string;
+  participants: ReadyCheckParticipant[];
+}
+
+export interface MatchRoomInfo {
+  roomId: number;
+}
+
+export interface MatchStateResponse {
+  status: "IDLE" | "ACCEPT_PENDING" | "ROOM_READY" | "EXPIRED" | "CANCELLED";
+  readyCheck: ReadyCheckState | null;
+  room: MatchRoomInfo | null;
+  message: string | null;
 }
 
 export interface ParticipantInfo {


### PR DESCRIPTION
refs #16 
closes #16 

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈의 매칭 흐름을 기존 <code>v1 즉시 매칭</code> 구조에서
<strong><code>v2 ready-check</code> 구조</strong>로 전환한 작업입니다.
</p>

<p>
기존에는 프론트가
<code>GET /api/matches/me</code> 하나를 기준으로
<code>SEARCHING -&gt; MATCHED</code> 흐름을 처리하고,
roomId가 생기면 바로 방으로 이동하는 구조였습니다.
</p>

<p>
하지만 v2에서는 역할이 분리됩니다.
</p>

<ul>
  <li><code>GET /api/v2/queue/me</code>: 큐 대기 상태 전용</li>
  <li><code>GET /api/v2/matches/me</code>: ready-check / room 준비 / 종료 상태 전용</li>
</ul>

<p>
따라서 이번 PR에서는 메인 홈에서
<strong><code>queue/me -&gt; matches/me</code>로 단계 전환하는 상태 머신</strong>을 구현하고,
ready-check 수락/거절 UI와 room 준비 이후의 기존 battle room join 흐름을 연결했습니다.
</p>

<hr />

<h3>1) v2 매칭 계약에 맞는 프론트 타입 정리</h3>
<p>
먼저 <code>src/shared/api/contracts.ts</code>에서
v2 계약을 프론트에서 그대로 사용할 수 있도록 타입을 확장했습니다.
</p>

<ul>
  <li><code>QueueStateResponse</code>에 <code>requiredCount</code> 추가</li>
  <li><code>QueueStatusResponse</code>에 <code>requiredCount</code> 추가</li>
  <li><code>ReadyCheckParticipant</code> 추가</li>
  <li><code>ReadyCheckState</code> 추가</li>
  <li><code>MatchRoomInfo</code> 추가</li>
  <li><code>MatchStateResponse</code>를 v2 status 기준으로 재정의</li>
</ul>

<pre><code class="language-ts">export interface MatchStateResponse {
  status: "IDLE" | "ACCEPT_PENDING" | "ROOM_READY" | "EXPIRED" | "CANCELLED";
  readyCheck: ReadyCheckState | null;
  room: MatchRoomInfo | null;
  message: string | null;
}</code></pre>

<p>
이제 프론트는 백엔드가 주는 ready-check 상태를
임의 변환 없이 그대로 사용할 수 있습니다.
</p>

<hr />

<h3>2) queue 관련 BFF를 v2 기준으로 교체</h3>
<p>
기존 홈 화면은 프론트 BFF를 통해 v1 큐 API를 호출하고 있었기 때문에,
이번 PR에서는 <code>/api/queue/*</code> 라우트를 그대로 유지하되
내부적으로는 <code>/api/v2/queue/*</code>를 바라보도록 바꿨습니다.
</p>

<ul>
  <li><code>POST /api/queue/join</code> → <code>POST /api/v2/queue/join</code> 프록시</li>
  <li><code>GET /api/queue/me</code> → <code>GET /api/v2/queue/me</code> 프록시</li>
  <li><code>DELETE /api/queue/cancel</code> → <code>DELETE /api/v2/queue/cancel</code> 프록시</li>
</ul>

<p>
모든 요청은 기존과 동일하게 JWT accessToken 쿠키 기반으로 인증합니다.
프론트에서는 BFF만 호출하고, BFF가 백엔드로 토큰을 넘겨주는 구조를 유지했습니다.
</p>

<p>
추가로 <code>requiredCount</code>가 비어 있는 경우를 대비해 기본값 <code>4</code>를 넣어
UI가 안정적으로 그려지도록 했습니다.
</p>

<hr />

<h3>3) matches 관련 BFF를 v2 ready-check 구조로 추가</h3>
<p>
v2 흐름에서는 ready-check와 room 준비 상태를 별도 endpoint에서 조회해야 하므로,
프론트에 아래 BFF를 추가했습니다.
</p>

<ul>
  <li><code>GET /api/matches/me</code> → <code>GET /api/v2/matches/me</code></li>
  <li><code>POST /api/matches/{matchId}/accept</code> → <code>POST /api/v2/matches/{matchId}/accept</code></li>
  <li><code>POST /api/matches/{matchId}/decline</code> → <code>POST /api/v2/matches/{matchId}/decline</code></li>
</ul>

<p>
즉 이제 홈 화면은
</p>

<pre><code class="language-text">queue 상태는 /api/queue/me
ready-check / room 준비 상태는 /api/matches/me
수락 / 거절 액션은 /api/matches/{matchId}/accept|decline</code></pre>

<p>
로 역할을 분리해서 사용합니다.
</p>

<hr />

<h3>4) 메인 홈 상태 머신을 v2 기준으로 재구성</h3>
<p>
이번 PR의 핵심은 <code>src/features/home/screen.tsx</code>에서
기존 v1 흐름을 버리고, v2 단계 전환에 맞는 로컬 상태 머신을 재구성한 것입니다.
</p>

<p>
로컬 UI 상태는 다음처럼 동작합니다.
</p>

<pre><code class="language-text">IDLE
  → 매칭 시작
SEARCHING
  → queue/me.inQueue === false
READY_CHECK
  → matches/me.status === ROOM_READY
ROOM_READY
  → battle room join 성공 후 방 이동
TERMINAL
  → EXPIRED / CANCELLED 안내 후 로컬 상태 초기화
</code></pre>

<p>
실제 구현에서는
<code>modalMode</code>와 <code>pollStage</code>를 분리해 두었습니다.
</p>

<ul>
  <li><code>modalMode</code>: 현재 사용자에게 어떤 모달을 보여줄지</li>
  <li><code>pollStage</code>: 지금 어떤 endpoint를 polling할지</li>
</ul>

<p>
이렇게 분리함으로써
UI 상태와 polling 대상을 함께 제어할 수 있게 했습니다.
</p>

<hr />

<h3>5) queue/me polling 단계 구현</h3>
<p>
매칭 시작 버튼 클릭 시 먼저 <code>POST /api/queue/join</code>을 호출합니다.
성공하면 프론트는 즉시 SEARCHING 상태로 전환하고,
<code>GET /api/queue/me</code> polling을 시작합니다.
</p>

<ul>
  <li>polling 간격: <code>1초</code></li>
  <li><code>inQueue === true</code>이면 SEARCHING 유지</li>
  <li><code>waitingCount / requiredCount</code>로 <code>1/4</code>, <code>2/4</code>, <code>3/4</code> 표시</li>
  <li>cancel 버튼은 SEARCHING 단계에서만 노출</li>
</ul>

<p>
중요한 점은, v2에서는 <code>matches/me</code>가 SEARCHING을 주지 않기 때문에
대기 중 표시와 인원 수 UI는 전부 <code>queue/me</code> 기준으로만 처리한다는 점입니다.
</p>

<hr />

<h3>6) queue → ready-check 전환 로직 구현</h3>
<p>
v2의 가장 중요한 전환 조건은
<code>queue/me.inQueue === false</code>입니다.
</p>

<p>
이번 PR에서는 이 전환 조건을 그대로 반영해,
큐 polling 중에 <code>inQueue=false</code>가 감지되면:
</p>

<ol>
  <li><code>queue/me</code> polling을 멈추고</li>
  <li><code>matches/me</code> polling 단계로 전환하고</li>
  <li>ready-check 세션을 조회하도록 구현했습니다.</li>
</ol>

<p>
즉, 프론트는 더 이상 v1처럼
<code>/matches/me</code>에서 SEARCHING을 기대하지 않습니다.
</p>

<hr />

<h3>7) ACCEPT_PENDING ready-check UI 구현</h3>
<p>
<code>matches/me.status === "ACCEPT_PENDING"</code>일 때
기존 대기 모달을 ready-check 모달로 확장해 수락/거절 UI를 표시하도록 구현했습니다.
</p>

<p>
모달에서 보여주는 정보는 다음과 같습니다.
</p>

<ul>
  <li><code>acceptedCount / requiredCount</code></li>
  <li><code>acceptedByMe</code> 기준 내 버튼 활성화/비활성화</li>
  <li><code>deadline</code> 기준 남은 시간 카운트다운</li>
  <li><code>participants[].nickname</code></li>
  <li><code>participants[].decision</code> 상태 배지</li>
</ul>

<p>
decision은 아래 세 가지로 단일화해서 표시합니다.
</p>

<ul>
  <li><code>PENDING</code> → 대기</li>
  <li><code>ACCEPTED</code> → 수락</li>
  <li><code>DECLINED</code> → 거절</li>
</ul>

<p>
즉, 프론트가 로컬 acceptedMemberIds 같은 임시 상태를 따로 만들지 않고,
백엔드가 주는 참가자 상태를 그대로 렌더링하는 방식으로 바꿨습니다.
</p>

<hr />

<h3>8) accept / decline 액션 연결</h3>
<p>
ready-check 단계에서는 아래 두 액션을 호출할 수 있도록 연결했습니다.
</p>

<ul>
  <li><code>POST /api/matches/{matchId}/accept</code></li>
  <li><code>POST /api/matches/{matchId}/decline</code></li>
</ul>

<p>
수락 성공 시 응답으로 받은 <code>MatchStateResponse</code>를 그대로 적용해
다시 상태를 갱신합니다.
거절도 동일하게 응답 상태를 받아 즉시 반영합니다.
</p>

<p>
즉 액션 이후에도 별도 후처리 상태를 프론트가 만들지 않고,
항상 서버 응답을 source of truth로 사용하도록 정리했습니다.
</p>

<hr />

<h3>9) ROOM_READY 이후 기존 battle room join 흐름 연결</h3>
<p>
<code>matches/me.status === "ROOM_READY"</code>가 되면,
프론트는 <code>room.roomId</code>를 확인한 뒤
기존 battle room join API를 재사용합니다.
</p>

<pre><code class="language-text">ROOM_READY
  → room.roomId 확인
  → POST /api/v1/battle/rooms/{roomId}/join
  → 성공 시 /battle/rooms/{roomId} 이동
</code></pre>

<p>
즉 이번 PR은 ready-check 도입 때문에 방 입장 API를 새로 만드는 대신,
기존 배틀룸 입장 흐름을 그대로 연결하는 방식으로 구현했습니다.
</p>

<p>
또한 join 실패 시에는 사용자가 다시 시도할 수 있도록
ROOM_READY 모달에서 재시도 버튼도 함께 제공합니다.
</p>

<hr />

<h3>10) EXPIRED / CANCELLED 종료 상태 처리</h3>
<p>
v2에서는 종료 상태가 별도 status로 내려오기 때문에,
이번 PR에서는 종료 상태를 위한 TERMINAL 모달도 추가했습니다.
</p>

<ul>
  <li><code>EXPIRED</code> → 수락 시간 만료 안내</li>
  <li><code>CANCELLED</code> → 다른 참가자 거절 또는 서버 취소 안내</li>
</ul>

<p>
현재 백엔드 정책상 종료 상태가 자동으로 바로 IDLE로 정리되지 않을 수 있으므로,
프론트는 종료 상태를 한 번 안내한 뒤
로컬 UI를 초기화하는 방식으로 대응합니다.
</p>

<p>
이때도 프론트가 종료 사유를 임의 생성하지 않고,
백엔드가 준 <code>message</code>와 참가자 상태를 그대로 보여주도록 했습니다.
</p>

<hr />

<h3>11) 홈 모달을 단계형 UI로 확장</h3>
<p>
기존의 <code>queue-modal.tsx</code>는 단순 큐 대기 모달에 가까웠지만,
이번 PR에서는 하나의 모달 컴포넌트 안에서 아래 네 상태를 모두 처리하도록 확장했습니다.
</p>

<ul>
  <li><code>SEARCHING</code></li>
  <li><code>READY_CHECK</code></li>
  <li><code>ROOM_READY</code></li>
  <li><code>TERMINAL</code></li>
</ul>

<p>
이를 통해 기존 홈 UI 톤은 유지하면서도,
ready-check 도입에 필요한 상태별 인터랙션을 한 곳에서 관리할 수 있게 했습니다.
</p>

<hr />

<h3>12) 기존 홈 UI 톤 유지</h3>
<p>
이번 작업은 로직 교체가 중심이기 때문에,
홈 레이아웃과 한국어 톤은 최대한 기존 흐름을 유지했습니다.
</p>

<ul>
  <li>상단 Hero 유지</li>
  <li>메트릭 카드 유지</li>
  <li>서비스 메뉴 / 매칭 설정 / 개인 통계 요약 패널 유지</li>
  <li>카테고리, 난이도 선택 UI 유지</li>
</ul>

<p>
즉 화면을 새로 갈아엎지 않고,
기존 메인 홈 위에 v2 ready-check 상태 머신을 얹는 방향으로 구현했습니다.
</p>

<hr />

<h3>13) 변경 파일</h3>
<ul>
  <li><code>src/shared/api/contracts.ts</code></li>
  <li><code>src/app/api/queue/join/route.ts</code></li>
  <li><code>src/app/api/queue/me/route.ts</code></li>
  <li><code>src/app/api/queue/cancel/route.ts</code></li>
  <li><code>src/app/api/matches/me/route.ts</code></li>
  <li><code>src/app/api/matches/[matchId]/accept/route.ts</code></li>
  <li><code>src/app/api/matches/[matchId]/decline/route.ts</code></li>
  <li><code>src/features/home/data.ts</code></li>
  <li><code>src/features/home/queue-modal.tsx</code></li>
  <li><code>src/features/home/screen.tsx</code></li>
  <li><code>package-lock.json</code></li>
</ul>

<hr />

<h3>테스트 / 확인 포인트</h3>
<ol>
  <li>로그인 상태에서 메인 홈 진입 시 세션, queue 상태, match 상태를 복원하는지 확인</li>
  <li><code>POST /api/queue/join</code> 성공 후 SEARCHING 모달과 <code>waitingCount / requiredCount</code>가 정상 표시되는지 확인</li>
  <li><code>queue/me.inQueue === false</code>가 되면 <code>matches/me</code> polling으로 전환되는지 확인</li>
  <li><code>ACCEPT_PENDING</code> 상태에서 참가자별 decision, acceptedCount, deadline 카운트다운이 표시되는지 확인</li>
  <li>accept / decline 버튼이 각각 올바른 endpoint를 호출하는지 확인</li>
  <li><code>ROOM_READY + roomId</code>가 오면 기존 battle room join API 호출 후 배틀룸으로 이동하는지 확인</li>
  <li><code>EXPIRED</code>, <code>CANCELLED</code> 상태에서 종료 모달과 message가 정상 표시되는지 확인</li>
  <li>SEARCHING 단계에서만 cancel 버튼이 보이는지 확인</li>
</ol>

<p>
정적 검사는 <code>npm run lint</code> 기준으로 확인했습니다.
다만 기존 프로젝트에 있던 <code>battle-room/screen.tsx</code>의 React Hook warning 1개는 이번 작업과 무관하게 그대로 남아 있습니다.
</p>
