### PR TITLE
[refactor] 메인 레이아웃 및 UI 수정 

### DIFF
--- a/src/app/api/me/battle-results/route.ts
+++ b/src/app/api/me/battle-results/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/app/api/members/me/battle-results/route";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,9 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f6f1ff;
-  --foreground: #1f1533;
-  --panel: #ffffff;
+  --background: #0f1115;
+  --foreground: #e5e7eb;
+  --panel: #171a21;
 }
 
 @theme inline {
@@ -35,6 +35,6 @@ pre {
 }
 
 ::selection {
-  background: #c4b5fd;
-  color: #1f1533;
+  background: #a78bfa;
+  color: #09090b;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
   --background: #0f1115;
   --foreground: #e5e7eb;
   --panel: #171a21;
+  --app-header-h: 56px;
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f4f4f5;
-  --foreground: #18181b;
+  --background: #f6f1ff;
+  --foreground: #1f1533;
   --panel: #ffffff;
 }
 
@@ -35,6 +35,6 @@ pre {
 }
 
 ::selection {
-  background: #18181b;
-  color: #fafafa;
+  background: #c4b5fd;
+  color: #1f1533;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,8 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "Algo Battle Front",
-    template: "%s | Algo Battle Front",
+    default: "BRACKET {}",
+    template: "%s | BRACKET {}",
   },
   description:
     "실제 백엔드 API와 화면 구조를 맞추는 Algo Battle 프론트엔드.",
@@ -43,18 +43,18 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full">
-        <div className="min-h-screen bg-[radial-gradient(circle_at_15%_0%,rgba(196,181,253,0.55),transparent_38%),radial-gradient(circle_at_85%_100%,rgba(167,139,250,0.32),transparent_42%),linear-gradient(180deg,#f8f4ff_0%,#f2ebff_52%,#ede4ff_100%)] text-zinc-950">
-          <header className="sticky top-0 z-20 border-b border-violet-300/60 bg-white/82 text-zinc-900 shadow-[0_10px_22px_-18px_rgba(76,29,149,0.55)] backdrop-blur">
+        <div className="min-h-screen bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
+          <header className="sticky top-0 z-20 border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
             <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
-              <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-900">
-                Algo Battle Front
+              <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
+                BRACKET {"{}"}
               </Link>
               <nav className="flex flex-wrap items-center justify-end gap-1.5">
                 {navigation.map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}
-                    className="rounded-full border border-violet-300/80 bg-white px-2.5 py-1 text-xs text-violet-900 transition hover:border-violet-500 hover:bg-violet-100"
+                    className="rounded-full border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-300 transition hover:border-violet-300/70 hover:bg-violet-500/20 hover:text-zinc-100"
                   >
                     {item.label}
                   </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,8 +44,8 @@ export default function RootLayout({
     >
       <body className="min-h-full">
         <div className="min-h-screen bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
-          <header className="sticky top-0 z-20 border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
-            <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
+          <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
+            <div className="mx-auto flex h-full w-full max-w-7xl items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
                 BRACKET {"{}"}
               </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,10 +43,10 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full">
-        <div className="min-h-screen bg-zinc-100 text-zinc-950">
-          <header className="sticky top-0 z-20 border-b border-zinc-300 bg-white/95 backdrop-blur">
-            <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-3 px-4 py-2 sm:px-6 lg:px-8">
-              <Link href="/" className="text-sm font-semibold tracking-tight">
+        <div className="min-h-screen bg-[radial-gradient(circle_at_15%_0%,rgba(196,181,253,0.55),transparent_38%),radial-gradient(circle_at_85%_100%,rgba(167,139,250,0.32),transparent_42%),linear-gradient(180deg,#f8f4ff_0%,#f2ebff_52%,#ede4ff_100%)] text-zinc-950">
+          <header className="sticky top-0 z-20 border-b border-violet-300/60 bg-white/82 text-zinc-900 shadow-[0_10px_22px_-18px_rgba(76,29,149,0.55)] backdrop-blur">
+            <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
+              <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-900">
                 Algo Battle Front
               </Link>
               <nav className="flex flex-wrap items-center justify-end gap-1.5">
@@ -54,7 +54,7 @@ export default function RootLayout({
                   <Link
                     key={item.href}
                     href={item.href}
-                    className="rounded-full border border-zinc-300 bg-zinc-50 px-2.5 py-1 text-xs text-zinc-700 transition hover:border-zinc-500 hover:text-zinc-950"
+                    className="rounded-full border border-violet-300/80 bg-white px-2.5 py-1 text-xs text-violet-900 transition hover:border-violet-500 hover:bg-violet-100"
                   >
                     {item.label}
                   </Link>
@@ -62,7 +62,7 @@ export default function RootLayout({
               </nav>
             </div>
           </header>
-          <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-5 sm:px-6 lg:px-8">
+          <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-4 sm:px-6 lg:px-8">
             {children}
           </main>
         </div>

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -42,10 +42,10 @@ function SectionTitle({
 }) {
   return (
     <div>
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
         {label}
       </p>
-      <p className="mt-2 font-medium text-zinc-950">{value}</p>
+      <p className="mt-2 font-medium text-zinc-100">{value}</p>
     </div>
   );
 }
@@ -92,7 +92,7 @@ export default function QueueModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 p-4">
-      <div className="w-full max-w-2xl rounded-[2rem] border border-zinc-300 bg-white p-6 shadow-2xl">
+      <div className="w-full max-w-2xl rounded-2xl border border-zinc-700 bg-[#1f222a] p-6 text-zinc-200 shadow-2xl">
         <div className="flex flex-wrap items-center gap-2">
           <StatusPill tone={modalTone}>{modalStatus}</StatusPill>
           <StatusPill>{categoryLabel}</StatusPill>
@@ -110,15 +110,15 @@ export default function QueueModal({
         {mode === "SEARCHING" ? (
           <>
             <div className="mt-6 flex items-center gap-4">
-              <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-300 border-t-zinc-950 bg-zinc-50 text-transparent">
+              <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-700 border-t-sky-400 bg-[#1a1d24] text-transparent">
                 .
               </div>
 
               <div>
-                <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+                <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
                   상대를 찾고 있습니다
                 </h2>
-                <p className="mt-2 text-sm leading-7 text-zinc-600">
+                <p className="mt-2 text-sm leading-7 text-zinc-400">
                   ready-check 전까지는 대기열 인원만 표시합니다.
                   네 명이 채워져서 큐에서 빠지면 자동으로 수락 화면으로 전환됩니다.
                 </p>
@@ -128,14 +128,14 @@ export default function QueueModal({
             <div
               className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
                 error
-                  ? "border-rose-300 bg-rose-50 text-rose-900"
-                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
               }`}
             >
               {error ?? feedback}
             </div>
 
-            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
               <SectionTitle label="경과 시간" value={formatClock(queueElapsedSeconds)} />
               <SectionTitle
                 label="현재 인원"
@@ -149,11 +149,11 @@ export default function QueueModal({
                 type="button"
                 onClick={onCancel}
                 disabled={isPending}
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                className="rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
               >
                 매칭 취소
               </button>
-              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
                 cancel 버튼은 SEARCHING 단계에서만 노출됩니다.
               </div>
             </div>
@@ -163,10 +163,10 @@ export default function QueueModal({
         {mode === "READY_CHECK" ? (
           <>
             <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
                 매칭이 성사되었습니다
               </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-600">
+              <p className="mt-2 text-sm leading-7 text-zinc-400">
                 수락 여부를 확인하는 단계입니다. 마지막 수락이 완료되면 방이 만들어지고
                 자동으로 입장 절차를 시작합니다.
               </p>
@@ -175,14 +175,14 @@ export default function QueueModal({
             <div
               className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
                 error
-                  ? "border-rose-300 bg-rose-50 text-rose-900"
-                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
               }`}
             >
               {error ?? feedback}
             </div>
 
-            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
               <SectionTitle
                 label="수락 현황"
                 value={
@@ -198,9 +198,9 @@ export default function QueueModal({
               />
             </div>
 
-            <div className="mt-6 rounded-2xl border border-zinc-300 bg-white p-4">
+            <div className="mt-6 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4">
               <div className="flex items-center justify-between gap-3">
-                <p className="text-sm font-medium text-zinc-950">참가자 상태</p>
+                <p className="text-sm font-medium text-zinc-100">참가자 상태</p>
                 {readyCheck ? (
                   <p className="text-xs text-zinc-500">matchId {readyCheck.matchId}</p>
                 ) : null}
@@ -211,10 +211,10 @@ export default function QueueModal({
                   readyCheck.participants.map((participant) => (
                     <div
                       key={`${participant.userId}-${participant.nickname}`}
-                      className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3"
+                      className="flex items-center justify-between rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3"
                     >
                       <div>
-                        <p className="font-medium text-zinc-950">
+                        <p className="font-medium text-zinc-100">
                           {participant.nickname}
                           {participant.userId === currentUserId ? " (나)" : ""}
                         </p>
@@ -228,7 +228,7 @@ export default function QueueModal({
                     </div>
                   ))
                 ) : (
-                  <div className="rounded-2xl border border-dashed border-zinc-300 px-4 py-6 text-center text-sm text-zinc-500">
+                  <div className="rounded-2xl border border-dashed border-zinc-700 px-4 py-6 text-center text-sm text-zinc-500">
                     참가자 상태를 불러오는 중입니다.
                   </div>
                 )}
@@ -240,7 +240,7 @@ export default function QueueModal({
                 type="button"
                 onClick={onDecline}
                 disabled={isPending || !readyCheck}
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                className="rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
               >
                 매칭 거절
               </button>
@@ -248,7 +248,7 @@ export default function QueueModal({
                 type="button"
                 onClick={onAccept}
                 disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
               >
                 {readyCheck?.acceptedByMe ? "이미 수락했습니다" : "매칭 수락"}
               </button>
@@ -259,10 +259,10 @@ export default function QueueModal({
         {mode === "ROOM_READY" ? (
           <>
             <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
                 방이 준비되었습니다
               </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-600">
+              <p className="mt-2 text-sm leading-7 text-zinc-400">
                 전원이 수락해서 방 입장 준비가 끝났습니다. 기존 battle room join API로
                 연결하는 중입니다.
               </p>
@@ -271,14 +271,14 @@ export default function QueueModal({
             <div
               className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
                 error
-                  ? "border-rose-300 bg-rose-50 text-rose-900"
-                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
+                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
               }`}
             >
               {error ?? feedback}
             </div>
 
-            <div className="mt-6 grid gap-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-700 md:grid-cols-3">
+            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
               <SectionTitle
                 label="roomId"
                 value={roomId !== null ? String(roomId) : "확인 중"}
@@ -299,11 +299,11 @@ export default function QueueModal({
                 type="button"
                 onClick={onRetryRoomEntry}
                 disabled={isPending}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
               >
                 방 입장 다시 시도
               </button>
-              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
                 join 성공 시 battle room 화면으로 이동합니다.
               </div>
             </div>
@@ -313,29 +313,29 @@ export default function QueueModal({
         {mode === "TERMINAL" ? (
           <>
             <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-950">
+              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
                 매칭이 종료되었습니다
               </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-600">
+              <p className="mt-2 text-sm leading-7 text-zinc-400">
                 서버 상태는 종료 상태를 유지할 수 있으므로, 현재 화면에서는 한 번 안내한 뒤
                 로컬 UI를 초기화합니다.
               </p>
             </div>
 
-            <div className="mt-6 rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+            <div className="mt-6 rounded-2xl border border-rose-400/60 bg-rose-900/20 px-4 py-3 text-sm text-rose-200">
               {terminalMessage ?? error ?? feedback}
             </div>
 
             {readyCheck?.participants?.length ? (
-              <div className="mt-6 rounded-2xl border border-zinc-300 bg-white p-4">
-                <p className="text-sm font-medium text-zinc-950">종료 시점 참가자 상태</p>
+              <div className="mt-6 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4">
+                <p className="text-sm font-medium text-zinc-100">종료 시점 참가자 상태</p>
                 <div className="mt-4 space-y-3">
                   {readyCheck.participants.map((participant) => (
                     <div
                       key={`${participant.userId}-${participant.nickname}`}
-                      className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3"
+                      className="flex items-center justify-between rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3"
                     >
-                      <p className="font-medium text-zinc-950">
+                      <p className="font-medium text-zinc-100">
                         {participant.nickname}
                         {participant.userId === currentUserId ? " (나)" : ""}
                       </p>
@@ -353,11 +353,11 @@ export default function QueueModal({
                 type="button"
                 onClick={onCloseTerminal}
                 disabled={isPending}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
               >
                 확인하고 닫기
               </button>
-              <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm leading-6 text-zinc-600">
+              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
                 닫은 뒤에는 메인에서 다시 매칭을 시작할 수 있습니다.
               </div>
             </div>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -738,7 +738,7 @@ export default function HomeScreen() {
         />
       </MetricGrid>
 
-      <div className="grid gap-6 xl:grid-cols-[0.85fr_1.3fr_0.85fr]">
+      <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr] xl:grid-cols-[0.85fr_1.3fr_0.85fr]">
         <Panel
           title="서비스 메뉴"
           description="주요 페이지별 작업 동선을 한곳에서 바로 열 수 있도록 진입점을 둡니다."
@@ -859,6 +859,7 @@ export default function HomeScreen() {
         <Panel
           title="개인 통계 요약"
           description="메인에서는 보조 정보만 보여주고, 실제 전적과 점수 API는 마이페이지에서 더 자세히 확인합니다."
+          className="lg:col-span-2 xl:col-span-1"
         >
           <div className="space-y-3 text-sm">
             <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
@@ -884,7 +885,7 @@ export default function HomeScreen() {
         title="현재 연결 사인"
         description="메인과 인접한 흐름에서 이번 단계에 실제로 붙여 둔 API 경로들입니다."
       >
-        <div className="grid gap-4 lg:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           <ApiCallout
             method="POST"
             path="/api/queue/join"

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -192,6 +192,8 @@ export default function HomeScreen() {
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
   const [resultsPreviewMessage, setResultsPreviewMessage] = useState("로그인 후 최근 전적을 확인할 수 있습니다.");
   const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
+  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
+  const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
 
   const joiningRoomIdRef = useRef<number | null>(null);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
@@ -752,6 +754,13 @@ export default function HomeScreen() {
   const editorContentStyle = {
     fontSize: `${editorFontSize}px`,
   };
+  const layoutColumnsClass = isQuickMenuOpen
+    ? isProfilePanelOpen
+      ? "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_38px]"
+    : isProfilePanelOpen
+      ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_250px] xl:grid-cols-[48px_minmax(0,1fr)_290px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_38px]";
   const ideProjectTreeItems: Array<{
     key: string;
     label: string;
@@ -793,7 +802,7 @@ export default function HomeScreen() {
     { key: "mypage", label: "마이페이지", depth: 2, icon: "class", href: "/mypage" },
   ];
   const ideRailTopItems = [
-    { icon: "project", active: true, title: "Project" },
+    { icon: "project", title: "Project" },
     { icon: "sliders", title: "Services" },
     { icon: "branch", title: "Git" },
     { icon: "layout", title: "Layout" },
@@ -810,7 +819,7 @@ export default function HomeScreen() {
   const ideDbRailTopItems = [
     { icon: "notifications", title: "알림" },
     { icon: "search", title: "검색" },
-    { icon: "database", title: "데이터베이스", active: true },
+    { icon: "database", title: "데이터베이스" },
     { icon: "gamepad", title: "게임" },
     { icon: "blocks", title: "서비스" },
     { icon: "docs", title: "문서" },
@@ -1047,19 +1056,24 @@ export default function HomeScreen() {
   return (
     <div className="-my-4 ml-[calc(50%-50dvw)] w-[100dvw] max-w-none min-h-[calc(100dvh-var(--app-header-h))] xl:h-[calc(100dvh-var(--app-header-h))] xl:overflow-hidden">
       <section className="overflow-hidden bg-[#1e1f22] xl:h-full xl:min-h-0">
-        <div className="grid h-full grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]">
+        <div className={`grid h-full ${layoutColumnsClass}`}>
           <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
-            <div className="grid h-full grid-cols-[48px_minmax(0,1fr)]">
+            <div className={`grid h-full ${isQuickMenuOpen ? "grid-cols-[48px_minmax(0,1fr)]" : "grid-cols-[48px]"}`}>
               <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
                 <div className="flex flex-col items-center gap-2">
                   {ideRailTopItems.map((item) => (
                     <button
                       key={item.title}
                       type="button"
+                      onClick={() => {
+                        if (item.icon === "project") {
+                          setIsQuickMenuOpen((current) => !current);
+                        }
+                      }}
                       title={item.title}
                       aria-label={item.title}
                       className={`h-8 w-8 rounded-md border text-[10px] font-semibold tracking-wide transition ${
-                        item.active
+                        item.icon === "project" && isQuickMenuOpen
                           ? "border-zinc-500 bg-zinc-700/70 text-zinc-100"
                           : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-300"
                       }`}
@@ -1083,7 +1097,7 @@ export default function HomeScreen() {
                 </div>
               </div>
 
-              <div className="flex min-h-0 flex-col">
+              <div className={`min-h-0 flex-col ${isQuickMenuOpen ? "flex" : "hidden"}`}>
                 <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
                   <p className="text-sm font-semibold text-zinc-200">퀵 메뉴</p>
                   <span className="text-xs text-zinc-500">▼</span>
@@ -1203,7 +1217,8 @@ export default function HomeScreen() {
                       # queue config
                     </div>
                     <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                      # 카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
+                      <span className="font-semibold text-[#ffcc66]"># TODO:</span>
+                      <span> 카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.</span>
                     </div>
                     <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
@@ -1305,8 +1320,8 @@ export default function HomeScreen() {
           </main>
 
           <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
-            <div className="grid h-full grid-cols-[minmax(0,1fr)_38px]">
-              <div className="min-h-0">
+            <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
+              <div className={`min-h-0 ${isProfilePanelOpen ? "block" : "hidden"}`}>
                 <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
                   <p className="text-sm font-semibold text-zinc-200">프로필</p>
                 </div>
@@ -1416,10 +1431,15 @@ export default function HomeScreen() {
                     <button
                       key={item.title}
                       type="button"
+                      onClick={() => {
+                        if (item.icon === "database") {
+                          setIsProfilePanelOpen((current) => !current);
+                        }
+                      }}
                       title={item.title}
                       aria-label={item.title}
                       className={`h-8 w-8 rounded-md border transition ${
-                        item.active
+                        item.icon === "database" && isProfilePanelOpen
                           ? "border-[#2f77ff] bg-[#2f77ff] text-white shadow-[0_0_0_1px_rgba(80,130,255,0.35)]"
                           : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-200"
                       }`}

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -184,6 +184,7 @@ export default function HomeScreen() {
   const [feedback, setFeedback] = useState(DEFAULT_FEEDBACK);
   const [error, setError] = useState<string | null>(null);
   const [terminalMessage, setTerminalMessage] = useState<string | null>(null);
+  const [queueMemo, setQueueMemo] = useState(DEFAULT_FEEDBACK);
   const [modalMode, setModalMode] = useState<ModalMode>(null);
   const [pollStage, setPollStage] = useState<PollStage>("IDLE");
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
@@ -193,6 +194,8 @@ export default function HomeScreen() {
   const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
 
   const joiningRoomIdRef = useRef<number | null>(null);
+  const editorPaneRef = useRef<HTMLDivElement | null>(null);
+  const [editorLineCount, setEditorLineCount] = useState(28);
 
   const resetFlow = useCallback((nextFeedback = DEFAULT_FEEDBACK) => {
     setQueueState(defaultQueueState);
@@ -290,6 +293,35 @@ export default function HomeScreen() {
 
     return () => {
       window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    const editorPane = editorPaneRef.current;
+
+    if (!editorPane) {
+      return;
+    }
+
+    const updateEditorLineCount = () => {
+      const lineHeight = 32;
+      const verticalPadding = 32;
+      const usableHeight = Math.max(editorPane.clientHeight - verticalPadding, lineHeight);
+      const nextLineCount = Math.max(18, Math.floor(usableHeight / lineHeight));
+
+      setEditorLineCount((current) => (current === nextLineCount ? current : nextLineCount));
+    };
+
+    updateEditorLineCount();
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateEditorLineCount();
+    });
+
+    resizeObserver.observe(editorPane);
+
+    return () => {
+      resizeObserver.disconnect();
     };
   }, []);
 
@@ -677,6 +709,7 @@ export default function HomeScreen() {
   const activeDifficultyLabel = queueState.difficulty ?? difficulty;
   const queueElapsedSeconds = getElapsedSeconds(queueStartedAt, now);
   const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
+  const canStartMatch = !(isBusy || (modalMode !== null && modalMode !== "TERMINAL"));
   const roomId = matchState.room?.roomId ?? null;
   const previewPlayedCount = recentResults.length;
   const previewSolvedCount = recentResults.filter((item) => item.solved).length;
@@ -685,7 +718,7 @@ export default function HomeScreen() {
   const previewScoreDelta = recentResults.reduce((acc, item) => acc + item.scoreDelta, 0);
   const previewScoreDeltaLabel =
     previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
-  const editorLineNumbers = Array.from({ length: 28 }, (_, index) => 41 + index);
+  const editorLineNumbers = Array.from({ length: editorLineCount }, (_, index) => 41 + index);
   const ideProjectTreeItems: Array<{
     key: string;
     label: string;
@@ -979,9 +1012,9 @@ export default function HomeScreen() {
   };
 
   return (
-    <div className="md:h-[calc(100dvh-7.5rem)] md:overflow-hidden">
-      <section className="overflow-hidden rounded-xl border border-zinc-700/80 bg-[#1e1f22] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] md:h-full md:min-h-0">
-        <div className="grid h-full grid-cols-1 md:grid-cols-[250px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_260px] xl:grid-cols-[280px_minmax(0,1fr)_300px]">
+    <div className="xl:h-[calc(100dvh-7.5rem)] xl:overflow-hidden">
+      <section className="overflow-hidden rounded-xl border border-zinc-700/80 bg-[#1e1f22] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] xl:h-full xl:min-h-0">
+        <div className="grid h-full grid-cols-1 md:grid-cols-[250px_minmax(0,1fr)] lg:grid-cols-[210px_minmax(0,1fr)_230px] xl:grid-cols-[250px_minmax(0,1fr)_280px] 2xl:grid-cols-[280px_minmax(0,1fr)_320px]">
           <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
             <div className="grid h-full grid-cols-[48px_minmax(0,1fr)]">
               <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
@@ -1072,20 +1105,25 @@ export default function HomeScreen() {
             </div>
           </aside>
 
-          <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] md:border-b-0 lg:border-r">
+          <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
             <div className="flex h-full min-h-0 flex-col">
               <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
                 <div className="flex h-full items-end gap-0.5 pt-1">
                   <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-                    <span className="text-sky-400">●</span>
-                    <span>QueueDemo.java</span>
+                    <span className="inline-flex h-4 w-4 items-center justify-center text-[#7da2f7]">
+                      <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                        <path
+                          d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
+                          stroke="currentColor"
+                          strokeWidth="1.2"
+                        />
+                        <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+                        <circle cx="6.4" cy="10.8" r="0.7" fill="currentColor" />
+                      </svg>
+                    </span>
+                    <span>.env</span>
                     <span className="text-zinc-500">×</span>
                     <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
-                  </div>
-                  <div className="flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-500">
-                    <span className="text-sky-600">●</span>
-                    <span>MatchLevel.java</span>
-                    <span>×</span>
                   </div>
                 </div>
                 <button
@@ -1093,19 +1131,28 @@ export default function HomeScreen() {
                   onClick={() => {
                     void handleStartMatch();
                   }}
-                  disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
-                  className="rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-4 py-1.5 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
+                  disabled={!canStartMatch}
+                  className="inline-flex h-10 items-center gap-2 rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-3 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
+                  aria-label="매칭 시작"
                 >
-                  {modalMode === "SEARCHING"
-                    ? "매칭 진행 중"
-                    : busyAction === "start"
-                      ? "처리 중..."
-                      : "매칭 시작"}
+                  <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#7dd48c]">
+                    <path
+                      d="M8 2.3v3M5 3.4A4.9 4.9 0 1 0 11 3.4"
+                      stroke="currentColor"
+                      strokeWidth="1.3"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <span>매칭 시작</span>
+                  <span className="mx-0.5 h-4 w-px bg-white/35" />
+                  <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#74cc84]">
+                    <path d="m6 4 5 4-5 4V4Z" fill="currentColor" />
+                  </svg>
                 </button>
               </div>
 
-              <div className="flex-1 overflow-y-auto bg-[#1e1f22]">
-                <div className="grid grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono text-sm">
+              <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-[#1e1f22]">
+                <div className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono text-sm">
                   <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
                     {editorLineNumbers.map((line) => (
                       <div key={line} className="h-8 leading-8">
@@ -1114,24 +1161,18 @@ export default function HomeScreen() {
                     ))}
                   </div>
                   <div className="px-4 py-4 text-[#a9b7c6]">
-                    <div className="h-8 whitespace-nowrap leading-8">
-                      <span className="text-[#cc7832]">enum</span> MatchLevel {"{"} EASY, MEDIUM, HARD {"}"}
+                    <div className="h-8 whitespace-nowrap leading-8 text-[#6a717d]"># queue config</div>
+                    <div className="h-8 whitespace-nowrap leading-8 text-[#6a717d]">
+                      # category, level 값이 실제 매칭 요청에 반영됩니다.
                     </div>
-                    <div className="h-8 whitespace-nowrap leading-8">
-                      <span className="text-[#cc7832]">public</span> <span className="text-[#cc7832]">class</span>{" "}
-                      <span className="text-[#56a8f5]">QueueDemo</span> {"{"}
-                    </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      <span className="text-[#cc7832]">public static void</span>{" "}
-                      <span className="text-[#56a8f5]">main</span>(String[] args) {"{"}
-                    </div>
-                    <div className="flex min-h-8 flex-wrap items-center gap-2 pl-4 leading-8">
-                      <span className="text-[#cc7832]">String</span> tag ={" "}
+                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                      <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
+                      <span className="text-[#80889a]">=</span>
                       <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
                         <select
                           value={category}
                           onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
-                          className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#a9b7c6] outline-none transition focus:border-[#4e89ff]/70"
+                          className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
                         >
                           {queueCategories.map((item) => (
                             <option
@@ -1147,18 +1188,18 @@ export default function HomeScreen() {
                           ▾
                         </span>
                       </div>
-                      <span>);</span>
                     </div>
-                    <div className="flex min-h-8 flex-wrap items-center gap-2 pl-4 leading-8">
-                      <span>MatchLevel level = MatchLevel.</span>
+                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                      <span className="w-40 text-[#9cdcfe]">QUEUE_LEVEL</span>
+                      <span className="text-[#80889a]">=</span>
                       <div className="flex flex-wrap gap-1 leading-none">
                         {difficultyOptions.map((option) => (
                           <label
                             key={option.value}
                             className={`rounded-sm border px-2 py-1 text-xs transition ${
                               difficulty === option.value
-                                ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#a9c7ff]"
-                                : "border-zinc-700 bg-[#2b2d30] text-[#a9b7c6] hover:bg-zinc-700/40"
+                                ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#dcdcaa]"
+                                : "border-zinc-700 bg-[#2b2d30] text-[#9aa5b1] hover:bg-zinc-700/40"
                             }`}
                           >
                             <input
@@ -1173,25 +1214,24 @@ export default function HomeScreen() {
                           </label>
                         ))}
                       </div>
-                      <span>;</span>
                     </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      <span className="text-[#cc7832]">int</span> partySize = <span className="text-[#6897bb]">4</span>;
+                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                      <span className="w-40 text-[#9cdcfe]">QUEUE_PARTY_SIZE</span>
+                      <span className="text-[#80889a]">=</span>
+                      <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#b5cea8]">
+                        4
+                      </span>
                     </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      <span className="text-[#cc7832]">String</span> preview = <span className="text-[#6aab73]">"["</span> + level + <span className="text-[#6aab73]">"] "</span> + tag;
+                    <div className="flex min-h-8 items-start gap-2 leading-8">
+                      <span className="w-40 text-[#9cdcfe]">QUEUE_MEMO</span>
+                      <span className="pt-1 text-[#80889a]">=</span>
+                      <input
+                        type="text"
+                        value={queueMemo}
+                        onChange={(event) => setQueueMemo(event.target.value)}
+                        className="mt-0.5 h-7 w-full rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
+                      />
                     </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      preview += <span className="text-[#6aab73]">" queue started ("</span> + partySize + <span className="text-[#6aab73]">"/4)"</span>;
-                    </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      System.out.<span className="text-[#56a8f5]">println</span>(preview);
-                    </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
-                      <span className="text-[#cc7832]">boolean</span> searching = <span className="text-[#6897bb]">true</span>;
-                    </div>
-                    <div className="h-8 whitespace-nowrap pl-4 leading-8">{"}"}</div>
-                    <div className="h-8 whitespace-nowrap leading-8">{"}"}</div>
 
                     <div className="mt-2 h-8 leading-8 text-[#6a717d]">
                       {modalMode === "SEARCHING" ? (
@@ -1205,26 +1245,19 @@ export default function HomeScreen() {
                         >
                           stopQueue();
                         </button>
-                      ) : (
-                        "// press start to run the queue demo"
-                      )}
+                      ) : null}
                     </div>
-                    <div
-                      className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
-                        error
-                          ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                          : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
-                      }`}
-                    >
-                      {error ?? terminalMessage ?? feedback}
-                    </div>
-                    <div className="mt-2 space-y-0">
-                      {editorLineNumbers.slice(12).map((line) => (
-                        <div key={`filler-${line}`} className="h-8 leading-8">
-                          <span className="opacity-0">.</span>
-                        </div>
-                      ))}
-                    </div>
+                    {error || terminalMessage ? (
+                      <div
+                        className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
+                          error
+                            ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                            : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                        }`}
+                      >
+                        {error ?? terminalMessage}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </div>
@@ -1236,7 +1269,6 @@ export default function HomeScreen() {
               <div className="min-h-0">
                 <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
                   <p className="text-sm font-semibold text-zinc-200">프로필</p>
-                  <span className="text-xs text-zinc-500">⚙</span>
                 </div>
                 <div className="h-full overflow-y-auto p-3 text-xs text-zinc-300">
                   <div className="rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -1218,7 +1218,10 @@ export default function HomeScreen() {
                     </div>
                     <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
                       <span className="font-semibold text-[#ffcc66]"># TODO:</span>
-                      <span> 카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.</span>
+                      <span className="text-[#ffcc66]">
+                        {" "}
+                        카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
+                      </span>
                     </div>
                     <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -1203,7 +1203,7 @@ export default function HomeScreen() {
                       # queue config
                     </div>
                     <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                      # required: category, level
+                      # 카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
                     </div>
                     <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -196,6 +196,8 @@ export default function HomeScreen() {
   const joiningRoomIdRef = useRef<number | null>(null);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
   const [editorLineCount, setEditorLineCount] = useState(28);
+  const [editorLineHeight, setEditorLineHeight] = useState(32);
+  const [editorFontSize, setEditorFontSize] = useState(13);
 
   const resetFlow = useCallback((nextFeedback = DEFAULT_FEEDBACK) => {
     setQueueState(defaultQueueState);
@@ -303,25 +305,45 @@ export default function HomeScreen() {
       return;
     }
 
-    const updateEditorLineCount = () => {
-      const lineHeight = 32;
-      const verticalPadding = 32;
+    const resolveEditorMetrics = (width: number) => {
+      if (width >= 1920) {
+        return { lineHeight: 34, fontSize: 14 };
+      }
+
+      if (width >= 1280) {
+        return { lineHeight: 33, fontSize: 13 };
+      }
+
+      if (width >= 1024) {
+        return { lineHeight: 32, fontSize: 13 };
+      }
+
+      return { lineHeight: 30, fontSize: 13 };
+    };
+
+    const updateEditorMetrics = () => {
+      const { lineHeight, fontSize } = resolveEditorMetrics(window.innerWidth);
+      const verticalPadding = lineHeight;
       const usableHeight = Math.max(editorPane.clientHeight - verticalPadding, lineHeight);
       const nextLineCount = Math.max(18, Math.floor(usableHeight / lineHeight));
 
+      setEditorLineHeight((current) => (current === lineHeight ? current : lineHeight));
+      setEditorFontSize((current) => (current === fontSize ? current : fontSize));
       setEditorLineCount((current) => (current === nextLineCount ? current : nextLineCount));
     };
 
-    updateEditorLineCount();
+    updateEditorMetrics();
 
     const resizeObserver = new ResizeObserver(() => {
-      updateEditorLineCount();
+      updateEditorMetrics();
     });
 
     resizeObserver.observe(editorPane);
+    window.addEventListener("resize", updateEditorMetrics);
 
     return () => {
       resizeObserver.disconnect();
+      window.removeEventListener("resize", updateEditorMetrics);
     };
   }, []);
 
@@ -719,6 +741,17 @@ export default function HomeScreen() {
   const previewScoreDeltaLabel =
     previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
   const editorLineNumbers = Array.from({ length: editorLineCount }, (_, index) => 41 + index);
+  const editorLineStyle = {
+    height: `${editorLineHeight}px`,
+    lineHeight: `${editorLineHeight}px`,
+  };
+  const editorRowStyle = {
+    minHeight: `${editorLineHeight}px`,
+    lineHeight: `${editorLineHeight}px`,
+  };
+  const editorContentStyle = {
+    fontSize: `${editorFontSize}px`,
+  };
   const ideProjectTreeItems: Array<{
     key: string;
     label: string;
@@ -1012,9 +1045,9 @@ export default function HomeScreen() {
   };
 
   return (
-    <div className="xl:h-[calc(100dvh-7.5rem)] xl:overflow-hidden">
-      <section className="overflow-hidden rounded-xl border border-zinc-700/80 bg-[#1e1f22] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] xl:h-full xl:min-h-0">
-        <div className="grid h-full grid-cols-1 md:grid-cols-[250px_minmax(0,1fr)] lg:grid-cols-[210px_minmax(0,1fr)_230px] xl:grid-cols-[250px_minmax(0,1fr)_280px] 2xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+    <div className="-my-4 ml-[calc(50%-50dvw)] w-[100dvw] max-w-none min-h-[calc(100dvh-var(--app-header-h))] xl:h-[calc(100dvh-var(--app-header-h))] xl:overflow-hidden">
+      <section className="overflow-hidden bg-[#1e1f22] xl:h-full xl:min-h-0">
+        <div className="grid h-full grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]">
           <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
             <div className="grid h-full grid-cols-[48px_minmax(0,1fr)]">
               <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
@@ -1069,7 +1102,7 @@ export default function HomeScreen() {
                     const content = (
                       <div
                         className={`flex h-7 items-center gap-1.5 rounded-sm px-1.5 ${rowToneClass}`}
-                        style={{ paddingLeft: `${item.depth * 10 + 4}px` }}
+                        style={{ paddingLeft: `${item.depth * 8 + 4}px` }}
                       >
                         <span className="inline-flex w-3 items-center justify-center text-[10px] text-zinc-500">
                           {item.hasChildren ? (item.expanded ? "▾" : "▸") : ""}
@@ -1077,7 +1110,9 @@ export default function HomeScreen() {
                         <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
                           {renderProjectTreeIcon(item.icon)}
                         </span>
-                        <span className="truncate text-[13px] text-zinc-200">{item.label}</span>
+                        <span className="min-w-0 flex-1 truncate text-[13px] text-zinc-200">
+                          {item.label}
+                        </span>
                         {item.subtitle ? (
                           <span className="truncate pl-1 text-[12px] text-zinc-500">{item.subtitle}</span>
                         ) : null}
@@ -1152,20 +1187,25 @@ export default function HomeScreen() {
               </div>
 
               <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-[#1e1f22]">
-                <div className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono text-sm">
+                <div
+                  className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono"
+                  style={editorContentStyle}
+                >
                   <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
                     {editorLineNumbers.map((line) => (
-                      <div key={line} className="h-8 leading-8">
+                      <div key={line} style={editorLineStyle}>
                         {line}
                       </div>
                     ))}
                   </div>
                   <div className="px-4 py-4 text-[#a9b7c6]">
-                    <div className="h-8 whitespace-nowrap leading-8 text-[#6a717d]"># queue config</div>
-                    <div className="h-8 whitespace-nowrap leading-8 text-[#6a717d]">
+                    <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
+                      # queue config
+                    </div>
+                    <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
                       # category, level 값이 실제 매칭 요청에 반영됩니다.
                     </div>
-                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                    <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
                       <span className="text-[#80889a]">=</span>
                       <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
@@ -1189,7 +1229,7 @@ export default function HomeScreen() {
                         </span>
                       </div>
                     </div>
-                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                    <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_LEVEL</span>
                       <span className="text-[#80889a]">=</span>
                       <div className="flex flex-wrap gap-1 leading-none">
@@ -1215,14 +1255,14 @@ export default function HomeScreen() {
                         ))}
                       </div>
                     </div>
-                    <div className="flex min-h-8 items-center gap-2 leading-8">
+                    <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_PARTY_SIZE</span>
                       <span className="text-[#80889a]">=</span>
                       <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#b5cea8]">
                         4
                       </span>
                     </div>
-                    <div className="flex min-h-8 items-start gap-2 leading-8">
+                    <div className="flex items-start gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_MEMO</span>
                       <span className="pt-1 text-[#80889a]">=</span>
                       <input
@@ -1233,7 +1273,7 @@ export default function HomeScreen() {
                       />
                     </div>
 
-                    <div className="mt-2 h-8 leading-8 text-[#6a717d]">
+                    <div className="mt-2 text-[#6a717d]" style={editorLineStyle}>
                       {modalMode === "SEARCHING" ? (
                         <button
                           type="button"

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -1203,7 +1203,7 @@ export default function HomeScreen() {
                       # queue config
                     </div>
                     <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                      # category, level 값이 실제 매칭 요청에 반영됩니다.
+                      # required: category, level
                     </div>
                     <div className="flex items-center gap-2" style={editorRowStyle}>
                       <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -687,41 +687,57 @@ export default function HomeScreen() {
 
   return (
     <div className="md:h-[calc(100dvh-7.5rem)] md:overflow-hidden">
-      <section className="overflow-hidden rounded-3xl border border-violet-300/80 bg-white/70 shadow-[0_24px_60px_-40px_rgba(76,29,149,0.3)] md:h-full md:min-h-0">
-        <div className="grid gap-4 p-4 md:h-full md:grid-cols-[200px_minmax(0,1fr)] lg:grid-cols-[180px_minmax(0,1.45fr)_240px] lg:p-5 xl:grid-cols-[200px_minmax(0,1.65fr)_280px]">
-          <aside className="space-y-4 rounded-2xl border border-violet-200 bg-white/80 p-4 text-zinc-900 md:min-h-0 md:overflow-y-auto">
-            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
-              <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">빠른 메뉴</p>
-              <div className="mt-2 space-y-1.5">
-                {dashboardMenus.map((menu) => {
+      <section className="overflow-hidden rounded-2xl border border-zinc-700/80 bg-[linear-gradient(180deg,#20232b_0%,#1b1d25_100%)] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] md:h-full md:min-h-0">
+        <div className="grid gap-4 p-4 md:h-full md:grid-cols-[220px_minmax(0,1fr)] lg:grid-cols-[220px_minmax(0,1.55fr)_280px] lg:p-5 xl:grid-cols-[230px_minmax(0,1.7fr)_300px]">
+          <aside className="space-y-4 rounded-xl border border-zinc-700 bg-[#1f222a] p-4 text-zinc-100 md:min-h-0 md:overflow-y-auto">
+            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-semibold text-zinc-400">Project</p>
+                <span className="font-mono text-xs text-zinc-500">▼</span>
+              </div>
+              <div className="mt-3 space-y-1 font-mono text-xs text-zinc-300">
+                <p className="flex items-center gap-2 px-2 py-1 text-zinc-200">
+                  <span className="text-zinc-500">▾</span>
+                  <span>BRACKET [front]</span>
+                </p>
+                {dashboardMenus.map((menu, index) => {
                   const href =
                     menu.requiresAuth && !session.authenticated
                       ? `/login?next=${encodeURIComponent(menu.href)}`
                       : menu.href;
+                  const branchGlyph = index === dashboardMenus.length - 1 ? "└─" : "├─";
 
                   return (
                     <Link
                       key={menu.title}
                       href={href}
-                      className="block rounded-lg border border-violet-200 bg-white px-3 py-2 text-xs text-zinc-700 transition hover:border-violet-400 hover:bg-violet-100"
+                      className="ml-4 flex items-center gap-2 rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5 text-zinc-200 transition hover:border-sky-400/45 hover:bg-sky-500/10"
                     >
-                      {menu.title}
+                      <span className="text-zinc-500">{branchGlyph}</span>
+                      <span>{menu.title}</span>
                     </Link>
                   );
                 })}
               </div>
             </div>
+            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
+              <p className="text-xs font-semibold text-zinc-400">Open Files</p>
+              <div className="mt-2 space-y-1 font-mono text-xs text-zinc-300">
+                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">MatchControl.tsx</p>
+                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">QueueState.json</p>
+                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">ProfilePreview.sql</p>
+              </div>
+            </div>
           </aside>
 
           <div className="space-y-4 md:min-h-0 md:overflow-y-auto">
-            <div className="rounded-2xl border border-violet-200 bg-white/90 p-5 text-zinc-900">
-              <div className="mb-5 flex flex-col gap-4 rounded-xl border border-violet-200 bg-violet-50/70 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.2em] text-violet-700">매칭 제어</p>
-                  <h2 className="mt-2 text-xl font-semibold">매칭 설정</h2>
-                  <p className="mt-1 text-sm text-zinc-600">
-                    카테고리와 난이도를 선택한 뒤 큐에 참가합니다.
-                  </p>
+            <div className="overflow-hidden rounded-xl border border-zinc-700 bg-[#1f222a] text-zinc-100">
+              <div className="flex items-center justify-between border-b border-zinc-700 bg-[#1a1d24] px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span className="size-2 rounded-full bg-rose-400" />
+                  <span className="size-2 rounded-full bg-amber-400" />
+                  <span className="size-2 rounded-full bg-emerald-400" />
+                  <p className="ml-2 font-mono text-xs text-zinc-300">MatchControl.tsx</p>
                 </div>
                 <button
                   type="button"
@@ -729,7 +745,7 @@ export default function HomeScreen() {
                     void handleStartMatch();
                   }}
                   disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
-                  className="min-h-12 rounded-xl bg-violet-300 px-8 text-base font-semibold text-zinc-950 transition hover:bg-violet-200 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                  className="rounded-lg border border-sky-300/40 bg-sky-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
                 >
                   {modalMode === "SEARCHING"
                     ? "매칭 진행 중"
@@ -739,58 +755,75 @@ export default function HomeScreen() {
                 </button>
               </div>
 
-              <div className="space-y-5">
-                <label className="block space-y-2">
-                  <span className="text-sm font-medium text-zinc-700">알고리즘 카테고리</span>
-                  <div className="relative">
-                    <select
-                      value={category}
-                      onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
-                      className="w-full appearance-none rounded-xl border border-violet-300 bg-white px-4 py-3 pr-10 text-sm text-zinc-900 outline-none transition focus:border-violet-500"
-                    >
-                      {queueCategories.map((item) => (
-                        <option
-                          key={item.value}
-                          value={item.value}
-                          disabled={"disabled" in item ? item.disabled : false}
-                        >
-                          {item.label}
-                        </option>
-                      ))}
-                    </select>
-                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-500">
-                      ▾
-                    </span>
+              <div className="space-y-3 p-4">
+                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
+                  <span className="font-mono text-xs text-zinc-500">1</span>
+                  <p className="font-mono text-sm text-zinc-400">// queue options</p>
+                </div>
+
+                <label className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-center gap-3">
+                  <span className="font-mono text-xs text-zinc-500">2</span>
+                  <div className="flex flex-wrap items-center gap-2 font-mono text-sm">
+                    <span className="text-sky-300">const</span>
+                    <span className="text-zinc-200">category =</span>
+                    <div className="relative min-w-[14rem] flex-1">
+                      <select
+                        value={category}
+                        onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
+                        className="w-full appearance-none rounded-md border border-zinc-700 bg-[#22262e] px-3 py-2 pr-8 text-sm text-zinc-100 outline-none transition focus:border-sky-400/55"
+                      >
+                        {queueCategories.map((item) => (
+                          <option
+                            key={item.value}
+                            value={item.value}
+                            disabled={"disabled" in item ? item.disabled : false}
+                          >
+                            {item.label}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-400">
+                        ▾
+                      </span>
+                    </div>
+                    <span className="text-zinc-500">;</span>
                   </div>
                 </label>
 
-                <fieldset className="space-y-3">
-                  <legend className="text-sm font-medium text-zinc-700">난이도 선택</legend>
-                  <div className="grid gap-3 md:grid-cols-3">
-                    {difficultyOptions.map((option) => (
-                      <label
-                        key={option.value}
-                        className={`flex cursor-pointer items-center justify-center rounded-xl border px-4 py-3 text-sm transition ${
-                          difficulty === option.value
-                            ? "border-violet-300 bg-violet-300 text-zinc-900"
-                            : "border-violet-200 bg-white text-zinc-700 hover:border-violet-400 hover:bg-violet-50"
-                        }`}
-                      >
-                        <input
-                          type="radio"
-                          name="difficulty"
-                          value={option.value}
-                          checked={difficulty === option.value}
-                          onChange={() => setDifficulty(option.value)}
-                          className="sr-only"
-                        />
-                        <span>{option.label}</span>
-                      </label>
-                    ))}
+                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
+                  <span className="font-mono text-xs text-zinc-500">3</span>
+                  <div className="space-y-2">
+                    <p className="font-mono text-sm">
+                      <span className="text-sky-300">const</span>{" "}
+                      <span className="text-zinc-200">difficulty =</span>
+                    </p>
+                    <div className="grid gap-2 md:grid-cols-3">
+                      {difficultyOptions.map((option) => (
+                        <label
+                          key={option.value}
+                          className={`flex cursor-pointer items-center justify-center rounded-md border px-3 py-2 text-sm transition ${
+                            difficulty === option.value
+                              ? "border-sky-300/40 bg-sky-500 text-zinc-950"
+                              : "border-zinc-700 bg-[#22262e] text-zinc-100 hover:border-sky-400/45 hover:bg-sky-500/10"
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name="difficulty"
+                            value={option.value}
+                            checked={difficulty === option.value}
+                            onChange={() => setDifficulty(option.value)}
+                            className="sr-only"
+                          />
+                          <span>{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
                   </div>
-                </fieldset>
+                </div>
 
-                <div className="flex flex-wrap gap-3">
+                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-center gap-3">
+                  <span className="font-mono text-xs text-zinc-500">4</span>
                   {modalMode === "SEARCHING" ? (
                     <button
                       type="button"
@@ -798,37 +831,67 @@ export default function HomeScreen() {
                         void handleCancelMatch();
                       }}
                       disabled={isBusy}
-                      className="rounded-xl border border-violet-300 bg-white px-4 py-3 text-sm font-medium text-zinc-800 transition hover:border-violet-500 hover:bg-violet-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400"
+                      className="w-fit rounded-md border border-zinc-700 bg-[#22262e] px-4 py-2 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
                     >
                       매칭 취소
                     </button>
-                  ) : null}
+                  ) : (
+                    <p className="font-mono text-sm text-zinc-500">/* cancel disabled */</p>
+                  )}
                 </div>
 
-                <div
-                  className={`rounded-xl border px-4 py-3 text-sm ${
-                    error
-                      ? "border-rose-300 bg-rose-50 text-rose-700"
-                      : "border-violet-200 bg-violet-50/80 text-zinc-700"
-                  }`}
-                >
-                  {error ?? terminalMessage ?? feedback}
+                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
+                  <span className="font-mono text-xs text-zinc-500">5</span>
+                  <div
+                    className={`rounded-md border px-3 py-2 text-sm ${
+                      error
+                        ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                        : "border-zinc-700 bg-[#1a1d24] text-zinc-200"
+                    }`}
+                  >
+                    {error ?? terminalMessage ?? feedback}
+                  </div>
                 </div>
               </div>
             </div>
-
           </div>
 
-          <aside className="space-y-4 rounded-2xl border border-violet-200 bg-white/80 p-4 text-zinc-900 md:col-span-2 md:min-h-0 md:overflow-y-auto lg:col-span-1">
-            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">프로필</p>
-                <StatusPill tone={session.authenticated ? "success" : "warn"}>
-                  {session.authenticated ? "로그인됨" : "게스트"}
-                </StatusPill>
+          <aside className="space-y-4 rounded-xl border border-zinc-700 bg-[#1f222a] p-4 text-zinc-100 md:col-span-2 md:min-h-0 md:overflow-y-auto lg:col-span-1">
+            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
+              <p className="text-xs font-semibold text-zinc-400">Database</p>
+              <div className="mt-2 space-y-1 font-mono text-xs text-zinc-300">
+                <p className="px-1 text-zinc-400">▾ back@localhost</p>
+                <p className="pl-4 text-zinc-400">▾ schemas</p>
+                <p className="pl-7 text-zinc-400">▾ public</p>
+                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5 pl-10">▾ members</p>
+                <p className="pl-14 text-zinc-500">member_id</p>
+                <p className="pl-14 text-zinc-500">email</p>
+                <p className="pl-14 text-zinc-500">nickname</p>
+                <p className="pl-14 text-zinc-500">role</p>
+                <p className="pl-14 text-zinc-500">score</p>
               </div>
-              <p className="mt-2 text-sm font-semibold">{session.member?.nickname ?? "게스트"}</p>
-              <p className="mt-1 text-xs text-zinc-500">{formatRoleLabel(session.member?.role)}</p>
+            </div>
+
+            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
+              <p className="font-mono text-xs text-zinc-400">members.selected_row</p>
+              <dl className="mt-2 space-y-2 text-xs">
+                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
+                  <dt className="font-mono text-zinc-500">member_id</dt>
+                  <dd className="font-mono text-zinc-200">{session.member?.memberId ?? "NULL"}</dd>
+                </div>
+                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
+                  <dt className="font-mono text-zinc-500">nickname</dt>
+                  <dd className="font-mono text-zinc-200">{session.member?.nickname ?? "guest"}</dd>
+                </div>
+                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
+                  <dt className="font-mono text-zinc-500">role</dt>
+                  <dd className="font-mono text-zinc-200">{formatRoleLabel(session.member?.role)}</dd>
+                </div>
+                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
+                  <dt className="font-mono text-zinc-500">recent_win_rate</dt>
+                  <dd className="font-mono text-zinc-200">{session.authenticated ? `${previewWinRate ?? 0}%` : "NULL"}</dd>
+                </div>
+              </dl>
             </div>
 
             <div className="grid gap-2">
@@ -837,7 +900,7 @@ export default function HomeScreen() {
                   <button
                     type="button"
                     onClick={() => handleProtectedMove("/mypage")}
-                    className="rounded-xl border border-violet-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition hover:border-violet-500 hover:bg-violet-50"
+                    className="rounded-lg border border-zinc-700 bg-[#22262e] px-3 py-2 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10"
                   >
                     내 프로필
                   </button>
@@ -845,7 +908,7 @@ export default function HomeScreen() {
                     type="button"
                     onClick={handleLogout}
                     disabled={isBusy}
-                    className="rounded-xl bg-violet-300 px-3 py-2 text-sm font-semibold text-zinc-900 transition hover:bg-violet-200 disabled:cursor-not-allowed disabled:bg-zinc-300 disabled:text-zinc-500"
+                    className="rounded-lg bg-sky-500 px-3 py-2 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
                   >
                     로그아웃
                   </button>
@@ -854,13 +917,13 @@ export default function HomeScreen() {
                 <>
                   <Link
                     href="/signup"
-                    className="rounded-xl border border-violet-300 bg-white px-3 py-2 text-center text-sm font-medium text-zinc-900 transition hover:border-violet-500 hover:bg-violet-50"
+                    className="rounded-lg border border-zinc-700 bg-[#22262e] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10"
                   >
                     회원가입
                   </Link>
                   <Link
                     href="/login?next=/"
-                    className="rounded-xl bg-violet-300 px-3 py-2 text-center text-sm font-semibold text-zinc-900 transition hover:bg-violet-200"
+                    className="rounded-lg bg-sky-500 px-3 py-2 text-center text-sm font-semibold text-zinc-950 transition hover:bg-sky-400"
                   >
                     로그인
                   </Link>
@@ -868,9 +931,9 @@ export default function HomeScreen() {
               )}
             </div>
 
-            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
-              <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">전적 미리보기</p>
-              <div className="mt-3 space-y-2 text-sm text-zinc-700">
+            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
+              <p className="font-mono text-xs text-zinc-400">query_preview</p>
+              <div className="mt-2 space-y-1 text-sm text-zinc-200">
                 {session.authenticated ? (
                   <>
                     <p>최근 {previewPlayedCount}전 승률: {previewWinRate ?? 0}%</p>
@@ -885,10 +948,10 @@ export default function HomeScreen() {
                 )}
               </div>
               <div
-                className={`mt-3 rounded-lg border px-3 py-2 text-xs ${
+                className={`mt-3 rounded-md border px-3 py-2 text-xs ${
                   resultsPreviewError
-                    ? "border-rose-300 bg-rose-50 text-rose-700"
-                    : "border-violet-200 bg-white text-zinc-600"
+                    ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                    : "border-zinc-700 bg-[#22262e] text-zinc-300"
                 }`}
               >
                 {resultsPreviewError ?? resultsPreviewMessage}

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -8,18 +8,14 @@ import type {
   ApiErrorResponse,
   Difficulty,
   MatchStateResponse,
+  MyBattleResultItem,
+  MyBattleResultsResponse,
   QueueStateResponse,
   QueueStatusResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
-import {
-  ApiCallout,
-  MetricCard,
-  MetricGrid,
-  PageHero,
-  Panel,
-  StatusPill,
-} from "@/shared/ui";
+import { StatusPill } from "@/shared/ui";
+import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
 import {
   dashboardMenus,
@@ -46,6 +42,7 @@ type BusyAction =
   | null;
 
 const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
+const PREVIEW_RESULTS_SIZE = 5;
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
@@ -131,6 +128,21 @@ async function requestBattleRoomJoin(roomId: number) {
   return { response, payload };
 }
 
+async function readMyBattleResultsPreview(size: number) {
+  const response = await fetch(`/api/me/battle-results?page=0&size=${size}`, {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as MyBattleResultsResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
 function isQueueStatusResponse(
   payload: QueueStatusResponse | ApiErrorResponse | null,
 ): payload is QueueStatusResponse {
@@ -177,6 +189,9 @@ export default function HomeScreen() {
   const [pollStage, setPollStage] = useState<PollStage>("IDLE");
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
   const [now, setNow] = useState(Date.now());
+  const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
+  const [resultsPreviewMessage, setResultsPreviewMessage] = useState("로그인 후 최근 전적을 확인할 수 있습니다.");
+  const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
 
   const joiningRoomIdRef = useRef<number | null>(null);
 
@@ -329,6 +344,55 @@ export default function HomeScreen() {
       active = false;
     };
   }, [applyMatchSnapshot, resetFlow]);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!session.authenticated) {
+      setRecentResults([]);
+      setResultsPreviewError(null);
+      setResultsPreviewMessage("로그인 후 최근 전적을 확인할 수 있습니다.");
+      return () => {
+        active = false;
+      };
+    }
+
+    setResultsPreviewError(null);
+    setResultsPreviewMessage("최근 전적을 불러오는 중입니다.");
+
+    void (async () => {
+      const { ok, status, payload } = await readMyBattleResultsPreview(PREVIEW_RESULTS_SIZE);
+
+      if (!active) {
+        return;
+      }
+
+      if (status === 401 || payload?.resultCode === "MEMBER_401") {
+        setRecentResults([]);
+        setResultsPreviewError(null);
+        setResultsPreviewMessage(payload?.msg ?? "로그인이 필요합니다.");
+        return;
+      }
+
+      if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
+        setRecentResults([]);
+        setResultsPreviewError(payload?.msg ?? "최근 전적을 불러오지 못했습니다.");
+        setResultsPreviewMessage(payload?.msg ?? "전적 조회에 실패했습니다.");
+        return;
+      }
+
+      const loaded = payload.data.battleResults;
+      setRecentResults(loaded);
+      setResultsPreviewError(null);
+      setResultsPreviewMessage(
+        loaded.length > 0 ? payload.msg : "아직 완료한 배틀 전적이 없습니다.",
+      );
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [session.authenticated]);
 
   useEffect(() => {
     if (!session.authenticated || pollStage !== "QUEUE") {
@@ -614,310 +678,225 @@ export default function HomeScreen() {
   const activeDifficultyLabel = queueState.difficulty ?? difficulty;
   const queueElapsedSeconds = getElapsedSeconds(queueStartedAt, now);
   const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
-  const acceptedCount = matchState.readyCheck?.acceptedCount ?? 0;
   const roomId = matchState.room?.roomId ?? null;
-
-  const flowStatusValue =
-    modalMode === "SEARCHING"
-      ? "대기 중"
-      : modalMode === "READY_CHECK"
-        ? "수락 대기"
-        : modalMode === "ROOM_READY"
-          ? "방 준비 완료"
-          : modalMode === "TERMINAL"
-            ? "종료 안내"
-            : "대기 없음";
-
-  const flowStatusHint =
-    modalMode === "SEARCHING"
-      ? `${waitingCount} / ${requiredCount}명 대기`
-      : modalMode === "READY_CHECK"
-        ? `${acceptedCount} / ${requiredCount}명 수락`
-        : modalMode === "ROOM_READY"
-          ? roomId !== null
-            ? `roomId ${roomId}`
-            : "roomId 확인 중"
-          : modalMode === "TERMINAL"
-            ? "종료 후 로컬 상태 초기화"
-            : "메인에서 바로 시작";
+  const previewPlayedCount = recentResults.length;
+  const previewSolvedCount = recentResults.filter((item) => item.solved).length;
+  const previewWinRate =
+    previewPlayedCount > 0 ? Math.round((previewSolvedCount / previewPlayedCount) * 100) : null;
+  const previewScoreDelta = recentResults.reduce((acc, item) => acc + item.scoreDelta, 0);
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Main"
-        title="프로필을 보고, ready-check까지 이어지는 메인 홈"
-        description="메인 홈에서 category와 difficulty를 고른 뒤 매칭을 시작합니다. v2 흐름에서는 먼저 queue/me를 polling하고, 큐에서 빠진 뒤에는 matches/me로 전환해 수락 여부와 room 준비 상태를 확인합니다."
-        actions={
-          <>
-            <StatusPill tone={session.authenticated ? "success" : "warn"}>
-              {session.authenticated ? "로그인 상태" : "게스트 상태"}
-            </StatusPill>
-            <StatusPill>ready-check v2</StatusPill>
-            <StatusPill>HTTP polling</StatusPill>
-          </>
-        }
-      />
+    <div className="md:h-[calc(100dvh-7.5rem)] md:overflow-hidden">
+      <section className="overflow-hidden rounded-3xl border border-violet-300/80 bg-white/70 shadow-[0_24px_60px_-40px_rgba(76,29,149,0.3)] md:h-full md:min-h-0">
+        <div className="grid gap-4 p-4 md:h-full md:grid-cols-[200px_minmax(0,1fr)] lg:grid-cols-[180px_minmax(0,1.45fr)_240px] lg:p-5 xl:grid-cols-[200px_minmax(0,1.65fr)_280px]">
+          <aside className="space-y-4 rounded-2xl border border-violet-200 bg-white/80 p-4 text-zinc-900 md:min-h-0 md:overflow-y-auto">
+            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">빠른 메뉴</p>
+              <div className="mt-2 space-y-1.5">
+                {dashboardMenus.map((menu) => {
+                  const href =
+                    menu.requiresAuth && !session.authenticated
+                      ? `/login?next=${encodeURIComponent(menu.href)}`
+                      : menu.href;
 
-      <div className="rounded-3xl border border-zinc-300 bg-white p-6 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <p className="text-sm text-zinc-500">상단바</p>
-            <h2 className="mt-1 text-2xl font-semibold tracking-tight text-zinc-950">
-              Algo Battle
-            </h2>
-            <p className="mt-2 text-sm text-zinc-600">
-              {session.authenticated
-                ? `${session.member?.nickname}님은 메인 홈에서 바로 매칭을 시작할 수 있습니다.`
-                : "비로그인 상태에서는 메인 구조만 볼 수 있고, 실제 매칭 시작 시 로그인으로 이동합니다."}
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm">
-              <p className="font-medium text-zinc-950">
-                {session.member?.nickname ?? "게스트"}
-              </p>
-              <p className="text-zinc-500">
-                {session.member?.role ?? "로그인 필요"} / 전적 API 연동 중
-              </p>
-            </div>
-            {session.authenticated ? (
-              <>
-                <button
-                  type="button"
-                  onClick={() => handleProtectedMove("/mypage")}
-                  className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
-                >
-                  내 프로필
-                </button>
-                <button
-                  type="button"
-                  onClick={handleLogout}
-                  disabled={isBusy}
-                  className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
-                >
-                  로그아웃
-                </button>
-              </>
-            ) : (
-              <>
-                <Link
-                  href="/signup"
-                  className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
-                >
-                  회원가입
-                </Link>
-                <Link
-                  href="/login?next=/"
-                  className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
-                >
-                  로그인
-                </Link>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-
-      <MetricGrid>
-        <MetricCard label="현재 상태" value={flowStatusValue} hint={flowStatusHint} />
-        <MetricCard
-          label="매칭 인원"
-          value={`${requiredCount}명`}
-          hint="현재 MVP는 4인 ready-check 기준"
-        />
-        <MetricCard
-          label="카테고리"
-          value={activeCategoryLabel}
-          hint="큐 대기 중에는 queue/me 기준으로 표시합니다."
-        />
-        <MetricCard
-          label="난이도"
-          value={activeDifficultyLabel}
-          hint="Easy / Medium / Hard"
-        />
-      </MetricGrid>
-
-      <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr] xl:grid-cols-[0.85fr_1.3fr_0.85fr]">
-        <Panel
-          title="서비스 메뉴"
-          description="주요 페이지별 작업 동선을 한곳에서 바로 열 수 있도록 진입점을 둡니다."
-        >
-          <div className="space-y-3">
-            {dashboardMenus.map((menu) => {
-              const href =
-                menu.requiresAuth && !session.authenticated
-                  ? `/login?next=${encodeURIComponent(menu.href)}`
-                  : menu.href;
-
-              return (
-                <Link
-                  key={menu.title}
-                  href={href}
-                  className="block rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 transition hover:border-zinc-500"
-                >
-                  <p className="font-medium text-zinc-950">{menu.title}</p>
-                  <p className="mt-1 text-sm leading-6 text-zinc-600">
-                    {menu.description}
-                  </p>
-                </Link>
-              );
-            })}
-          </div>
-        </Panel>
-
-        <Panel
-          title="매칭 설정 영역"
-          description="메인 홈의 가장 중요한 기능은 카테고리와 난이도를 고른 뒤 바로 매칭을 시작하는 것입니다."
-        >
-          <div className="space-y-6">
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">알고리즘 카테고리</span>
-              <select
-                value={category}
-                onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-              >
-                {queueCategories.map((item) => (
-                  <option key={item.value} value={item.value} disabled={item.disabled}>
-                    {item.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <p className="text-sm leading-6 text-zinc-500">
-              현재는 실제 출제 가능한 카테고리만 사용하고, 전체(무작위)는 준비 중으로 둡니다.
-            </p>
-
-            <fieldset className="space-y-3">
-              <legend className="text-sm font-medium text-zinc-700">난이도 선택</legend>
-              <div className="grid gap-3 md:grid-cols-3">
-                {difficultyOptions.map((option) => (
-                  <label
-                    key={option.value}
-                    className={`flex cursor-pointer items-center gap-3 rounded-2xl border px-4 py-3 text-sm transition ${
-                      difficulty === option.value
-                        ? "border-zinc-950 bg-zinc-950 text-white"
-                        : "border-zinc-300 bg-zinc-50 text-zinc-900"
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="difficulty"
-                      value={option.value}
-                      checked={difficulty === option.value}
-                      onChange={() => setDifficulty(option.value)}
-                      className="sr-only"
-                    />
-                    <span>{option.label}</span>
-                  </label>
-                ))}
+                  return (
+                    <Link
+                      key={menu.title}
+                      href={href}
+                      className="block rounded-lg border border-violet-200 bg-white px-3 py-2 text-xs text-zinc-700 transition hover:border-violet-400 hover:bg-violet-100"
+                    >
+                      {menu.title}
+                    </Link>
+                  );
+                })}
               </div>
-            </fieldset>
+            </div>
+          </aside>
 
-            <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={() => {
-                  void handleStartMatch();
-                }}
-                disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
-              >
-                {modalMode === "SEARCHING"
-                  ? "매칭 진행 중"
-                  : busyAction === "start"
-                    ? "처리 중..."
-                    : "매칭 시작"}
-              </button>
-              {modalMode === "SEARCHING" ? (
+          <div className="space-y-4 md:min-h-0 md:overflow-y-auto">
+            <div className="rounded-2xl border border-violet-200 bg-white/90 p-5 text-zinc-900">
+              <div className="mb-5 flex flex-col gap-4 rounded-xl border border-violet-200 bg-violet-50/70 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-violet-700">매칭 제어</p>
+                  <h2 className="mt-2 text-xl font-semibold">매칭 설정</h2>
+                  <p className="mt-1 text-sm text-zinc-600">
+                    카테고리와 난이도를 선택한 뒤 큐에 참가합니다.
+                  </p>
+                </div>
                 <button
                   type="button"
                   onClick={() => {
-                    void handleCancelMatch();
+                    void handleStartMatch();
                   }}
-                  disabled={isBusy}
-                  className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                  disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
+                  className="min-h-12 rounded-xl bg-violet-300 px-8 text-base font-semibold text-zinc-950 transition hover:bg-violet-200 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
                 >
-                  매칭 취소
+                  {modalMode === "SEARCHING"
+                    ? "매칭 진행 중"
+                    : busyAction === "start"
+                      ? "처리 중..."
+                      : "매칭 시작"}
                 </button>
-              ) : null}
+              </div>
+
+              <div className="space-y-5">
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium text-zinc-700">알고리즘 카테고리</span>
+                  <div className="relative">
+                    <select
+                      value={category}
+                      onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
+                      className="w-full appearance-none rounded-xl border border-violet-300 bg-white px-4 py-3 pr-10 text-sm text-zinc-900 outline-none transition focus:border-violet-500"
+                    >
+                      {queueCategories.map((item) => (
+                        <option
+                          key={item.value}
+                          value={item.value}
+                          disabled={"disabled" in item ? item.disabled : false}
+                        >
+                          {item.label}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-500">
+                      ▾
+                    </span>
+                  </div>
+                </label>
+
+                <fieldset className="space-y-3">
+                  <legend className="text-sm font-medium text-zinc-700">난이도 선택</legend>
+                  <div className="grid gap-3 md:grid-cols-3">
+                    {difficultyOptions.map((option) => (
+                      <label
+                        key={option.value}
+                        className={`flex cursor-pointer items-center justify-center rounded-xl border px-4 py-3 text-sm transition ${
+                          difficulty === option.value
+                            ? "border-violet-300 bg-violet-300 text-zinc-900"
+                            : "border-violet-200 bg-white text-zinc-700 hover:border-violet-400 hover:bg-violet-50"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="difficulty"
+                          value={option.value}
+                          checked={difficulty === option.value}
+                          onChange={() => setDifficulty(option.value)}
+                          className="sr-only"
+                        />
+                        <span>{option.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </fieldset>
+
+                <div className="flex flex-wrap gap-3">
+                  {modalMode === "SEARCHING" ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleCancelMatch();
+                      }}
+                      disabled={isBusy}
+                      className="rounded-xl border border-violet-300 bg-white px-4 py-3 text-sm font-medium text-zinc-800 transition hover:border-violet-500 hover:bg-violet-50 disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400"
+                    >
+                      매칭 취소
+                    </button>
+                  ) : null}
+                </div>
+
+                <div
+                  className={`rounded-xl border px-4 py-3 text-sm ${
+                    error
+                      ? "border-rose-300 bg-rose-50 text-rose-700"
+                      : "border-violet-200 bg-violet-50/80 text-zinc-700"
+                  }`}
+                >
+                  {error ?? terminalMessage ?? feedback}
+                </div>
+              </div>
             </div>
 
-            <div
-              className={`rounded-2xl border px-4 py-3 text-sm ${
-                error
-                  ? "border-rose-300 bg-rose-50 text-rose-900"
-                  : "border-zinc-300 bg-zinc-50 text-zinc-700"
-              }`}
-            >
-              {error ?? terminalMessage ?? feedback}
-            </div>
           </div>
-        </Panel>
 
-        <Panel
-          title="개인 통계 요약"
-          description="메인에서는 보조 정보만 보여주고, 실제 전적과 점수 API는 마이페이지에서 더 자세히 확인합니다."
-          className="lg:col-span-2 xl:col-span-1"
-        >
-          <div className="space-y-3 text-sm">
-            <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              티어/총점: API 연결 전
+          <aside className="space-y-4 rounded-2xl border border-violet-200 bg-white/80 p-4 text-zinc-900 md:col-span-2 md:min-h-0 md:overflow-y-auto lg:col-span-1">
+            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">프로필</p>
+                <StatusPill tone={session.authenticated ? "success" : "warn"}>
+                  {session.authenticated ? "로그인됨" : "게스트"}
+                </StatusPill>
+              </div>
+              <p className="mt-2 text-sm font-semibold">{session.member?.nickname ?? "게스트"}</p>
+              <p className="mt-1 text-xs text-zinc-500">{formatRoleLabel(session.member?.role)}</p>
             </div>
-            <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              현재 단계: {flowStatusValue}
-            </div>
-            <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-              {modalMode === "SEARCHING"
-                ? `현재 큐: ${activeCategoryLabel} / ${activeDifficultyLabel} / ${waitingCount}명 대기`
-                : modalMode === "READY_CHECK"
-                  ? `ready-check: ${acceptedCount} / ${requiredCount}명 수락`
-                  : modalMode === "ROOM_READY"
-                    ? `방 입장 준비: roomId ${roomId ?? "확인 중"}`
-                    : "현재는 대기 중이 아닙니다."}
-            </div>
-          </div>
-        </Panel>
-      </div>
 
-      <Panel
-        title="현재 연결 사인"
-        description="메인과 인접한 흐름에서 이번 단계에 실제로 붙여 둔 API 경로들입니다."
-      >
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <ApiCallout
-            method="POST"
-            path="/api/queue/join"
-            note="큐 참가 후에는 응답 메시지를 고정 상태로 쓰지 않고, queue/me polling으로 실제 대기 상태를 그립니다."
-          />
-          <ApiCallout
-            method="GET"
-            path="/api/queue/me"
-            note="SEARCHING 단계 전용입니다. waitingCount와 requiredCount를 이용해 1/4, 2/4 같은 대기 UI를 만듭니다."
-          />
-          <ApiCallout
-            method="GET"
-            path="/api/matches/me"
-            note="queue/me에서 inQueue=false가 되면 이쪽으로 전환해 ready-check, room 준비, 종료 상태를 확인합니다."
-          />
-          <ApiCallout
-            method="POST"
-            path="/api/matches/[matchId]/accept"
-            note="내 decision을 ACCEPTED로 바꾸고, 마지막 수락이면 ROOM_READY까지 이어집니다."
-          />
-          <ApiCallout
-            method="POST"
-            path="/api/matches/[matchId]/decline"
-            note="한 명이라도 거절하면 세션 전체가 CANCELLED로 바뀌고 종료 안내를 보여줍니다."
-          />
-          <ApiCallout
-            method="POST"
-            path="/api/battle/rooms/{roomId}/join"
-            note="ROOM_READY가 되면 기존 battle room join API를 재사용해서 실제 방으로 입장합니다."
-          />
+            <div className="grid gap-2">
+              {session.authenticated ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => handleProtectedMove("/mypage")}
+                    className="rounded-xl border border-violet-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition hover:border-violet-500 hover:bg-violet-50"
+                  >
+                    내 프로필
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleLogout}
+                    disabled={isBusy}
+                    className="rounded-xl bg-violet-300 px-3 py-2 text-sm font-semibold text-zinc-900 transition hover:bg-violet-200 disabled:cursor-not-allowed disabled:bg-zinc-300 disabled:text-zinc-500"
+                  >
+                    로그아웃
+                  </button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/signup"
+                    className="rounded-xl border border-violet-300 bg-white px-3 py-2 text-center text-sm font-medium text-zinc-900 transition hover:border-violet-500 hover:bg-violet-50"
+                  >
+                    회원가입
+                  </Link>
+                  <Link
+                    href="/login?next=/"
+                    className="rounded-xl bg-violet-300 px-3 py-2 text-center text-sm font-semibold text-zinc-900 transition hover:bg-violet-200"
+                  >
+                    로그인
+                  </Link>
+                </>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-violet-200 bg-violet-50/70 p-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">전적 미리보기</p>
+              <div className="mt-3 space-y-2 text-sm text-zinc-700">
+                {session.authenticated ? (
+                  <>
+                    <p>최근 {previewPlayedCount}전 승률: {previewWinRate ?? 0}%</p>
+                    <p>최근 정답 수: {previewSolvedCount}</p>
+                    <p>
+                      최근 점수 변화 합계: {previewScoreDelta > 0 ? "+" : ""}
+                      {previewScoreDelta}
+                    </p>
+                  </>
+                ) : (
+                  <p>로그인 후 전적 미리보기를 확인할 수 있습니다.</p>
+                )}
+              </div>
+              <div
+                className={`mt-3 rounded-lg border px-3 py-2 text-xs ${
+                  resultsPreviewError
+                    ? "border-rose-300 bg-rose-50 text-rose-700"
+                    : "border-violet-200 bg-white text-zinc-600"
+                }`}
+              >
+                {resultsPreviewError ?? resultsPreviewMessage}
+              </div>
+            </div>
+          </aside>
         </div>
-      </Panel>
+      </section>
 
       <QueueModal
         mode={modalMode}

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -18,7 +18,6 @@ import { StatusPill } from "@/shared/ui";
 import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
 import {
-  dashboardMenus,
   DEFAULT_REQUIRED_COUNT,
   difficultyOptions,
   getElapsedSeconds,
@@ -684,60 +683,410 @@ export default function HomeScreen() {
   const previewWinRate =
     previewPlayedCount > 0 ? Math.round((previewSolvedCount / previewPlayedCount) * 100) : null;
   const previewScoreDelta = recentResults.reduce((acc, item) => acc + item.scoreDelta, 0);
+  const previewScoreDeltaLabel =
+    previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
+  const editorLineNumbers = Array.from({ length: 28 }, (_, index) => 41 + index);
+  const ideProjectTreeItems: Array<{
+    key: string;
+    label: string;
+    depth: number;
+    icon: "root" | "folder" | "folderAccent" | "package" | "class" | "file" | "fileAccent";
+    hasChildren?: boolean;
+    expanded?: boolean;
+    subtitle?: string;
+    rowTone?: "amber" | "green" | "selected";
+    href?: string;
+  }> = [
+    {
+      key: "root",
+      label: "BRACKET {}",
+      depth: 0,
+      icon: "root",
+      hasChildren: true,
+      expanded: true,
+    },
+    {
+      key: "quick-menu",
+      label: "퀵메뉴",
+      depth: 1,
+      icon: "folderAccent",
+      hasChildren: true,
+      expanded: true,
+      rowTone: "amber",
+    },
+    {
+      key: "home-screen",
+      label: "메인",
+      depth: 2,
+      icon: "class",
+      rowTone: "selected",
+      href: "/",
+    },
+    { key: "problem-list", label: "문제 목록", depth: 2, icon: "class", href: "/problems" },
+    { key: "spectate-list", label: "관전", depth: 2, icon: "class", href: "/spectate" },
+    { key: "mypage", label: "마이페이지", depth: 2, icon: "class", href: "/mypage" },
+  ];
+  const ideRailTopItems = [
+    { icon: "project", active: true, title: "Project" },
+    { icon: "sliders", title: "Services" },
+    { icon: "branch", title: "Git" },
+    { icon: "layout", title: "Layout" },
+    { icon: "more", title: "More" },
+  ];
+  const ideRailBottomItems = [
+    { icon: "cube", title: "AI" },
+    { icon: "tools", title: "Tools" },
+    { icon: "play", title: "Run" },
+    { icon: "terminal", title: "Terminal" },
+    { icon: "issue", title: "Problems" },
+    { icon: "nodes", title: "Connections" },
+  ];
+  const ideDbRailTopItems = [
+    { icon: "notifications", title: "알림" },
+    { icon: "search", title: "검색" },
+    { icon: "database", title: "데이터베이스", active: true },
+    { icon: "gamepad", title: "게임" },
+    { icon: "blocks", title: "서비스" },
+    { icon: "docs", title: "문서" },
+    { icon: "users", title: "사용자" },
+    { icon: "cloud", title: "클라우드" },
+    { icon: "link", title: "연결" },
+  ];
+  const ideDbRailBottomItems = [{ icon: "hammer", title: "도구" }];
+  const renderRailIcon = (name: string) => {
+    const baseClass = "h-4 w-4";
+
+    switch (name) {
+      case "project":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path
+              d="M2 4.5h4l1.1 1.2H14v6.8a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5v-8Z"
+              stroke="currentColor"
+              strokeWidth="1.3"
+            />
+            <path d="M2.2 6h11.6" stroke="currentColor" strokeWidth="1.1" />
+          </svg>
+        );
+      case "sliders":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M2 5.2h12M2 10.8h12" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            <circle cx="6" cy="5.2" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="10" cy="10.8" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "branch":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="4" cy="3.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="11.8" cy="6.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="8.2" cy="12.2" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+            <path
+              d="M5.3 4.4c2 .2 3.4.7 4.8 1.6M11 8c-.5 1.5-1.3 2.4-2.2 3.2"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+            />
+          </svg>
+        );
+      case "layout":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <rect x="2.2" y="2.2" width="11.6" height="11.6" rx="1.6" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M2.2 7.8h11.6M7.8 2.2v11.6" stroke="currentColor" strokeWidth="1.1" />
+          </svg>
+        );
+      case "more":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="4" cy="8" r="1" fill="currentColor" />
+            <circle cx="8" cy="8" r="1" fill="currentColor" />
+            <circle cx="12" cy="8" r="1" fill="currentColor" />
+          </svg>
+        );
+      case "cube":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M8 2.4 12.8 5v6L8 13.6 3.2 11V5L8 2.4Z" stroke="currentColor" strokeWidth="1.1" />
+            <path d="m8 2.4 4.8 2.6L8 7.5 3.2 5 8 2.4ZM8 7.5V13.6" stroke="currentColor" strokeWidth="1.1" />
+            <path d="m12.2 2.2.8.8m0 0 .8-.8M13 3v1.1" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+          </svg>
+        );
+      case "tools":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="m4 5 7 7M11.5 4.5a2 2 0 0 0-2.6 2.6l2.6-2.6ZM3.2 10.8l2-2L7 10.6l-2 2-1.8-1.8Z" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="m9 3 1.2 1.2M8 4l1.2 1.2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+          </svg>
+        );
+      case "play":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M4.2 3.8h7.6v8.4H4.2z" stroke="currentColor" strokeWidth="1.1" transform="rotate(-30 8 8)" />
+            <path d="m6.6 5.9 4 2.1-4 2.1V5.9Z" fill="currentColor" />
+          </svg>
+        );
+      case "terminal":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <rect x="2.2" y="2.8" width="11.6" height="10.4" rx="1.3" stroke="currentColor" strokeWidth="1.2" />
+            <path d="m5.1 6.7 2 1.5-2 1.5M8.8 9.8h2.2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        );
+      case "issue":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M8 5.4v3.2M8 11h.01" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+          </svg>
+        );
+      case "nodes":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="5" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="11.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="8" cy="11.3" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M6.4 5.2h3.6M10.8 6.8l-2 3.1M6.8 10l-1.2-3.1" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+          </svg>
+        );
+      default:
+        return null;
+    }
+  };
+  const renderProjectTreeIcon = (
+    icon: "root" | "folder" | "folderAccent" | "package" | "class" | "file" | "fileAccent",
+  ) => {
+    switch (icon) {
+      case "class":
+        return (
+          <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#3b78e7] text-[8px] font-semibold leading-none text-[#62a5ff]">
+            C
+          </span>
+        );
+      case "package":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+            <path d="M2.2 5h3.2l.9.9h7.5v6.1a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V5Z" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "folderAccent":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#cf8f4e]">
+            <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "root":
+      case "folder":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+            <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "fileAccent":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "file":
+      default:
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+    }
+  };
+  const renderDbRailIcon = (name: string) => {
+    const baseClass = "h-4 w-4";
+
+    switch (name) {
+      case "notifications":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M8 3a3 3 0 0 0-3 3v2.2l-1 1.6h8l-1-1.6V6a3 3 0 0 0-3-3Z" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="12.2" cy="3.8" r="1.4" fill="#ff5f6d" />
+          </svg>
+        );
+      case "search":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="7" cy="7" r="3.6" stroke="currentColor" strokeWidth="1.2" />
+            <path d="m10 10 3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        );
+      case "database":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <ellipse cx="8" cy="4.1" rx="4.7" ry="2" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M3.3 4.1v4.8c0 1.1 2.1 2 4.7 2s4.7-.9 4.7-2V4.1" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "gamepad":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <rect x="3" y="6.2" width="10" height="5.8" rx="2.2" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M5.4 9h2.2M6.5 7.9v2.2M10.6 8.4h.01M11.8 9.6h.01" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        );
+      case "blocks":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <rect x="2.4" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+            <rect x="8.8" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+            <rect x="5.6" y="8.8" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "docs":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M9 2.5V6h3M5.2 8.2h5.6M5.2 10.2h5.6" stroke="currentColor" strokeWidth="1.1" />
+          </svg>
+        );
+      case "users":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <circle cx="6.1" cy="6.1" r="2.1" stroke="currentColor" strokeWidth="1.2" />
+            <circle cx="11.1" cy="6.7" r="1.6" stroke="currentColor" strokeWidth="1.2" />
+            <path d="M3.4 12c.5-1.7 1.6-2.7 2.9-2.7s2.4 1 2.9 2.7M9 12.1c.4-1.3 1.2-2.1 2.2-2.1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        );
+      case "cloud":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M4.8 11.8h6a2.2 2.2 0 1 0-.4-4.4 3.1 3.1 0 0 0-5.9.8 1.9 1.9 0 0 0 .3 3.6Z" stroke="currentColor" strokeWidth="1.2" />
+          </svg>
+        );
+      case "link":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="M6.5 9.5 9.5 6.5M5.3 11a2.3 2.3 0 0 1 0-3.2l1.5-1.5a2.3 2.3 0 1 1 3.2 3.2l-.6.6M10.7 5a2.3 2.3 0 0 1 0 3.2l-1.5 1.5a2.3 2.3 0 1 1-3.2-3.2l.6-.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        );
+      case "hammer":
+        return (
+          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+            <path d="m9.2 3.2 3.1 3.1M4.1 12.2 9.9 6.4 7.6 4.1 1.8 9.9l2.3 2.3Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
     <div className="md:h-[calc(100dvh-7.5rem)] md:overflow-hidden">
-      <section className="overflow-hidden rounded-2xl border border-zinc-700/80 bg-[linear-gradient(180deg,#20232b_0%,#1b1d25_100%)] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] md:h-full md:min-h-0">
-        <div className="grid gap-4 p-4 md:h-full md:grid-cols-[220px_minmax(0,1fr)] lg:grid-cols-[220px_minmax(0,1.55fr)_280px] lg:p-5 xl:grid-cols-[230px_minmax(0,1.7fr)_300px]">
-          <aside className="space-y-4 rounded-xl border border-zinc-700 bg-[#1f222a] p-4 text-zinc-100 md:min-h-0 md:overflow-y-auto">
-            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
-              <div className="flex items-center justify-between">
-                <p className="text-xs font-semibold text-zinc-400">Project</p>
-                <span className="font-mono text-xs text-zinc-500">▼</span>
-              </div>
-              <div className="mt-3 space-y-1 font-mono text-xs text-zinc-300">
-                <p className="flex items-center gap-2 px-2 py-1 text-zinc-200">
-                  <span className="text-zinc-500">▾</span>
-                  <span>BRACKET [front]</span>
-                </p>
-                {dashboardMenus.map((menu, index) => {
-                  const href =
-                    menu.requiresAuth && !session.authenticated
-                      ? `/login?next=${encodeURIComponent(menu.href)}`
-                      : menu.href;
-                  const branchGlyph = index === dashboardMenus.length - 1 ? "└─" : "├─";
-
-                  return (
-                    <Link
-                      key={menu.title}
-                      href={href}
-                      className="ml-4 flex items-center gap-2 rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5 text-zinc-200 transition hover:border-sky-400/45 hover:bg-sky-500/10"
+      <section className="overflow-hidden rounded-xl border border-zinc-700/80 bg-[#1e1f22] shadow-[0_34px_82px_-42px_rgba(0,0,0,0.92),0_12px_24px_-16px_rgba(0,0,0,0.78)] md:h-full md:min-h-0">
+        <div className="grid h-full grid-cols-1 md:grid-cols-[250px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_260px] xl:grid-cols-[280px_minmax(0,1fr)_300px]">
+          <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
+            <div className="grid h-full grid-cols-[48px_minmax(0,1fr)]">
+              <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
+                <div className="flex flex-col items-center gap-2">
+                  {ideRailTopItems.map((item) => (
+                    <button
+                      key={item.title}
+                      type="button"
+                      title={item.title}
+                      aria-label={item.title}
+                      className={`h-8 w-8 rounded-md border text-[10px] font-semibold tracking-wide transition ${
+                        item.active
+                          ? "border-zinc-500 bg-zinc-700/70 text-zinc-100"
+                          : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-300"
+                      }`}
                     >
-                      <span className="text-zinc-500">{branchGlyph}</span>
-                      <span>{menu.title}</span>
-                    </Link>
-                  );
-                })}
+                      <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  {ideRailBottomItems.map((item) => (
+                    <button
+                      key={item.title}
+                      type="button"
+                      title={item.title}
+                      aria-label={item.title}
+                      className="h-8 w-8 rounded-md border border-transparent text-[10px] font-semibold tracking-wide text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-300"
+                    >
+                      <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
-              <p className="text-xs font-semibold text-zinc-400">Open Files</p>
-              <div className="mt-2 space-y-1 font-mono text-xs text-zinc-300">
-                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">MatchControl.tsx</p>
-                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">QueueState.json</p>
-                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">ProfilePreview.sql</p>
+
+              <div className="flex min-h-0 flex-col">
+                <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
+                  <p className="text-sm font-semibold text-zinc-200">퀵 메뉴</p>
+                  <span className="text-xs text-zinc-500">▼</span>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-sm text-zinc-300">
+                  {ideProjectTreeItems.map((item) => {
+                    const rowToneClass =
+                      item.rowTone === "amber"
+                        ? "bg-[#4a3924]/50"
+                        : item.rowTone === "green"
+                          ? "bg-[#1f3a2a]/55"
+                          : item.rowTone === "selected"
+                            ? "bg-zinc-600/70"
+                            : "hover:bg-zinc-700/30";
+
+                    const content = (
+                      <div
+                        className={`flex h-7 items-center gap-1.5 rounded-sm px-1.5 ${rowToneClass}`}
+                        style={{ paddingLeft: `${item.depth * 10 + 4}px` }}
+                      >
+                        <span className="inline-flex w-3 items-center justify-center text-[10px] text-zinc-500">
+                          {item.hasChildren ? (item.expanded ? "▾" : "▸") : ""}
+                        </span>
+                        <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
+                          {renderProjectTreeIcon(item.icon)}
+                        </span>
+                        <span className="truncate text-[13px] text-zinc-200">{item.label}</span>
+                        {item.subtitle ? (
+                          <span className="truncate pl-1 text-[12px] text-zinc-500">{item.subtitle}</span>
+                        ) : null}
+                      </div>
+                    );
+
+                    if (item.href) {
+                      const href = item.href === "/"
+                        ? "/"
+                        : !session.authenticated
+                          ? `/login?next=${encodeURIComponent(item.href)}`
+                          : item.href;
+
+                      return (
+                        <Link key={item.key} href={href}>
+                          {content}
+                        </Link>
+                      );
+                    }
+
+                    return <div key={item.key}>{content}</div>;
+                  })}
+                </div>
               </div>
             </div>
           </aside>
 
-          <div className="space-y-4 md:min-h-0 md:overflow-y-auto">
-            <div className="overflow-hidden rounded-xl border border-zinc-700 bg-[#1f222a] text-zinc-100">
-              <div className="flex items-center justify-between border-b border-zinc-700 bg-[#1a1d24] px-4 py-3">
-                <div className="flex items-center gap-2">
-                  <span className="size-2 rounded-full bg-rose-400" />
-                  <span className="size-2 rounded-full bg-amber-400" />
-                  <span className="size-2 rounded-full bg-emerald-400" />
-                  <p className="ml-2 font-mono text-xs text-zinc-300">MatchControl.tsx</p>
+          <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] md:border-b-0 lg:border-r">
+            <div className="flex h-full min-h-0 flex-col">
+              <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+                <div className="flex h-full items-end gap-0.5 pt-1">
+                  <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+                    <span className="text-sky-400">●</span>
+                    <span>QueueDemo.java</span>
+                    <span className="text-zinc-500">×</span>
+                    <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+                  </div>
+                  <div className="flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-500">
+                    <span className="text-sky-600">●</span>
+                    <span>MatchLevel.java</span>
+                    <span>×</span>
+                  </div>
                 </div>
                 <button
                   type="button"
@@ -745,7 +1094,7 @@ export default function HomeScreen() {
                     void handleStartMatch();
                   }}
                   disabled={isBusy || (modalMode !== null && modalMode !== "TERMINAL")}
-                  className="rounded-lg border border-sky-300/40 bg-sky-500 px-5 py-2 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
+                  className="rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-4 py-1.5 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
                 >
                   {modalMode === "SEARCHING"
                     ? "매칭 진행 중"
@@ -755,206 +1104,271 @@ export default function HomeScreen() {
                 </button>
               </div>
 
-              <div className="space-y-3 p-4">
-                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
-                  <span className="font-mono text-xs text-zinc-500">1</span>
-                  <p className="font-mono text-sm text-zinc-400">// queue options</p>
-                </div>
-
-                <label className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-center gap-3">
-                  <span className="font-mono text-xs text-zinc-500">2</span>
-                  <div className="flex flex-wrap items-center gap-2 font-mono text-sm">
-                    <span className="text-sky-300">const</span>
-                    <span className="text-zinc-200">category =</span>
-                    <div className="relative min-w-[14rem] flex-1">
-                      <select
-                        value={category}
-                        onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
-                        className="w-full appearance-none rounded-md border border-zinc-700 bg-[#22262e] px-3 py-2 pr-8 text-sm text-zinc-100 outline-none transition focus:border-sky-400/55"
-                      >
-                        {queueCategories.map((item) => (
-                          <option
-                            key={item.value}
-                            value={item.value}
-                            disabled={"disabled" in item ? item.disabled : false}
-                          >
-                            {item.label}
-                          </option>
-                        ))}
-                      </select>
-                      <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-400">
-                        ▾
-                      </span>
-                    </div>
-                    <span className="text-zinc-500">;</span>
+              <div className="flex-1 overflow-y-auto bg-[#1e1f22]">
+                <div className="grid grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono text-sm">
+                  <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
+                    {editorLineNumbers.map((line) => (
+                      <div key={line} className="h-8 leading-8">
+                        {line}
+                      </div>
+                    ))}
                   </div>
-                </label>
-
-                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
-                  <span className="font-mono text-xs text-zinc-500">3</span>
-                  <div className="space-y-2">
-                    <p className="font-mono text-sm">
-                      <span className="text-sky-300">const</span>{" "}
-                      <span className="text-zinc-200">difficulty =</span>
-                    </p>
-                    <div className="grid gap-2 md:grid-cols-3">
-                      {difficultyOptions.map((option) => (
-                        <label
-                          key={option.value}
-                          className={`flex cursor-pointer items-center justify-center rounded-md border px-3 py-2 text-sm transition ${
-                            difficulty === option.value
-                              ? "border-sky-300/40 bg-sky-500 text-zinc-950"
-                              : "border-zinc-700 bg-[#22262e] text-zinc-100 hover:border-sky-400/45 hover:bg-sky-500/10"
-                          }`}
+                  <div className="px-4 py-4 text-[#a9b7c6]">
+                    <div className="h-8 whitespace-nowrap leading-8">
+                      <span className="text-[#cc7832]">enum</span> MatchLevel {"{"} EASY, MEDIUM, HARD {"}"}
+                    </div>
+                    <div className="h-8 whitespace-nowrap leading-8">
+                      <span className="text-[#cc7832]">public</span> <span className="text-[#cc7832]">class</span>{" "}
+                      <span className="text-[#56a8f5]">QueueDemo</span> {"{"}
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      <span className="text-[#cc7832]">public static void</span>{" "}
+                      <span className="text-[#56a8f5]">main</span>(String[] args) {"{"}
+                    </div>
+                    <div className="flex min-h-8 flex-wrap items-center gap-2 pl-4 leading-8">
+                      <span className="text-[#cc7832]">String</span> tag ={" "}
+                      <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
+                        <select
+                          value={category}
+                          onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
+                          className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#a9b7c6] outline-none transition focus:border-[#4e89ff]/70"
                         >
-                          <input
-                            type="radio"
-                            name="difficulty"
-                            value={option.value}
-                            checked={difficulty === option.value}
-                            onChange={() => setDifficulty(option.value)}
-                            className="sr-only"
-                          />
-                          <span>{option.label}</span>
-                        </label>
+                          {queueCategories.map((item) => (
+                            <option
+                              key={item.value}
+                              value={item.value}
+                              disabled={"disabled" in item ? item.disabled : false}
+                            >
+                              {item.label}
+                            </option>
+                          ))}
+                        </select>
+                        <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-500">
+                          ▾
+                        </span>
+                      </div>
+                      <span>);</span>
+                    </div>
+                    <div className="flex min-h-8 flex-wrap items-center gap-2 pl-4 leading-8">
+                      <span>MatchLevel level = MatchLevel.</span>
+                      <div className="flex flex-wrap gap-1 leading-none">
+                        {difficultyOptions.map((option) => (
+                          <label
+                            key={option.value}
+                            className={`rounded-sm border px-2 py-1 text-xs transition ${
+                              difficulty === option.value
+                                ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#a9c7ff]"
+                                : "border-zinc-700 bg-[#2b2d30] text-[#a9b7c6] hover:bg-zinc-700/40"
+                            }`}
+                          >
+                            <input
+                              type="radio"
+                              name="difficulty"
+                              value={option.value}
+                              checked={difficulty === option.value}
+                              onChange={() => setDifficulty(option.value)}
+                              className="sr-only"
+                            />
+                            {option.label.toUpperCase()}
+                          </label>
+                        ))}
+                      </div>
+                      <span>;</span>
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      <span className="text-[#cc7832]">int</span> partySize = <span className="text-[#6897bb]">4</span>;
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      <span className="text-[#cc7832]">String</span> preview = <span className="text-[#6aab73]">"["</span> + level + <span className="text-[#6aab73]">"] "</span> + tag;
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      preview += <span className="text-[#6aab73]">" queue started ("</span> + partySize + <span className="text-[#6aab73]">"/4)"</span>;
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      System.out.<span className="text-[#56a8f5]">println</span>(preview);
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">
+                      <span className="text-[#cc7832]">boolean</span> searching = <span className="text-[#6897bb]">true</span>;
+                    </div>
+                    <div className="h-8 whitespace-nowrap pl-4 leading-8">{"}"}</div>
+                    <div className="h-8 whitespace-nowrap leading-8">{"}"}</div>
+
+                    <div className="mt-2 h-8 leading-8 text-[#6a717d]">
+                      {modalMode === "SEARCHING" ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void handleCancelMatch();
+                          }}
+                          disabled={isBusy}
+                          className="rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 py-0.5 text-xs text-zinc-100 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
+                        >
+                          stopQueue();
+                        </button>
+                      ) : (
+                        "// press start to run the queue demo"
+                      )}
+                    </div>
+                    <div
+                      className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
+                        error
+                          ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                          : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                      }`}
+                    >
+                      {error ?? terminalMessage ?? feedback}
+                    </div>
+                    <div className="mt-2 space-y-0">
+                      {editorLineNumbers.slice(12).map((line) => (
+                        <div key={`filler-${line}`} className="h-8 leading-8">
+                          <span className="opacity-0">.</span>
+                        </div>
                       ))}
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+          </main>
 
-                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-center gap-3">
-                  <span className="font-mono text-xs text-zinc-500">4</span>
-                  {modalMode === "SEARCHING" ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void handleCancelMatch();
-                      }}
-                      disabled={isBusy}
-                      className="w-fit rounded-md border border-zinc-700 bg-[#22262e] px-4 py-2 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
-                    >
-                      매칭 취소
-                    </button>
-                  ) : (
-                    <p className="font-mono text-sm text-zinc-500">/* cancel disabled */</p>
-                  )}
+          <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
+            <div className="grid h-full grid-cols-[minmax(0,1fr)_38px]">
+              <div className="min-h-0">
+                <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
+                  <p className="text-sm font-semibold text-zinc-200">프로필</p>
+                  <span className="text-xs text-zinc-500">⚙</span>
                 </div>
+                <div className="h-full overflow-y-auto p-3 text-xs text-zinc-300">
+                  <div className="rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+                    <div className="flex items-center justify-between">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        계정
+                      </p>
+                      <StatusPill tone={session.authenticated ? "success" : "warn"}>
+                        {session.authenticated ? "로그인됨" : "게스트"}
+                      </StatusPill>
+                    </div>
+                    <div className="mt-3 space-y-1">
+                      <p className="text-base font-semibold text-zinc-100">
+                        {session.member?.nickname ?? "게스트"}
+                      </p>
+                      <p className="text-zinc-400">
+                        {session.authenticated
+                          ? formatRoleLabel(session.member?.role)
+                          : "로그인이 필요합니다."}
+                      </p>
+                    </div>
+                  </div>
 
-                <div className="grid grid-cols-[1.6rem_minmax(0,1fr)] items-start gap-3">
-                  <span className="font-mono text-xs text-zinc-500">5</span>
-                  <div
-                    className={`rounded-md border px-3 py-2 text-sm ${
-                      error
-                        ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                        : "border-zinc-700 bg-[#1a1d24] text-zinc-200"
-                    }`}
-                  >
-                    {error ?? terminalMessage ?? feedback}
+                  <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      전적 요약
+                    </p>
+                    {session.authenticated ? (
+                      <>
+                        <div className="mt-2 grid grid-cols-2 gap-2">
+                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                            <p className="text-[10px] text-zinc-500">최근 경기</p>
+                            <p className="text-sm font-semibold text-zinc-100">{previewPlayedCount}</p>
+                          </div>
+                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                            <p className="text-[10px] text-zinc-500">클리어</p>
+                            <p className="text-sm font-semibold text-zinc-100">{previewSolvedCount}</p>
+                          </div>
+                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                            <p className="text-[10px] text-zinc-500">승률</p>
+                            <p className="text-sm font-semibold text-zinc-100">{previewWinRate ?? 0}%</p>
+                          </div>
+                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                            <p className="text-[10px] text-zinc-500">점수 변화</p>
+                            <p className="text-sm font-semibold text-zinc-100">{previewScoreDeltaLabel}</p>
+                          </div>
+                        </div>
+                        <p
+                          className={`mt-2 text-[11px] ${
+                            resultsPreviewError ? "text-rose-300" : "text-zinc-500"
+                          }`}
+                        >
+                          {resultsPreviewError ?? resultsPreviewMessage}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="mt-2 text-[11px] text-zinc-500">
+                        로그인 후 전적 요약을 확인할 수 있습니다.
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="mt-4 space-y-2 font-sans">
+                    {session.authenticated ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => handleProtectedMove("/mypage")}
+                          className="w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                        >
+                          내 프로필
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleLogout}
+                          disabled={isBusy}
+                          className="w-full rounded-md bg-[#9146ff] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                        >
+                          로그아웃
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <Link
+                          href="/signup"
+                          className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                        >
+                          회원가입
+                        </Link>
+                        <Link
+                          href="/login?next=/"
+                          className="block w-full rounded-md bg-[#9146ff] px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                        >
+                          로그인
+                        </Link>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
 
-          <aside className="space-y-4 rounded-xl border border-zinc-700 bg-[#1f222a] p-4 text-zinc-100 md:col-span-2 md:min-h-0 md:overflow-y-auto lg:col-span-1">
-            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
-              <p className="text-xs font-semibold text-zinc-400">Database</p>
-              <div className="mt-2 space-y-1 font-mono text-xs text-zinc-300">
-                <p className="px-1 text-zinc-400">▾ back@localhost</p>
-                <p className="pl-4 text-zinc-400">▾ schemas</p>
-                <p className="pl-7 text-zinc-400">▾ public</p>
-                <p className="rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5 pl-10">▾ members</p>
-                <p className="pl-14 text-zinc-500">member_id</p>
-                <p className="pl-14 text-zinc-500">email</p>
-                <p className="pl-14 text-zinc-500">nickname</p>
-                <p className="pl-14 text-zinc-500">role</p>
-                <p className="pl-14 text-zinc-500">score</p>
-              </div>
-            </div>
-
-            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
-              <p className="font-mono text-xs text-zinc-400">members.selected_row</p>
-              <dl className="mt-2 space-y-2 text-xs">
-                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
-                  <dt className="font-mono text-zinc-500">member_id</dt>
-                  <dd className="font-mono text-zinc-200">{session.member?.memberId ?? "NULL"}</dd>
+              <div className="flex min-h-0 flex-col items-center justify-between border-l border-zinc-800/90 bg-[#25272d] py-2">
+                <div className="flex flex-col items-center gap-2">
+                  {ideDbRailTopItems.map((item) => (
+                    <button
+                      key={item.title}
+                      type="button"
+                      title={item.title}
+                      aria-label={item.title}
+                      className={`h-8 w-8 rounded-md border transition ${
+                        item.active
+                          ? "border-[#2f77ff] bg-[#2f77ff] text-white shadow-[0_0_0_1px_rgba(80,130,255,0.35)]"
+                          : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-200"
+                      }`}
+                    >
+                      <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
+                    </button>
+                  ))}
                 </div>
-                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
-                  <dt className="font-mono text-zinc-500">nickname</dt>
-                  <dd className="font-mono text-zinc-200">{session.member?.nickname ?? "guest"}</dd>
+                <div className="flex flex-col items-center gap-2">
+                  {ideDbRailBottomItems.map((item) => (
+                    <button
+                      key={item.title}
+                      type="button"
+                      title={item.title}
+                      aria-label={item.title}
+                      className="h-8 w-8 rounded-md border border-transparent text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-200"
+                    >
+                      <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
+                    </button>
+                  ))}
                 </div>
-                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
-                  <dt className="font-mono text-zinc-500">role</dt>
-                  <dd className="font-mono text-zinc-200">{formatRoleLabel(session.member?.role)}</dd>
-                </div>
-                <div className="flex items-center justify-between rounded-md border border-zinc-700 bg-[#22262e] px-2 py-1.5">
-                  <dt className="font-mono text-zinc-500">recent_win_rate</dt>
-                  <dd className="font-mono text-zinc-200">{session.authenticated ? `${previewWinRate ?? 0}%` : "NULL"}</dd>
-                </div>
-              </dl>
-            </div>
-
-            <div className="grid gap-2">
-              {session.authenticated ? (
-                <>
-                  <button
-                    type="button"
-                    onClick={() => handleProtectedMove("/mypage")}
-                    className="rounded-lg border border-zinc-700 bg-[#22262e] px-3 py-2 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10"
-                  >
-                    내 프로필
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleLogout}
-                    disabled={isBusy}
-                    className="rounded-lg bg-sky-500 px-3 py-2 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
-                  >
-                    로그아웃
-                  </button>
-                </>
-              ) : (
-                <>
-                  <Link
-                    href="/signup"
-                    className="rounded-lg border border-zinc-700 bg-[#22262e] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10"
-                  >
-                    회원가입
-                  </Link>
-                  <Link
-                    href="/login?next=/"
-                    className="rounded-lg bg-sky-500 px-3 py-2 text-center text-sm font-semibold text-zinc-950 transition hover:bg-sky-400"
-                  >
-                    로그인
-                  </Link>
-                </>
-              )}
-            </div>
-
-            <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] p-3">
-              <p className="font-mono text-xs text-zinc-400">query_preview</p>
-              <div className="mt-2 space-y-1 text-sm text-zinc-200">
-                {session.authenticated ? (
-                  <>
-                    <p>최근 {previewPlayedCount}전 승률: {previewWinRate ?? 0}%</p>
-                    <p>최근 정답 수: {previewSolvedCount}</p>
-                    <p>
-                      최근 점수 변화 합계: {previewScoreDelta > 0 ? "+" : ""}
-                      {previewScoreDelta}
-                    </p>
-                  </>
-                ) : (
-                  <p>로그인 후 전적 미리보기를 확인할 수 있습니다.</p>
-                )}
-              </div>
-              <div
-                className={`mt-3 rounded-md border px-3 py-2 text-xs ${
-                  resultsPreviewError
-                    ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                    : "border-zinc-700 bg-[#22262e] text-zinc-300"
-                }`}
-              >
-                {resultsPreviewError ?? resultsPreviewMessage}
               </div>
             </div>
           </aside>

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -18,6 +18,7 @@ import {
   StatusPill,
 } from "@/shared/ui";
 import { formatDateTime } from "@/shared/utils/format-date-time";
+import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
 const PAGE_SIZE = 20;
 
@@ -317,7 +318,7 @@ export default function MyPageScreen() {
                 이메일: {session.member?.email}
               </div>
               <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-                역할: {session.member?.role}
+                역할: {formatRoleLabel(session.member?.role)}
               </div>
               <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
                 전적 상태: {error ?? message}

--- a/src/shared/ui/page-hero.tsx
+++ b/src/shared/ui/page-hero.tsx
@@ -5,23 +5,37 @@ export function PageHero({
   title,
   description,
   actions,
+  className = "",
+  tone = "default",
 }: {
   eyebrow: string;
   title: string;
   description: string;
   actions?: ReactNode;
+  className?: string;
+  tone?: "default" | "dark";
 }) {
+  const rootToneClass =
+    tone === "dark"
+      ? "border-zinc-700 bg-zinc-900 text-zinc-100"
+      : "border-zinc-300 bg-white text-zinc-950";
+  const eyebrowToneClass = tone === "dark" ? "text-zinc-400" : "text-zinc-500";
+  const titleToneClass = tone === "dark" ? "text-zinc-50" : "text-zinc-950";
+  const descriptionToneClass = tone === "dark" ? "text-zinc-300" : "text-zinc-600";
+
   return (
-    <section className="rounded-3xl border border-zinc-300 bg-white p-6 shadow-sm sm:p-8">
-      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-zinc-500">
+    <section
+      className={`rounded-3xl border p-6 shadow-sm sm:p-8 ${rootToneClass} ${className}`.trim()}
+    >
+      <p className={`text-xs font-semibold uppercase tracking-[0.22em] ${eyebrowToneClass}`}>
         {eyebrow}
       </p>
       <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="max-w-3xl">
-          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 sm:text-4xl">
+          <h1 className={`text-3xl font-semibold tracking-tight sm:text-4xl ${titleToneClass}`}>
             {title}
           </h1>
-          <p className="mt-3 text-sm leading-7 text-zinc-600 sm:text-base">
+          <p className={`mt-3 text-sm leading-7 sm:text-base ${descriptionToneClass}`}>
             {description}
           </p>
         </div>

--- a/src/shared/utils/format-role-label.ts
+++ b/src/shared/utils/format-role-label.ts
@@ -1,0 +1,12 @@
+const ROLE_LABELS: Record<string, string> = {
+  ROLE_USER: "일반사용자",
+  ROLE_ADMIN: "관리자",
+};
+
+export function formatRoleLabel(role?: string | null) {
+  if (!role) {
+    return "로그인 필요";
+  }
+
+  return ROLE_LABELS[role] ?? role;
+}


### PR DESCRIPTION
## 작업 개요

- 메인(`/`) 화면을 IDE 컨셉으로 재구성하고, iPad/QHD를 포함한 반응형 레이아웃 동작을 정리했습니다.
- 좌/우 패널 토글, 코드 패널 가독성, 상단/하단 여백 정렬 등 메인 화면 UX를 전체적으로 정비했습니다.

## 영향 범위

- route: `/`
- feature: `home screen` (메인 레이아웃/IDE UI/매칭 설정 영역)
- api/bff: 없음

## 작업 내용

- [x] 메인 화면 IDE 스타일 레이아웃 구성/정리
- [x] iPad/QHD 기준 컬럼 폭 및 반응형 브레이크포인트 조정
- [x] 코드 패널 line 수/line-height/font-size 반응형 처리
- [x] 좌측 `Project` 아이콘으로 퀵메뉴 패널 토글
- [x] 우측 `Database` 아이콘으로 프로필 패널 토글
- [x] 안내 문구를 `# TODO:` 형태로 정리 및 강조 색상 통일

## 변경 사항

- 메인 컨테이너를 브라우저 폭 기준으로 확장하고, 카드형 외곽 스타일(라운드/쉐도우) 의존을 줄여 화면 밀도를 개선했습니다.
- 레이아웃 계산 기준을 `--app-header-h` 변수로 통일해 상단 헤더/본문 높이 정렬을 안정화했습니다.
- 좌/우 패널 상태(`isQuickMenuOpen`, `isProfilePanelOpen`)에 따라 그리드 컬럼이 동적으로 재계산되도록 변경했습니다.
- IDE rail active 상태를 실제 패널 열림/닫힘 상태와 동기화했습니다.
- 중앙 코드 패널의 안내 문구를 사용자 친화 문장으로 유지하면서 `# TODO:` 시각 강조를 적용했습니다.

## 테스트 및 확인

- [ ] `npm run lint` (현재 저장소 ESLint 설정 import 경로 이슈로 실행 실패)
- [x] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #23

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 없음
