### PR TITLE
Feat/18 배틀룸 관전 기능 구현

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -525,6 +525,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       if (stompClientRef.current?.connected && room?.status === "PLAYING") {
                         stompClientRef.current.publish({
                           destination: `/app/room/${roomId}/code`,
+                          headers: { "content-type": "application/json" },
                           body: JSON.stringify({ code: newCode }),
                         });
                       }

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -83,6 +83,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [source, setSource] = useState<"api" | "fallback">("api");
   const hasAttemptedJoinRef = useRef(false);
+  const stompClientRef = useRef<Client | null>(null);
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
@@ -241,7 +242,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     });
 
     client.activate();
-    return () => { void client.deactivate(); };
+    stompClientRef.current = client;
+    return () => {
+      stompClientRef.current = null;
+      void client.deactivate();
+    };
   }, [roomId, session.authenticated]);
 
   function handleSubmit() {
@@ -515,7 +520,15 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   <BattleCodeEditor
                     language={language}
                     value={code}
-                    onChange={setCode}
+                    onChange={(newCode) => {
+                      setCode(newCode);
+                      if (stompClientRef.current?.connected && room?.status === "PLAYING") {
+                        stompClientRef.current.publish({
+                          destination: `/app/room/${roomId}/code`,
+                          body: JSON.stringify({ code: newCode }),
+                        });
+                      }
+                    }}
                   />
                 </div>
 

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
+  CodeUpdateWsMessage,
   ProblemDetailResponse,
   RoomResponse,
+  SessionResponse,
 } from "@/shared/api/contracts";
 import {
-  ApiCallout,
   CodeWindow,
-  EventTimeline,
   MetricCard,
   MetricGrid,
   PageHero,
@@ -21,16 +23,42 @@ import {
 
 import { getSpectateRoom } from "./data";
 
+async function readSession() {
+  const response = await fetch("/api/auth/session", { cache: "no-store" });
+
+  if (!response.ok) {
+    return { authenticated: false, member: null } satisfies SessionResponse;
+  }
+
+  return (await response.json()) as SessionResponse;
+}
+
 export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
+  const [session, setSession] = useState<SessionResponse>({
+    authenticated: false,
+    member: null,
+  });
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
-  const [message, setMessage] = useState("관전 상세 정보를 불러오는 중입니다.");
+  const [message, setMessage] = useState("관전 정보를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
-  const [source, setSource] = useState<"api" | "fallback">("api");
   const [requiresLogin, setRequiresLogin] = useState(false);
+  const [codeByUserId, setCodeByUserId] = useState<Record<number, string>>({});
+  const [lastUpdatedByUserId, setLastUpdatedByUserId] = useState<Record<number, string>>({});
+  const stompClientRef = useRef<Client | null>(null);
 
+  // 세션 및 방 정보 로드
   useEffect(() => {
     void (async () => {
+      const nextSession = await readSession();
+      setSession(nextSession);
+
+      if (!nextSession.authenticated) {
+        setRequiresLogin(true);
+        setMessage("관전 상세는 로그인 후 접근할 수 있습니다.");
+        return;
+      }
+
       const response = await fetch(`/api/battle/rooms/${roomId}`, {
         cache: "no-store",
       });
@@ -45,7 +73,6 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         const fallback = getSpectateRoom(roomId);
 
         if (fallback) {
-          setSource("fallback");
           setMessage("백엔드 연결 실패로 샘플 관전 데이터를 표시합니다.");
           return;
         }
@@ -57,7 +84,6 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
 
       const nextRoom = (await response.json()) as RoomResponse;
       setRoom(nextRoom);
-      setSource("api");
 
       const problemResponse = await fetch(`/api/problems/${nextRoom.problemId}`, {
         cache: "no-store",
@@ -67,9 +93,52 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         setProblem((await problemResponse.json()) as ProblemDetailResponse);
       }
 
-      setMessage("실제 방 정보 기반 관전 상세 화면입니다.");
+      setMessage("실시간 관전 중입니다.");
     })();
   }, [roomId]);
+
+  // WebSocket: /topic/room/{roomId}/spectate 구독
+  useEffect(() => {
+    if (!session.authenticated) return;
+
+    const client = new Client({
+      webSocketFactory: () => new SockJS("/ws"),
+      reconnectDelay: 3000,
+      onConnect: () => {
+        client.subscribe(`/topic/room/${roomId}/spectate`, (frame) => {
+          let payload: unknown;
+          try {
+            payload = JSON.parse(frame.body) as unknown;
+          } catch {
+            console.warn("[Spectate WS] 메시지 파싱 실패:", frame.body);
+            return;
+          }
+
+          if (
+            typeof payload !== "object" ||
+            payload === null ||
+            !("type" in payload)
+          ) {
+            return;
+          }
+
+          if ((payload as { type: unknown }).type === "CODE_UPDATE") {
+            const msg = payload as CodeUpdateWsMessage;
+            const now = new Date().toLocaleTimeString("ko-KR");
+            setCodeByUserId((prev) => ({ ...prev, [msg.userId]: msg.code }));
+            setLastUpdatedByUserId((prev) => ({ ...prev, [msg.userId]: now }));
+          }
+        });
+      },
+    });
+
+    client.activate();
+    stompClientRef.current = client;
+
+    return () => {
+      void client.deactivate();
+    };
+  }, [roomId, session.authenticated]);
 
   if (requiresLogin) {
     return (
@@ -102,28 +171,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
 
   const fallback = getSpectateRoom(roomId);
   const participants = room?.participants ?? fallback?.participants ?? [];
-  const codePanels =
-    fallback?.codePanels ??
-    participants.map((participant) => ({
-      userId: participant.userId,
-      nickname: participant.nickname,
-      lastUpdated: "실시간 코드 스트림 준비 전",
-      code: `// ${participant.nickname}의 관전자용 코드 스트림은\n// /topic/room/${roomId}/spectate 연결 후 표시됩니다.`,
-    }));
-  const liveEvents =
-    fallback?.liveEvents ??
-    [
-      {
-        timestamp: "실시간",
-        type: "CODE_UPDATE",
-        headline: "관전자용 코드 스트림 준비 전",
-        detail: "현재는 방 정보와 문제 정보만 실제 API로 읽고, 코드 스트림은 placeholder로 둡니다.",
-      },
-    ];
-  const problemTitle =
-    problem?.title ?? fallback?.problemTitle ?? `roomId ${roomId} 관전 상세`;
-  const topicPath = `/topic/room/${roomId}`;
-  const codeTopicPath = `/topic/room/${roomId}/spectate`;
+  const problemTitle = problem?.title ?? fallback?.problemTitle ?? `Room ${roomId}`;
 
   if (!fallback && !room) {
     return (
@@ -131,7 +179,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         <PageHero
           eyebrow="Spectate Room"
           title="관전 상세를 열지 못했습니다."
-          description="현재 roomId에 해당하는 관전 대상을 찾지 못했습니다."
+          description="현재 roomId에 해당하는 관전 대상을 찾을 수 없습니다."
           actions={<StatusPill tone="danger">Load failed</StatusPill>}
         />
         <Panel title="오류" description="응답 메시지">
@@ -145,12 +193,12 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
     <div className="space-y-8">
       <PageHero
         eyebrow="Spectate Room"
-        title={`관전 Room ${roomId}`}
-        description="방 상태와 문제 정보는 실제 API를 우선하고, 관전자용 코드 패널은 전용 스트림이 붙기 전까지 샘플 또는 placeholder로 유지합니다."
+        title={`관전 Room ${roomId} — ${problemTitle}`}
+        description="참여자들의 코드가 실시간으로 업데이트됩니다."
         actions={
           <>
-            <StatusPill tone="success">{problemTitle}</StatusPill>
-            <StatusPill>{source === "api" ? "API" : "Fallback"}</StatusPill>
+            <StatusPill tone="success">LIVE</StatusPill>
+            <StatusPill>{participants.length}명 참여 중</StatusPill>
           </>
         }
       />
@@ -160,56 +208,42 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
       </div>
 
       <MetricGrid>
+        <MetricCard label="Room ID" value={roomId} />
+        <MetricCard label="Problem" value={problemTitle} />
         <MetricCard label="Participants" value={participants.length} />
-        <MetricCard label="Event Count" value={liveEvents.length} />
-        <MetricCard label="Topic" value={topicPath} />
-        <MetricCard label="Code Topic" value={codeTopicPath} />
+        <MetricCard
+          label="수신된 코드 수"
+          value={Object.keys(codeByUserId).length}
+        />
       </MetricGrid>
 
-      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
-        <Panel
-          title="참가자 코드 패널"
-          description="관전자용 코드 업데이트 채널이 붙기 전까지는 샘플 또는 placeholder를 사용합니다."
-        >
-          <div className="grid gap-4 xl:grid-cols-2">
-            {codePanels.map((panel) => (
-              <CodeWindow
-                key={panel.userId}
-                title={`${panel.nickname} / ${panel.lastUpdated}`}
-                code={panel.code}
-                footer={<span>userId {panel.userId}</span>}
-              />
-            ))}
-          </div>
-        </Panel>
+      <div className="grid gap-4 xl:grid-cols-2">
+        {participants.map((participant) => {
+          const code =
+            codeByUserId[participant.userId] ??
+            `// ${participant.nickname}의 코드 업데이트를 기다리는 중...`;
+          const lastUpdated =
+            lastUpdatedByUserId[participant.userId] ?? "대기 중";
 
-        <Panel
-          title="실시간 이벤트 로그"
-          description="배틀 상태 이벤트와 코드 업데이트 이벤트를 한눈에 보여줍니다."
-        >
-          <EventTimeline events={liveEvents} />
-        </Panel>
+          return (
+            <CodeWindow
+              key={participant.userId}
+              title={`${participant.nickname}  ·  ${lastUpdated}`}
+              code={code}
+              footer={<span>userId {participant.userId}</span>}
+            />
+          );
+        })}
       </div>
 
-      <Panel title="소켓 경로와 의미" description="프론트 구현 시 subscribe 또는 send 해야 하는 경로">
-        <div className="grid gap-4 lg:grid-cols-3">
-          <ApiCallout
-            method="SUBSCRIBE"
-            path={topicPath}
-            note="배틀 시작, 제출, 참가자 완료, 배틀 종료 이벤트 수신"
-          />
-          <ApiCallout
-            method="SUBSCRIBE"
-            path={codeTopicPath}
-            note="관전자 전용 코드 업데이트 스트림 수신"
-          />
-          <ApiCallout
-            method="SEND"
-            path={`/app/room/${roomId}/code`}
-            note="참여자가 코드 변경을 보낼 때 사용하는 경로"
-          />
-        </div>
-      </Panel>
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href="/spectate"
+          className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+        >
+          관전 목록으로 돌아가기
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -160,6 +160,12 @@ export interface SubmissionWsMessage {
   totalCount: number;
 }
 
+export interface CodeUpdateWsMessage {
+  type: "CODE_UPDATE";
+  userId: number;
+  code: string;
+}
+
 export interface ParticipantDoneWsMessage {
   type: "PARTICIPANT_DONE";
   userId: number;

--- a/src/shared/auth/session.ts
+++ b/src/shared/auth/session.ts
@@ -1,6 +1,6 @@
 import type { SessionMember } from "@/shared/api/contracts";
 
-export const FRONTEND_ACCESS_TOKEN_COOKIE = "algo_access_token";
+export const FRONTEND_ACCESS_TOKEN_COOKIE = "accessToken";
 export const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 
 interface JwtPayload {


### PR DESCRIPTION
## 작업 개요

- 이 PR에서 무엇을 왜 바꾸는지 간단히 작성해주세요.

## 영향 범위

## 작업 내용

관전 페이지 구현 및 배틀룸 실시간 코드 동기화 연동

## 변경 사항

- 관전페이지 스켈레톤 구현
- 관전 페이지에서 /topic/room/{roomId}/spectate 구독해 CODE_UPDATE 수신                                                            
- 참여자별 코드를 2×2 그리드로 실시간 표시                                                                                         
- 배틀룸 Monaco 에디터 변경 시 /app/room/{roomId}/code 로 STOMP publish                                                            
- WebSocket 핸드셰이크 쿠키 이름 accessToken 으로 통일   

## 테스트 및 확인


## 관련 이슈

- close #18 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
