### PR TITLE
[refactor] 인증/문제/마이페이지 IDE 톤 통일

### DIFF
--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import {
+  fetchBackend,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
+
+interface BackendTagItem {
+  code?: string;
+  label?: string;
+  value?: string;
+  name?: string;
+}
+
+interface TagOption {
+  value: string;
+  label: string;
+}
+
+function normalizeTags(payload: unknown): TagOption[] {
+  const source = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === "object" && "data" in payload
+      ? (payload as { data?: unknown }).data
+      : null;
+
+  if (!Array.isArray(source)) {
+    return [];
+  }
+
+  const mapped = source
+    .map((item) => {
+      if (typeof item === "string") {
+        return {
+          value: item.trim(),
+          label: item.trim(),
+        };
+      }
+
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+
+      const candidate = item as BackendTagItem;
+      const value = (candidate.code ?? candidate.value ?? candidate.name ?? "").trim();
+      const label = (candidate.label ?? candidate.name ?? candidate.code ?? value).trim();
+
+      if (!value || !label) {
+        return null;
+      }
+
+      return { value, label };
+    })
+    .filter((item): item is TagOption => item !== null);
+
+  const deduped: TagOption[] = [];
+  const seen = new Set<string>();
+
+  for (const item of mapped) {
+    const key = item.value.toLowerCase();
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
+
+  if (!token) {
+    return NextResponse.json([] as TagOption[]);
+  }
+
+  try {
+    const response = await fetchBackend("/api/v1/tags", { token });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return NextResponse.json([] as TagOption[]);
+      }
+
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    const body = await readJsonBody<unknown>(response);
+    return NextResponse.json(normalizeTags(body));
+  } catch {
+    return NextResponse.json([] as TagOption[]);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,15 +24,6 @@ export const metadata: Metadata = {
     "실제 백엔드 API와 화면 구조를 맞추는 Algo Battle 프론트엔드.",
 };
 
-const navigation = [
-  { href: "/", label: "메인" },
-  { href: "/problems", label: "문제목록" },
-  { href: "/login", label: "로그인" },
-  { href: "/signup", label: "회원가입" },
-  { href: "/mypage", label: "마이페이지" },
-  { href: "/spectate", label: "관전" },
-];
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -46,21 +37,10 @@ export default function RootLayout({
       <body className="min-h-full">
         <div className="flex min-h-screen flex-col bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
           <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
-            <div className="mx-auto flex h-full w-full max-w-7xl items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+            <div className="mx-auto flex h-full w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
               <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
                 BRACKET {"{}"}
               </Link>
-              <nav className="flex flex-wrap items-center justify-end gap-1.5">
-                {navigation.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className="rounded-full border border-zinc-700 bg-zinc-900/60 px-2.5 py-1 text-xs text-zinc-300 transition hover:border-violet-300/70 hover:bg-violet-500/20 hover:text-zinc-100"
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </nav>
             </div>
           </header>
           <main className="flex min-h-0 flex-1">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "katex/dist/katex.min.css";
+import IdeShell from "@/features/layout/ide-shell";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -43,7 +44,7 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full">
-        <div className="min-h-screen bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
+        <div className="flex min-h-screen flex-col bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
           <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
             <div className="mx-auto flex h-full w-full max-w-7xl items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
               <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
@@ -62,8 +63,8 @@ export default function RootLayout({
               </nav>
             </div>
           </header>
-          <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-4 sm:px-6 lg:px-8">
-            {children}
+          <main className="flex min-h-0 flex-1">
+            <IdeShell>{children}</IdeShell>
           </main>
         </div>
       </body>

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -1,0 +1,273 @@
+import Link from "next/link";
+
+import type { SessionResponse } from "@/shared/api/contracts";
+import { StatusPill } from "@/shared/ui";
+import { formatRoleLabel } from "@/shared/utils/format-role-label";
+
+const ideDbRailTopItems = [
+  { icon: "notifications", title: "알림" },
+  { icon: "search", title: "검색" },
+  { icon: "database", title: "데이터베이스" },
+  { icon: "gamepad", title: "게임" },
+  { icon: "blocks", title: "서비스" },
+  { icon: "docs", title: "문서" },
+  { icon: "users", title: "사용자" },
+  { icon: "cloud", title: "클라우드" },
+  { icon: "link", title: "연결" },
+];
+
+const ideDbRailBottomItems = [{ icon: "hammer", title: "도구" }];
+
+function renderDbRailIcon(name: string) {
+  const baseClass = "h-4 w-4";
+
+  switch (name) {
+    case "notifications":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M8 3a3 3 0 0 0-3 3v2.2l-1 1.6h8l-1-1.6V6a3 3 0 0 0-3-3Z" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="12.2" cy="3.8" r="1.4" fill="#ff5f6d" />
+        </svg>
+      );
+    case "search":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="7" cy="7" r="3.6" stroke="currentColor" strokeWidth="1.2" />
+          <path d="m10 10 3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case "database":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <ellipse cx="8" cy="4.1" rx="4.7" ry="2" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M3.3 4.1v4.8c0 1.1 2.1 2 4.7 2s4.7-.9 4.7-2V4.1" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "gamepad":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <rect x="3" y="6.2" width="10" height="5.8" rx="2.2" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M5.4 9h2.2M6.5 7.9v2.2M10.6 8.4h.01M11.8 9.6h.01" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case "blocks":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <rect x="2.4" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+          <rect x="8.8" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+          <rect x="5.6" y="8.8" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "docs":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M9 2.5V6h3M5.2 8.2h5.6M5.2 10.2h5.6" stroke="currentColor" strokeWidth="1.1" />
+        </svg>
+      );
+    case "users":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="6.1" cy="6.1" r="2.1" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="11.1" cy="6.7" r="1.6" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M3.4 12c.5-1.7 1.6-2.7 2.9-2.7s2.4 1 2.9 2.7M9 12.1c.4-1.3 1.2-2.1 2.2-2.1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case "cloud":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M4.8 11.8h6a2.2 2.2 0 1 0-.4-4.4 3.1 3.1 0 0 0-5.9.8 1.9 1.9 0 0 0 .3 3.6Z" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "link":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M6.5 9.5 9.5 6.5M5.3 11a2.3 2.3 0 0 1 0-3.2l1.5-1.5a2.3 2.3 0 1 1 3.2 3.2l-.6.6M10.7 5a2.3 2.3 0 0 1 0 3.2l-1.5 1.5a2.3 2.3 0 1 1-3.2-3.2l.6-.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case "hammer":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="m9.2 3.2 3.1 3.1M4.1 12.2 9.9 6.4 7.6 4.1 1.8 9.9l2.3 2.3Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+interface ProfilePaneProps {
+  isProfilePanelOpen: boolean;
+  onToggleProfilePanel: () => void;
+  session: SessionResponse;
+  previewPlayedCount: number;
+  previewSolvedCount: number;
+  previewWinRate: number;
+  previewScoreDeltaLabel: string;
+  resultsPreviewMessage: string;
+  resultsPreviewError: string | null;
+  isBusy: boolean;
+  onLogout: () => void;
+}
+
+export default function ProfilePane({
+  isProfilePanelOpen,
+  onToggleProfilePanel,
+  session,
+  previewPlayedCount,
+  previewSolvedCount,
+  previewWinRate,
+  previewScoreDeltaLabel,
+  resultsPreviewMessage,
+  resultsPreviewError,
+  isBusy,
+  onLogout,
+}: ProfilePaneProps) {
+  return (
+    <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
+      <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
+        <div className={`min-h-0 ${isProfilePanelOpen ? "block" : "hidden"}`}>
+          <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
+            <p className="text-sm font-semibold text-zinc-200">프로필</p>
+          </div>
+          <div className="h-full overflow-y-auto p-3 text-xs text-zinc-300">
+            <div className="rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  계정
+                </p>
+                <StatusPill tone={session.authenticated ? "success" : "warn"}>
+                  {session.authenticated ? "로그인됨" : "게스트"}
+                </StatusPill>
+              </div>
+              <div className="mt-3 space-y-1">
+                <p className="text-base font-semibold text-zinc-100">
+                  {session.member?.nickname ?? "게스트"}
+                </p>
+                <p className="text-zinc-400">
+                  {session.authenticated
+                    ? formatRoleLabel(session.member?.role)
+                    : "로그인이 필요합니다."}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                전적 요약
+              </p>
+              {session.authenticated ? (
+                <>
+                  <div className="mt-2 grid grid-cols-2 gap-2">
+                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                      <p className="text-[10px] text-zinc-500">최근 경기</p>
+                      <p className="text-sm font-semibold text-zinc-100">{previewPlayedCount}</p>
+                    </div>
+                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                      <p className="text-[10px] text-zinc-500">클리어</p>
+                      <p className="text-sm font-semibold text-zinc-100">{previewSolvedCount}</p>
+                    </div>
+                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                      <p className="text-[10px] text-zinc-500">승률</p>
+                      <p className="text-sm font-semibold text-zinc-100">{previewWinRate}%</p>
+                    </div>
+                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                      <p className="text-[10px] text-zinc-500">점수 변화</p>
+                      <p className="text-sm font-semibold text-zinc-100">{previewScoreDeltaLabel}</p>
+                    </div>
+                  </div>
+                  <p
+                    className={`mt-2 text-[11px] ${
+                      resultsPreviewError ? "text-rose-300" : "text-zinc-500"
+                    }`}
+                  >
+                    {resultsPreviewError ?? resultsPreviewMessage}
+                  </p>
+                </>
+              ) : (
+                <p className="mt-2 text-[11px] text-zinc-500">
+                  로그인 후 전적 요약을 확인할 수 있습니다.
+                </p>
+              )}
+            </div>
+
+            <div className="mt-4 space-y-2 font-sans">
+              {session.authenticated ? (
+                <>
+                  <Link
+                    href="/mypage"
+                    className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                  >
+                    내 프로필
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={onLogout}
+                    disabled={isBusy}
+                    className="w-full rounded-md bg-[#9146ff] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                  >
+                    로그아웃
+                  </button>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/signup"
+                    className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                  >
+                    회원가입
+                  </Link>
+                  <Link
+                    href="/login?next=/"
+                    className="block w-full rounded-md bg-[#9146ff] px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                  >
+                    로그인
+                  </Link>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-col items-center justify-between border-l border-zinc-800/90 bg-[#25272d] py-2">
+          <div className="flex flex-col items-center gap-2">
+            {ideDbRailTopItems.map((item) => (
+              <button
+                key={item.title}
+                type="button"
+                onClick={() => {
+                  if (item.icon === "database") {
+                    onToggleProfilePanel();
+                  }
+                }}
+                title={item.title}
+                aria-label={item.title}
+                className={`h-8 w-8 rounded-md border transition ${
+                  item.icon === "database" && isProfilePanelOpen
+                    ? "border-[#2f77ff] bg-[#2f77ff] text-white shadow-[0_0_0_1px_rgba(80,130,255,0.35)]"
+                    : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-200"
+                }`}
+              >
+                <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
+              </button>
+            ))}
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            {ideDbRailBottomItems.map((item) => (
+              <button
+                key={item.title}
+                type="button"
+                title={item.title}
+                aria-label={item.title}
+                className="h-8 w-8 rounded-md border border-transparent text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-200"
+              >
+                <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -1,0 +1,218 @@
+import type { CSSProperties, RefObject } from "react";
+
+import type { Difficulty } from "@/shared/api/contracts";
+
+import type { QueueCategoryOption, QueueCategoryValue } from "../data";
+
+interface QueueEditorPaneProps {
+  editorPaneRef: RefObject<HTMLDivElement | null>;
+  editorContentStyle: CSSProperties;
+  editorLineNumbers: number[];
+  editorLineStyle: CSSProperties;
+  editorRowStyle: CSSProperties;
+  canStartMatch: boolean;
+  onStartMatch: () => void;
+  category: QueueCategoryValue;
+  onCategoryChange: (nextCategory: QueueCategoryValue) => void;
+  categoryOptions: QueueCategoryOption[];
+  difficulty: Difficulty;
+  onDifficultyChange: (nextDifficulty: Difficulty) => void;
+  difficultyOptions: Array<{ value: Difficulty; label: string }>;
+  queueMemo: string;
+  onQueueMemoChange: (nextMemo: string) => void;
+  showStopQueueButton: boolean;
+  onCancelQueue: () => void;
+  isBusy: boolean;
+  error: string | null;
+  terminalMessage: string | null;
+}
+
+export default function QueueEditorPane({
+  editorPaneRef,
+  editorContentStyle,
+  editorLineNumbers,
+  editorLineStyle,
+  editorRowStyle,
+  canStartMatch,
+  onStartMatch,
+  category,
+  onCategoryChange,
+  categoryOptions,
+  difficulty,
+  onDifficultyChange,
+  difficultyOptions,
+  queueMemo,
+  onQueueMemoChange,
+  showStopQueueButton,
+  onCancelQueue,
+  isBusy,
+  error,
+  terminalMessage,
+}: QueueEditorPaneProps) {
+  return (
+    <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+          <div className="flex h-full items-end gap-0.5 pt-1">
+            <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+              <span className="inline-flex h-4 w-4 items-center justify-center text-[#7da2f7]">
+                <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                  <path
+                    d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                  />
+                  <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+                  <circle cx="6.4" cy="10.8" r="0.7" fill="currentColor" />
+                </svg>
+              </span>
+              <span>.env</span>
+              <span className="text-zinc-500">×</span>
+              <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onStartMatch}
+            disabled={!canStartMatch}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-3 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
+            aria-label="매칭 시작"
+          >
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#7dd48c]">
+              <path
+                d="M8 2.3v3M5 3.4A4.9 4.9 0 1 0 11 3.4"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinecap="round"
+              />
+            </svg>
+            <span>매칭 시작</span>
+            <span className="mx-0.5 h-4 w-px bg-white/35" />
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#74cc84]">
+              <path d="m6 4 5 4-5 4V4Z" fill="currentColor" />
+            </svg>
+          </button>
+        </div>
+
+        <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-[#1e1f22]">
+          <div
+            className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono"
+            style={editorContentStyle}
+          >
+            <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
+              {editorLineNumbers.map((line) => (
+                <div key={line} style={editorLineStyle}>
+                  {line}
+                </div>
+              ))}
+            </div>
+            <div className="px-4 py-4 text-[#a9b7c6]">
+              <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
+                # queue config
+              </div>
+              <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
+                <span className="font-semibold text-[#ffcc66]"># TODO:</span>
+                <span className="text-[#ffcc66]">
+                  {" "}
+                  카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
+                </span>
+              </div>
+              <div className="flex items-center gap-2" style={editorRowStyle}>
+                <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
+                <span className="text-[#80889a]">=</span>
+                <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
+                  <select
+                    value={category}
+                    onChange={(event) => onCategoryChange(event.target.value as QueueCategoryValue)}
+                    className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
+                  >
+                    {categoryOptions.map((item) => (
+                      <option
+                        key={item.value}
+                        value={item.value}
+                        disabled={"disabled" in item ? item.disabled : false}
+                      >
+                        {item.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-500">
+                    ▾
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2" style={editorRowStyle}>
+                <span className="w-40 text-[#9cdcfe]">QUEUE_LEVEL</span>
+                <span className="text-[#80889a]">=</span>
+                <div className="flex flex-wrap gap-1 leading-none">
+                  {difficultyOptions.map((option) => (
+                    <label
+                      key={option.value}
+                      className={`rounded-sm border px-2 py-1 text-xs transition ${
+                        difficulty === option.value
+                          ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#dcdcaa]"
+                          : "border-zinc-700 bg-[#2b2d30] text-[#9aa5b1] hover:bg-zinc-700/40"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="difficulty"
+                        value={option.value}
+                        checked={difficulty === option.value}
+                        onChange={() => onDifficultyChange(option.value)}
+                        className="sr-only"
+                      />
+                      {option.label.toUpperCase()}
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center gap-2" style={editorRowStyle}>
+                <span className="w-40 text-[#9cdcfe]">QUEUE_PARTY_SIZE</span>
+                <span className="text-[#80889a]">=</span>
+                <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#b5cea8]">
+                  4
+                </span>
+              </div>
+              <div className="flex items-start gap-2" style={editorRowStyle}>
+                <span className="w-40 text-[#9cdcfe]">QUEUE_MEMO</span>
+                <span className="pt-1 text-[#80889a]">=</span>
+                <input
+                  type="text"
+                  value={queueMemo}
+                  onChange={(event) => onQueueMemoChange(event.target.value)}
+                  className="mt-0.5 h-7 w-full rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
+                />
+              </div>
+
+              <div className="mt-2 text-[#6a717d]" style={editorLineStyle}>
+                {showStopQueueButton ? (
+                  <button
+                    type="button"
+                    onClick={onCancelQueue}
+                    disabled={isBusy}
+                    className="rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 py-0.5 text-xs text-zinc-100 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
+                  >
+                    stopQueue();
+                  </button>
+                ) : null}
+              </div>
+              {error || terminalMessage ? (
+                <div
+                  className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
+                    error
+                      ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
+                      : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                  }`}
+                >
+                  {error ?? terminalMessage}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -66,7 +66,7 @@ export default function QueueEditorPane({
                   <circle cx="6.4" cy="10.8" r="0.7" fill="currentColor" />
                 </svg>
               </span>
-              <span>.env</span>
+              <span>.env.queue.match</span>
               <span className="text-zinc-500">×</span>
               <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
             </div>
@@ -215,4 +215,3 @@ export default function QueueEditorPane({
     </main>
   );
 }
-

--- a/src/features/home/components/quick-menu-pane.tsx
+++ b/src/features/home/components/quick-menu-pane.tsx
@@ -1,0 +1,306 @@
+import Link from "next/link";
+
+export type QuickMenuTreeIcon =
+  | "root"
+  | "folder"
+  | "folderAccent"
+  | "package"
+  | "class"
+  | "file"
+  | "fileAccent";
+
+export interface QuickMenuTreeItem {
+  key: string;
+  label: string;
+  depth: number;
+  icon: QuickMenuTreeIcon;
+  hasChildren?: boolean;
+  expanded?: boolean;
+  subtitle?: string;
+  rowTone?: "amber" | "green" | "selected";
+  href?: string;
+}
+
+const ideRailTopItems = [
+  { icon: "project", title: "Project" },
+  { icon: "sliders", title: "Services" },
+  { icon: "branch", title: "Git" },
+  { icon: "layout", title: "Layout" },
+  { icon: "more", title: "More" },
+];
+
+const ideRailBottomItems = [
+  { icon: "cube", title: "AI" },
+  { icon: "tools", title: "Tools" },
+  { icon: "play", title: "Run" },
+  { icon: "terminal", title: "Terminal" },
+  { icon: "issue", title: "Problems" },
+  { icon: "nodes", title: "Connections" },
+];
+
+function renderRailIcon(name: string) {
+  const baseClass = "h-4 w-4";
+
+  switch (name) {
+    case "project":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path
+            d="M2 4.5h4l1.1 1.2H14v6.8a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5v-8Z"
+            stroke="currentColor"
+            strokeWidth="1.3"
+          />
+          <path d="M2.2 6h11.6" stroke="currentColor" strokeWidth="1.1" />
+        </svg>
+      );
+    case "sliders":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path
+            d="M2 5.2h12M2 10.8h12"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+          />
+          <circle cx="6" cy="5.2" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="10" cy="10.8" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "branch":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="4" cy="3.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="11.8" cy="6.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="8.2" cy="12.2" r="1.3" stroke="currentColor" strokeWidth="1.2" />
+          <path
+            d="M5.3 4.4c2 .2 3.4.7 4.8 1.6M11 8c-.5 1.5-1.3 2.4-2.2 3.2"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "layout":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <rect x="2.2" y="2.2" width="11.6" height="11.6" rx="1.6" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M2.2 7.8h11.6M7.8 2.2v11.6" stroke="currentColor" strokeWidth="1.1" />
+        </svg>
+      );
+    case "more":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="4" cy="8" r="1" fill="currentColor" />
+          <circle cx="8" cy="8" r="1" fill="currentColor" />
+          <circle cx="12" cy="8" r="1" fill="currentColor" />
+        </svg>
+      );
+    case "cube":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M8 2.4 12.8 5v6L8 13.6 3.2 11V5L8 2.4Z" stroke="currentColor" strokeWidth="1.1" />
+          <path d="m8 2.4 4.8 2.6L8 7.5 3.2 5 8 2.4ZM8 7.5V13.6" stroke="currentColor" strokeWidth="1.1" />
+          <path d="m12.2 2.2.8.8m0 0 .8-.8M13 3v1.1" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+        </svg>
+      );
+    case "tools":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="m4 5 7 7M11.5 4.5a2 2 0 0 0-2.6 2.6l2.6-2.6ZM3.2 10.8l2-2L7 10.6l-2 2-1.8-1.8Z" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="m9 3 1.2 1.2M8 4l1.2 1.2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+        </svg>
+      );
+    case "play":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <path d="M4.2 3.8h7.6v8.4H4.2z" stroke="currentColor" strokeWidth="1.1" transform="rotate(-30 8 8)" />
+          <path d="m6.6 5.9 4 2.1-4 2.1V5.9Z" fill="currentColor" />
+        </svg>
+      );
+    case "terminal":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <rect x="2.2" y="2.8" width="11.6" height="10.4" rx="1.3" stroke="currentColor" strokeWidth="1.2" />
+          <path d="m5.1 6.7 2 1.5-2 1.5M8.8 9.8h2.2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
+      );
+    case "issue":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M8 5.4v3.2M8 11h.01" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+        </svg>
+      );
+    case "nodes":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
+          <circle cx="5" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="11.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="8" cy="11.3" r="1.5" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M6.4 5.2h3.6M10.8 6.8l-2 3.1M6.8 10l-1.2-3.1" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+        </svg>
+      );
+    default:
+      return null;
+  }
+}
+
+function renderProjectTreeIcon(icon: QuickMenuTreeIcon) {
+  switch (icon) {
+    case "class":
+      return (
+        <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#3b78e7] text-[8px] font-semibold leading-none text-[#62a5ff]">
+          C
+        </span>
+      );
+    case "package":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+          <path d="M2.2 5h3.2l.9.9h7.5v6.1a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V5Z" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "folderAccent":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#cf8f4e]">
+          <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "root":
+    case "folder":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+          <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "fileAccent":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+          <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+    case "file":
+    default:
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+          <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
+          <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+        </svg>
+      );
+  }
+}
+
+interface QuickMenuPaneProps {
+  isQuickMenuOpen: boolean;
+  onToggleQuickMenu: () => void;
+  sessionAuthenticated: boolean;
+  projectTreeItems: QuickMenuTreeItem[];
+}
+
+export default function QuickMenuPane({
+  isQuickMenuOpen,
+  onToggleQuickMenu,
+  sessionAuthenticated,
+  projectTreeItems,
+}: QuickMenuPaneProps) {
+  return (
+    <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
+      <div className={`grid h-full ${isQuickMenuOpen ? "grid-cols-[48px_minmax(0,1fr)]" : "grid-cols-[48px]"}`}>
+        <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
+          <div className="flex flex-col items-center gap-2">
+            {ideRailTopItems.map((item) => (
+              <button
+                key={item.title}
+                type="button"
+                onClick={() => {
+                  if (item.icon === "project") {
+                    onToggleQuickMenu();
+                  }
+                }}
+                title={item.title}
+                aria-label={item.title}
+                className={`h-8 w-8 rounded-md border text-[10px] font-semibold tracking-wide transition ${
+                  item.icon === "project" && isQuickMenuOpen
+                    ? "border-zinc-500 bg-zinc-700/70 text-zinc-100"
+                    : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-300"
+                }`}
+              >
+                <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
+              </button>
+            ))}
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            {ideRailBottomItems.map((item) => (
+              <button
+                key={item.title}
+                type="button"
+                title={item.title}
+                aria-label={item.title}
+                className="h-8 w-8 rounded-md border border-transparent text-[10px] font-semibold tracking-wide text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-300"
+              >
+                <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={`min-h-0 flex-col ${isQuickMenuOpen ? "flex" : "hidden"}`}>
+          <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
+            <p className="text-sm font-semibold text-zinc-200">퀵 메뉴</p>
+            <span className="text-xs text-zinc-500">▼</span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-sm text-zinc-300">
+            {projectTreeItems.map((item) => {
+              const rowToneClass =
+                item.rowTone === "amber"
+                  ? "bg-[#4a3924]/50"
+                  : item.rowTone === "green"
+                    ? "bg-[#1f3a2a]/55"
+                    : item.rowTone === "selected"
+                      ? "bg-zinc-600/70"
+                      : "hover:bg-zinc-700/30";
+
+              const content = (
+                <div
+                  className={`flex h-7 items-center gap-1.5 rounded-sm px-1.5 ${rowToneClass}`}
+                  style={{ paddingLeft: `${item.depth * 8 + 4}px` }}
+                >
+                  <span className="inline-flex w-3 items-center justify-center text-[10px] text-zinc-500">
+                    {item.hasChildren ? (item.expanded ? "▾" : "▸") : ""}
+                  </span>
+                  <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
+                    {renderProjectTreeIcon(item.icon)}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-zinc-200">
+                    {item.label}
+                  </span>
+                  {item.subtitle ? (
+                    <span className="truncate pl-1 text-[12px] text-zinc-500">{item.subtitle}</span>
+                  ) : null}
+                </div>
+              );
+
+              if (item.href) {
+                const href =
+                  item.href === "/"
+                    ? "/"
+                    : !sessionAuthenticated
+                      ? `/login?next=${encodeURIComponent(item.href)}`
+                      : item.href;
+
+                return (
+                  <Link key={item.key} href={href}>
+                    {content}
+                  </Link>
+                );
+              }
+
+              return <div key={item.key}>{content}</div>;
+            })}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+

--- a/src/features/home/data.ts
+++ b/src/features/home/data.ts
@@ -3,7 +3,13 @@ import type { Difficulty } from "@/shared/api/contracts";
 export const SEARCH_POLL_INTERVAL_MS = 1_000;
 export const DEFAULT_REQUIRED_COUNT = 4;
 
-export const queueCategories = [
+export interface QueueCategoryOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export const queueCategories: QueueCategoryOption[] = [
   { value: "RANDOM", label: "전체 (무작위 준비 중)", disabled: true },
   { value: "dp", label: "DP" },
   { value: "graphs", label: "그래프" },
@@ -12,7 +18,7 @@ export const queueCategories = [
   { value: "implementation", label: "구현" },
 ] as const;
 
-export type QueueCategoryValue = (typeof queueCategories)[number]["value"];
+export type QueueCategoryValue = string;
 
 export const difficultyOptions: Array<{ value: Difficulty; label: string }> = [
   { value: "EASY", label: "Easy" },
@@ -47,12 +53,15 @@ export const dashboardMenus = [
   },
 ];
 
-export function getQueueCategoryLabel(category: string | null) {
+export function getQueueCategoryLabel(
+  category: string | null,
+  categories: QueueCategoryOption[] = queueCategories,
+) {
   if (!category) {
     return "-";
   }
 
-  return queueCategories.find((item) => item.value === category)?.label ?? category;
+  return categories.find((item) => item.value === category)?.label ?? category;
 }
 
 export function getReadyDecisionLabel(decision: "PENDING" | "ACCEPTED" | "DECLINED") {

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -8,14 +7,10 @@ import type {
   ApiErrorResponse,
   Difficulty,
   MatchStateResponse,
-  MyBattleResultItem,
-  MyBattleResultsResponse,
   QueueStateResponse,
   QueueStatusResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
-import { StatusPill } from "@/shared/ui";
-import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
 import {
   DEFAULT_REQUIRED_COUNT,
@@ -28,6 +23,7 @@ import {
   type QueueCategoryOption,
   type QueueCategoryValue,
 } from "./data";
+import QueueEditorPane from "./components/queue-editor-pane";
 import QueueModal from "./queue-modal";
 
 type ModalMode = "SEARCHING" | "READY_CHECK" | "ROOM_READY" | "TERMINAL" | null;
@@ -38,11 +34,9 @@ type BusyAction =
   | "accept"
   | "decline"
   | "join-room"
-  | "logout"
   | null;
 
 const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
-const PREVIEW_RESULTS_SIZE = 5;
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
@@ -154,21 +148,6 @@ async function requestBattleRoomJoin(roomId: number) {
   return { response, payload };
 }
 
-async function readMyBattleResultsPreview(size: number) {
-  const response = await fetch(`/api/me/battle-results?page=0&size=${size}`, {
-    cache: "no-store",
-    credentials: "include",
-  });
-
-  const payload = (await response.json().catch(() => null)) as MyBattleResultsResponse | null;
-
-  return {
-    ok: response.ok,
-    status: response.status,
-    payload,
-  };
-}
-
 function isQueueStatusResponse(
   payload: QueueStatusResponse | ApiErrorResponse | null,
 ): payload is QueueStatusResponse {
@@ -217,11 +196,6 @@ export default function HomeScreen() {
   const [pollStage, setPollStage] = useState<PollStage>("IDLE");
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
   const [now, setNow] = useState(Date.now());
-  const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
-  const [resultsPreviewMessage, setResultsPreviewMessage] = useState("로그인 후 최근 전적을 확인할 수 있습니다.");
-  const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
-  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
-  const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
 
   const joiningRoomIdRef = useRef<number | null>(null);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
@@ -458,55 +432,6 @@ export default function HomeScreen() {
   }, [applyMatchSnapshot, resetFlow]);
 
   useEffect(() => {
-    let active = true;
-
-    if (!session.authenticated) {
-      setRecentResults([]);
-      setResultsPreviewError(null);
-      setResultsPreviewMessage("로그인 후 최근 전적을 확인할 수 있습니다.");
-      return () => {
-        active = false;
-      };
-    }
-
-    setResultsPreviewError(null);
-    setResultsPreviewMessage("최근 전적을 불러오는 중입니다.");
-
-    void (async () => {
-      const { ok, status, payload } = await readMyBattleResultsPreview(PREVIEW_RESULTS_SIZE);
-
-      if (!active) {
-        return;
-      }
-
-      if (status === 401 || payload?.resultCode === "MEMBER_401") {
-        setRecentResults([]);
-        setResultsPreviewError(null);
-        setResultsPreviewMessage(payload?.msg ?? "로그인이 필요합니다.");
-        return;
-      }
-
-      if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
-        setRecentResults([]);
-        setResultsPreviewError(payload?.msg ?? "최근 전적을 불러오지 못했습니다.");
-        setResultsPreviewMessage(payload?.msg ?? "전적 조회에 실패했습니다.");
-        return;
-      }
-
-      const loaded = payload.data.battleResults;
-      setRecentResults(loaded);
-      setResultsPreviewError(null);
-      setResultsPreviewMessage(
-        loaded.length > 0 ? payload.msg : "아직 완료한 배틀 전적이 없습니다.",
-      );
-    })();
-
-    return () => {
-      active = false;
-    };
-  }, [session.authenticated]);
-
-  useEffect(() => {
     if (!session.authenticated || pollStage !== "QUEUE") {
       return;
     }
@@ -608,15 +533,6 @@ export default function HomeScreen() {
 
     void attemptRoomEntry(roomId);
   }, [attemptRoomEntry, matchState.room?.roomId, modalMode, session.authenticated]);
-
-  function handleProtectedMove(href: string) {
-    if (!session.authenticated) {
-      router.push(`/login?next=${encodeURIComponent(href)}`);
-      return;
-    }
-
-    router.push(href);
-  }
 
   async function handleStartMatch() {
     if (!session.authenticated) {
@@ -761,25 +677,6 @@ export default function HomeScreen() {
     resetFlow("종료 상태를 정리했습니다. 메인에서 다시 매칭을 시작할 수 있습니다.");
   }
 
-  async function handleLogout() {
-    setBusyAction("logout");
-
-    try {
-      await fetch("/api/auth/logout", {
-        method: "POST",
-        credentials: "include",
-      });
-      setSession({
-        authenticated: false,
-        member: null,
-      });
-      resetFlow("로그아웃했습니다.");
-      router.refresh();
-    } finally {
-      setBusyAction(null);
-    }
-  }
-
   const isBusy = busyAction !== null;
   const waitingCount = queueState.inQueue ? Math.max(queueState.waitingCount, 1) : 0;
   const requiredCount =
@@ -795,13 +692,6 @@ export default function HomeScreen() {
   const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
   const canStartMatch = !(isBusy || (modalMode !== null && modalMode !== "TERMINAL"));
   const roomId = matchState.room?.roomId ?? null;
-  const previewPlayedCount = recentResults.length;
-  const previewSolvedCount = recentResults.filter((item) => item.solved).length;
-  const previewWinRate =
-    previewPlayedCount > 0 ? Math.round((previewSolvedCount / previewPlayedCount) * 100) : null;
-  const previewScoreDelta = recentResults.reduce((acc, item) => acc + item.scoreDelta, 0);
-  const previewScoreDeltaLabel =
-    previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
   const editorLineNumbers = Array.from({ length: editorLineCount }, (_, index) => 41 + index);
   const editorLineStyle = {
     height: `${editorLineHeight}px`,
@@ -814,721 +704,35 @@ export default function HomeScreen() {
   const editorContentStyle = {
     fontSize: `${editorFontSize}px`,
   };
-  const layoutColumnsClass = isQuickMenuOpen
-    ? isProfilePanelOpen
-      ? "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]"
-      : "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_38px]"
-    : isProfilePanelOpen
-      ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_250px] xl:grid-cols-[48px_minmax(0,1fr)_290px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_320px]"
-      : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_38px]";
-  const ideProjectTreeItems: Array<{
-    key: string;
-    label: string;
-    depth: number;
-    icon: "root" | "folder" | "folderAccent" | "package" | "class" | "file" | "fileAccent";
-    hasChildren?: boolean;
-    expanded?: boolean;
-    subtitle?: string;
-    rowTone?: "amber" | "green" | "selected";
-    href?: string;
-  }> = [
-    {
-      key: "root",
-      label: "BRACKET {}",
-      depth: 0,
-      icon: "root",
-      hasChildren: true,
-      expanded: true,
-    },
-    {
-      key: "quick-menu",
-      label: "퀵메뉴",
-      depth: 1,
-      icon: "folderAccent",
-      hasChildren: true,
-      expanded: true,
-      rowTone: "amber",
-    },
-    {
-      key: "home-screen",
-      label: "메인",
-      depth: 2,
-      icon: "class",
-      rowTone: "selected",
-      href: "/",
-    },
-    { key: "problem-list", label: "문제 목록", depth: 2, icon: "class", href: "/problems" },
-    { key: "spectate-list", label: "관전", depth: 2, icon: "class", href: "/spectate" },
-    { key: "mypage", label: "마이페이지", depth: 2, icon: "class", href: "/mypage" },
-  ];
-  const ideRailTopItems = [
-    { icon: "project", title: "Project" },
-    { icon: "sliders", title: "Services" },
-    { icon: "branch", title: "Git" },
-    { icon: "layout", title: "Layout" },
-    { icon: "more", title: "More" },
-  ];
-  const ideRailBottomItems = [
-    { icon: "cube", title: "AI" },
-    { icon: "tools", title: "Tools" },
-    { icon: "play", title: "Run" },
-    { icon: "terminal", title: "Terminal" },
-    { icon: "issue", title: "Problems" },
-    { icon: "nodes", title: "Connections" },
-  ];
-  const ideDbRailTopItems = [
-    { icon: "notifications", title: "알림" },
-    { icon: "search", title: "검색" },
-    { icon: "database", title: "데이터베이스" },
-    { icon: "gamepad", title: "게임" },
-    { icon: "blocks", title: "서비스" },
-    { icon: "docs", title: "문서" },
-    { icon: "users", title: "사용자" },
-    { icon: "cloud", title: "클라우드" },
-    { icon: "link", title: "연결" },
-  ];
-  const ideDbRailBottomItems = [{ icon: "hammer", title: "도구" }];
-  const renderRailIcon = (name: string) => {
-    const baseClass = "h-4 w-4";
-
-    switch (name) {
-      case "project":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path
-              d="M2 4.5h4l1.1 1.2H14v6.8a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5v-8Z"
-              stroke="currentColor"
-              strokeWidth="1.3"
-            />
-            <path d="M2.2 6h11.6" stroke="currentColor" strokeWidth="1.1" />
-          </svg>
-        );
-      case "sliders":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M2 5.2h12M2 10.8h12" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-            <circle cx="6" cy="5.2" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="10" cy="10.8" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "branch":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="4" cy="3.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="11.8" cy="6.8" r="1.3" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="8.2" cy="12.2" r="1.3" stroke="currentColor" strokeWidth="1.2" />
-            <path
-              d="M5.3 4.4c2 .2 3.4.7 4.8 1.6M11 8c-.5 1.5-1.3 2.4-2.2 3.2"
-              stroke="currentColor"
-              strokeWidth="1.2"
-              strokeLinecap="round"
-            />
-          </svg>
-        );
-      case "layout":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <rect x="2.2" y="2.2" width="11.6" height="11.6" rx="1.6" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M2.2 7.8h11.6M7.8 2.2v11.6" stroke="currentColor" strokeWidth="1.1" />
-          </svg>
-        );
-      case "more":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="4" cy="8" r="1" fill="currentColor" />
-            <circle cx="8" cy="8" r="1" fill="currentColor" />
-            <circle cx="12" cy="8" r="1" fill="currentColor" />
-          </svg>
-        );
-      case "cube":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M8 2.4 12.8 5v6L8 13.6 3.2 11V5L8 2.4Z" stroke="currentColor" strokeWidth="1.1" />
-            <path d="m8 2.4 4.8 2.6L8 7.5 3.2 5 8 2.4ZM8 7.5V13.6" stroke="currentColor" strokeWidth="1.1" />
-            <path d="m12.2 2.2.8.8m0 0 .8-.8M13 3v1.1" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
-          </svg>
-        );
-      case "tools":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="m4 5 7 7M11.5 4.5a2 2 0 0 0-2.6 2.6l2.6-2.6ZM3.2 10.8l2-2L7 10.6l-2 2-1.8-1.8Z" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" strokeLinejoin="round" />
-            <path d="m9 3 1.2 1.2M8 4l1.2 1.2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
-          </svg>
-        );
-      case "play":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M4.2 3.8h7.6v8.4H4.2z" stroke="currentColor" strokeWidth="1.1" transform="rotate(-30 8 8)" />
-            <path d="m6.6 5.9 4 2.1-4 2.1V5.9Z" fill="currentColor" />
-          </svg>
-        );
-      case "terminal":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <rect x="2.2" y="2.8" width="11.6" height="10.4" rx="1.3" stroke="currentColor" strokeWidth="1.2" />
-            <path d="m5.1 6.7 2 1.5-2 1.5M8.8 9.8h2.2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        );
-      case "issue":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M8 5.4v3.2M8 11h.01" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
-          </svg>
-        );
-      case "nodes":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="5" cy="5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="11.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="8" cy="11.3" r="1.5" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M6.4 5.2h3.6M10.8 6.8l-2 3.1M6.8 10l-1.2-3.1" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
-          </svg>
-        );
-      default:
-        return null;
-    }
-  };
-  const renderProjectTreeIcon = (
-    icon: "root" | "folder" | "folderAccent" | "package" | "class" | "file" | "fileAccent",
-  ) => {
-    switch (icon) {
-      case "class":
-        return (
-          <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#3b78e7] text-[8px] font-semibold leading-none text-[#62a5ff]">
-            C
-          </span>
-        );
-      case "package":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
-            <path d="M2.2 5h3.2l.9.9h7.5v6.1a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V5Z" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "folderAccent":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#cf8f4e]">
-            <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "root":
-      case "folder":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
-            <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "fileAccent":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
-            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "file":
-      default:
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
-            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-    }
-  };
-  const renderDbRailIcon = (name: string) => {
-    const baseClass = "h-4 w-4";
-
-    switch (name) {
-      case "notifications":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M8 3a3 3 0 0 0-3 3v2.2l-1 1.6h8l-1-1.6V6a3 3 0 0 0-3-3Z" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="12.2" cy="3.8" r="1.4" fill="#ff5f6d" />
-          </svg>
-        );
-      case "search":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="7" cy="7" r="3.6" stroke="currentColor" strokeWidth="1.2" />
-            <path d="m10 10 3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        );
-      case "database":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <ellipse cx="8" cy="4.1" rx="4.7" ry="2" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M3.3 4.1v4.8c0 1.1 2.1 2 4.7 2s4.7-.9 4.7-2V4.1" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "gamepad":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <rect x="3" y="6.2" width="10" height="5.8" rx="2.2" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M5.4 9h2.2M6.5 7.9v2.2M10.6 8.4h.01M11.8 9.6h.01" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        );
-      case "blocks":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <rect x="2.4" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
-            <rect x="8.8" y="2.4" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
-            <rect x="5.6" y="8.8" width="4.8" height="4.8" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "docs":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M9 2.5V6h3M5.2 8.2h5.6M5.2 10.2h5.6" stroke="currentColor" strokeWidth="1.1" />
-          </svg>
-        );
-      case "users":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <circle cx="6.1" cy="6.1" r="2.1" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="11.1" cy="6.7" r="1.6" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M3.4 12c.5-1.7 1.6-2.7 2.9-2.7s2.4 1 2.9 2.7M9 12.1c.4-1.3 1.2-2.1 2.2-2.1" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        );
-      case "cloud":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M4.8 11.8h6a2.2 2.2 0 1 0-.4-4.4 3.1 3.1 0 0 0-5.9.8 1.9 1.9 0 0 0 .3 3.6Z" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-        );
-      case "link":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="M6.5 9.5 9.5 6.5M5.3 11a2.3 2.3 0 0 1 0-3.2l1.5-1.5a2.3 2.3 0 1 1 3.2 3.2l-.6.6M10.7 5a2.3 2.3 0 0 1 0 3.2l-1.5 1.5a2.3 2.3 0 1 1-3.2-3.2l.6-.6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        );
-      case "hammer":
-        return (
-          <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
-            <path d="m9.2 3.2 3.1 3.1M4.1 12.2 9.9 6.4 7.6 4.1 1.8 9.9l2.3 2.3Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
-    <div className="-my-4 ml-[calc(50%-50dvw)] w-[100dvw] max-w-none min-h-[calc(100dvh-var(--app-header-h))] xl:h-[calc(100dvh-var(--app-header-h))] xl:overflow-hidden">
-      <section className="overflow-hidden bg-[#1e1f22] xl:h-full xl:min-h-0">
-        <div className={`grid h-full ${layoutColumnsClass}`}>
-          <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
-            <div className={`grid h-full ${isQuickMenuOpen ? "grid-cols-[48px_minmax(0,1fr)]" : "grid-cols-[48px]"}`}>
-              <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
-                <div className="flex flex-col items-center gap-2">
-                  {ideRailTopItems.map((item) => (
-                    <button
-                      key={item.title}
-                      type="button"
-                      onClick={() => {
-                        if (item.icon === "project") {
-                          setIsQuickMenuOpen((current) => !current);
-                        }
-                      }}
-                      title={item.title}
-                      aria-label={item.title}
-                      className={`h-8 w-8 rounded-md border text-[10px] font-semibold tracking-wide transition ${
-                        item.icon === "project" && isQuickMenuOpen
-                          ? "border-zinc-500 bg-zinc-700/70 text-zinc-100"
-                          : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-300"
-                      }`}
-                    >
-                      <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
-                    </button>
-                  ))}
-                </div>
-                <div className="flex flex-col items-center gap-2">
-                  {ideRailBottomItems.map((item) => (
-                    <button
-                      key={item.title}
-                      type="button"
-                      title={item.title}
-                      aria-label={item.title}
-                      className="h-8 w-8 rounded-md border border-transparent text-[10px] font-semibold tracking-wide text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-300"
-                    >
-                      <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className={`min-h-0 flex-col ${isQuickMenuOpen ? "flex" : "hidden"}`}>
-                <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
-                  <p className="text-sm font-semibold text-zinc-200">퀵 메뉴</p>
-                  <span className="text-xs text-zinc-500">▼</span>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-sm text-zinc-300">
-                  {ideProjectTreeItems.map((item) => {
-                    const rowToneClass =
-                      item.rowTone === "amber"
-                        ? "bg-[#4a3924]/50"
-                        : item.rowTone === "green"
-                          ? "bg-[#1f3a2a]/55"
-                          : item.rowTone === "selected"
-                            ? "bg-zinc-600/70"
-                            : "hover:bg-zinc-700/30";
-
-                    const content = (
-                      <div
-                        className={`flex h-7 items-center gap-1.5 rounded-sm px-1.5 ${rowToneClass}`}
-                        style={{ paddingLeft: `${item.depth * 8 + 4}px` }}
-                      >
-                        <span className="inline-flex w-3 items-center justify-center text-[10px] text-zinc-500">
-                          {item.hasChildren ? (item.expanded ? "▾" : "▸") : ""}
-                        </span>
-                        <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
-                          {renderProjectTreeIcon(item.icon)}
-                        </span>
-                        <span className="min-w-0 flex-1 truncate text-[13px] text-zinc-200">
-                          {item.label}
-                        </span>
-                        {item.subtitle ? (
-                          <span className="truncate pl-1 text-[12px] text-zinc-500">{item.subtitle}</span>
-                        ) : null}
-                      </div>
-                    );
-
-                    if (item.href) {
-                      const href = item.href === "/"
-                        ? "/"
-                        : !session.authenticated
-                          ? `/login?next=${encodeURIComponent(item.href)}`
-                          : item.href;
-
-                      return (
-                        <Link key={item.key} href={href}>
-                          {content}
-                        </Link>
-                      );
-                    }
-
-                    return <div key={item.key}>{content}</div>;
-                  })}
-                </div>
-              </div>
-            </div>
-          </aside>
-
-          <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
-            <div className="flex h-full min-h-0 flex-col">
-              <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
-                <div className="flex h-full items-end gap-0.5 pt-1">
-                  <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-                    <span className="inline-flex h-4 w-4 items-center justify-center text-[#7da2f7]">
-                      <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
-                        <path
-                          d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                        />
-                        <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
-                        <circle cx="6.4" cy="10.8" r="0.7" fill="currentColor" />
-                      </svg>
-                    </span>
-                    <span>.env</span>
-                    <span className="text-zinc-500">×</span>
-                    <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void handleStartMatch();
-                  }}
-                  disabled={!canStartMatch}
-                  className="inline-flex h-10 items-center gap-2 rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-3 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
-                  aria-label="매칭 시작"
-                >
-                  <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#7dd48c]">
-                    <path
-                      d="M8 2.3v3M5 3.4A4.9 4.9 0 1 0 11 3.4"
-                      stroke="currentColor"
-                      strokeWidth="1.3"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                  <span>매칭 시작</span>
-                  <span className="mx-0.5 h-4 w-px bg-white/35" />
-                  <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#74cc84]">
-                    <path d="m6 4 5 4-5 4V4Z" fill="currentColor" />
-                  </svg>
-                </button>
-              </div>
-
-              <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-[#1e1f22]">
-                <div
-                  className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono"
-                  style={editorContentStyle}
-                >
-                  <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
-                    {editorLineNumbers.map((line) => (
-                      <div key={line} style={editorLineStyle}>
-                        {line}
-                      </div>
-                    ))}
-                  </div>
-                  <div className="px-4 py-4 text-[#a9b7c6]">
-                    <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                      # queue config
-                    </div>
-                    <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                      <span className="font-semibold text-[#ffcc66]"># TODO:</span>
-                      <span className="text-[#ffcc66]">
-                        {" "}
-                        카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2" style={editorRowStyle}>
-                      <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
-                      <span className="text-[#80889a]">=</span>
-                      <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
-                        <select
-                          value={category}
-                          onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
-                          className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
-                        >
-                          {categoryOptions.map((item) => (
-                            <option
-                              key={item.value}
-                              value={item.value}
-                              disabled={"disabled" in item ? item.disabled : false}
-                            >
-                              {item.label}
-                            </option>
-                          ))}
-                        </select>
-                        <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-500">
-                          ▾
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2" style={editorRowStyle}>
-                      <span className="w-40 text-[#9cdcfe]">QUEUE_LEVEL</span>
-                      <span className="text-[#80889a]">=</span>
-                      <div className="flex flex-wrap gap-1 leading-none">
-                        {difficultyOptions.map((option) => (
-                          <label
-                            key={option.value}
-                            className={`rounded-sm border px-2 py-1 text-xs transition ${
-                              difficulty === option.value
-                                ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#dcdcaa]"
-                                : "border-zinc-700 bg-[#2b2d30] text-[#9aa5b1] hover:bg-zinc-700/40"
-                            }`}
-                          >
-                            <input
-                              type="radio"
-                              name="difficulty"
-                              value={option.value}
-                              checked={difficulty === option.value}
-                              onChange={() => setDifficulty(option.value)}
-                              className="sr-only"
-                            />
-                            {option.label.toUpperCase()}
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2" style={editorRowStyle}>
-                      <span className="w-40 text-[#9cdcfe]">QUEUE_PARTY_SIZE</span>
-                      <span className="text-[#80889a]">=</span>
-                      <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#b5cea8]">
-                        4
-                      </span>
-                    </div>
-                    <div className="flex items-start gap-2" style={editorRowStyle}>
-                      <span className="w-40 text-[#9cdcfe]">QUEUE_MEMO</span>
-                      <span className="pt-1 text-[#80889a]">=</span>
-                      <input
-                        type="text"
-                        value={queueMemo}
-                        onChange={(event) => setQueueMemo(event.target.value)}
-                        className="mt-0.5 h-7 w-full rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
-                      />
-                    </div>
-
-                    <div className="mt-2 text-[#6a717d]" style={editorLineStyle}>
-                      {modalMode === "SEARCHING" ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            void handleCancelMatch();
-                          }}
-                          disabled={isBusy}
-                          className="rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 py-0.5 text-xs text-zinc-100 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
-                        >
-                          stopQueue();
-                        </button>
-                      ) : null}
-                    </div>
-                    {error || terminalMessage ? (
-                      <div
-                        className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
-                          error
-                            ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                            : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
-                        }`}
-                      >
-                        {error ?? terminalMessage}
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </main>
-
-          <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
-            <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
-              <div className={`min-h-0 ${isProfilePanelOpen ? "block" : "hidden"}`}>
-                <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
-                  <p className="text-sm font-semibold text-zinc-200">프로필</p>
-                </div>
-                <div className="h-full overflow-y-auto p-3 text-xs text-zinc-300">
-                  <div className="rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
-                    <div className="flex items-center justify-between">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        계정
-                      </p>
-                      <StatusPill tone={session.authenticated ? "success" : "warn"}>
-                        {session.authenticated ? "로그인됨" : "게스트"}
-                      </StatusPill>
-                    </div>
-                    <div className="mt-3 space-y-1">
-                      <p className="text-base font-semibold text-zinc-100">
-                        {session.member?.nickname ?? "게스트"}
-                      </p>
-                      <p className="text-zinc-400">
-                        {session.authenticated
-                          ? formatRoleLabel(session.member?.role)
-                          : "로그인이 필요합니다."}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
-                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      전적 요약
-                    </p>
-                    {session.authenticated ? (
-                      <>
-                        <div className="mt-2 grid grid-cols-2 gap-2">
-                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                            <p className="text-[10px] text-zinc-500">최근 경기</p>
-                            <p className="text-sm font-semibold text-zinc-100">{previewPlayedCount}</p>
-                          </div>
-                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                            <p className="text-[10px] text-zinc-500">클리어</p>
-                            <p className="text-sm font-semibold text-zinc-100">{previewSolvedCount}</p>
-                          </div>
-                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                            <p className="text-[10px] text-zinc-500">승률</p>
-                            <p className="text-sm font-semibold text-zinc-100">{previewWinRate ?? 0}%</p>
-                          </div>
-                          <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                            <p className="text-[10px] text-zinc-500">점수 변화</p>
-                            <p className="text-sm font-semibold text-zinc-100">{previewScoreDeltaLabel}</p>
-                          </div>
-                        </div>
-                        <p
-                          className={`mt-2 text-[11px] ${
-                            resultsPreviewError ? "text-rose-300" : "text-zinc-500"
-                          }`}
-                        >
-                          {resultsPreviewError ?? resultsPreviewMessage}
-                        </p>
-                      </>
-                    ) : (
-                      <p className="mt-2 text-[11px] text-zinc-500">
-                        로그인 후 전적 요약을 확인할 수 있습니다.
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="mt-4 space-y-2 font-sans">
-                    {session.authenticated ? (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() => handleProtectedMove("/mypage")}
-                          className="w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
-                        >
-                          내 프로필
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleLogout}
-                          disabled={isBusy}
-                          className="w-full rounded-md bg-[#9146ff] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
-                        >
-                          로그아웃
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <Link
-                          href="/signup"
-                          className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
-                        >
-                          회원가입
-                        </Link>
-                        <Link
-                          href="/login?next=/"
-                          className="block w-full rounded-md bg-[#9146ff] px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
-                        >
-                          로그인
-                        </Link>
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex min-h-0 flex-col items-center justify-between border-l border-zinc-800/90 bg-[#25272d] py-2">
-                <div className="flex flex-col items-center gap-2">
-                  {ideDbRailTopItems.map((item) => (
-                    <button
-                      key={item.title}
-                      type="button"
-                      onClick={() => {
-                        if (item.icon === "database") {
-                          setIsProfilePanelOpen((current) => !current);
-                        }
-                      }}
-                      title={item.title}
-                      aria-label={item.title}
-                      className={`h-8 w-8 rounded-md border transition ${
-                        item.icon === "database" && isProfilePanelOpen
-                          ? "border-[#2f77ff] bg-[#2f77ff] text-white shadow-[0_0_0_1px_rgba(80,130,255,0.35)]"
-                          : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-200"
-                      }`}
-                    >
-                      <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
-                    </button>
-                  ))}
-                </div>
-                <div className="flex flex-col items-center gap-2">
-                  {ideDbRailBottomItems.map((item) => (
-                    <button
-                      key={item.title}
-                      type="button"
-                      title={item.title}
-                      aria-label={item.title}
-                      className="h-8 w-8 rounded-md border border-transparent text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-200"
-                    >
-                      <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </aside>
-        </div>
-      </section>
+    <div className="h-full min-h-0">
+      <QueueEditorPane
+        editorPaneRef={editorPaneRef}
+        editorContentStyle={editorContentStyle}
+        editorLineNumbers={editorLineNumbers}
+        editorLineStyle={editorLineStyle}
+        editorRowStyle={editorRowStyle}
+        canStartMatch={canStartMatch}
+        onStartMatch={() => {
+          void handleStartMatch();
+        }}
+        category={category}
+        onCategoryChange={setCategory}
+        categoryOptions={categoryOptions}
+        difficulty={difficulty}
+        onDifficultyChange={setDifficulty}
+        difficultyOptions={difficultyOptions}
+        queueMemo={queueMemo}
+        onQueueMemoChange={setQueueMemo}
+        showStopQueueButton={modalMode === "SEARCHING"}
+        onCancelQueue={() => {
+          void handleCancelMatch();
+        }}
+        isBusy={isBusy}
+        error={error}
+        terminalMessage={terminalMessage}
+      />
 
       <QueueModal
         mode={modalMode}

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -356,9 +356,14 @@ export default function HomeScreen() {
 
     const updateEditorMetrics = () => {
       const { lineHeight, fontSize } = resolveEditorMetrics(window.innerWidth);
-      const verticalPadding = lineHeight;
-      const usableHeight = Math.max(editorPane.clientHeight - verticalPadding, lineHeight);
-      const nextLineCount = Math.max(18, Math.floor(usableHeight / lineHeight));
+      const fallbackHeight = Math.max(window.innerHeight - 180, lineHeight);
+      const measuredHeight = editorPane.getBoundingClientRect().height;
+      const usableHeight = Math.max(measuredHeight, fallbackHeight);
+      const safetyBufferLines = 8;
+      const nextLineCount = Math.max(
+        24,
+        Math.ceil(usableHeight / lineHeight) + safetyBufferLines,
+      );
 
       setEditorLineHeight((current) => (current === lineHeight ? current : lineHeight));
       setEditorFontSize((current) => (current === fontSize ? current : fontSize));

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -25,6 +25,7 @@ import {
   getRemainingSeconds,
   queueCategories,
   SEARCH_POLL_INTERVAL_MS,
+  type QueueCategoryOption,
   type QueueCategoryValue,
 } from "./data";
 import QueueModal from "./queue-modal";
@@ -98,6 +99,32 @@ async function readMatchState() {
   }
 
   return (await response.json()) as MatchStateResponse;
+}
+
+async function readTagCategories() {
+  const response = await fetch("/api/tags", {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json().catch(() => null)) as QueueCategoryOption[] | null;
+
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return null;
+  }
+
+  const normalized = payload
+    .map((item) => ({
+      value: (item.value ?? "").trim(),
+      label: (item.label ?? "").trim(),
+      disabled: item.disabled ?? false,
+    }))
+    .filter((item) => item.value.length > 0 && item.label.length > 0);
+
+  return normalized.length > 0 ? normalized : null;
 }
 
 async function postMatchDecision(matchId: number, action: "accept" | "decline") {
@@ -179,6 +206,7 @@ export default function HomeScreen() {
   const [queueState, setQueueState] = useState(defaultQueueState);
   const [matchState, setMatchState] = useState(defaultMatchState);
   const [category, setCategory] = useState<QueueCategoryValue>("dp");
+  const [categoryOptions, setCategoryOptions] = useState<QueueCategoryOption[]>(queueCategories);
   const [difficulty, setDifficulty] = useState<Difficulty>("EASY");
   const [queueStartedAt, setQueueStartedAt] = useState<string | null>(null);
   const [feedback, setFeedback] = useState(DEFAULT_FEEDBACK);
@@ -299,6 +327,35 @@ export default function HomeScreen() {
       window.clearInterval(intervalId);
     };
   }, []);
+
+  useEffect(() => {
+    if (!session.authenticated) {
+      return;
+    }
+
+    let active = true;
+
+    void (async () => {
+      const loadedCategories = await readTagCategories();
+
+      if (!active || !loadedCategories) {
+        return;
+      }
+
+      setCategoryOptions(loadedCategories);
+      setCategory((current) => {
+        if (loadedCategories.some((item) => item.value === current)) {
+          return current;
+        }
+
+        return loadedCategories.find((item) => !item.disabled)?.value ?? current;
+      });
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [session.authenticated]);
 
   useEffect(() => {
     const editorPane = editorPaneRef.current;
@@ -729,7 +786,10 @@ export default function HomeScreen() {
     queueState.requiredCount ||
     matchState.readyCheck?.requiredCount ||
     DEFAULT_REQUIRED_COUNT;
-  const activeCategoryLabel = getQueueCategoryLabel(queueState.category ?? category);
+  const activeCategoryLabel = getQueueCategoryLabel(
+    queueState.category ?? category,
+    categoryOptions,
+  );
   const activeDifficultyLabel = queueState.difficulty ?? difficulty;
   const queueElapsedSeconds = getElapsedSeconds(queueStartedAt, now);
   const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
@@ -1232,7 +1292,7 @@ export default function HomeScreen() {
                           onChange={(event) => setCategory(event.target.value as QueueCategoryValue)}
                           className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
                         >
-                          {queueCategories.map((item) => (
+                          {categoryOptions.map((item) => (
                             <option
                               key={item.value}
                               value={item.value}

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  MyBattleResultItem,
+  MyBattleResultsResponse,
+  SessionResponse,
+} from "@/shared/api/contracts";
+
+import ProfilePane from "@/features/home/components/profile-pane";
+import QuickMenuPane, {
+  type QuickMenuTreeItem,
+} from "@/features/home/components/quick-menu-pane";
+
+const PREVIEW_RESULTS_SIZE = 5;
+
+async function readSession() {
+  const response = await fetch("/api/auth/session", {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    return {
+      authenticated: false,
+      member: null,
+    } satisfies SessionResponse;
+  }
+
+  return (await response.json()) as SessionResponse;
+}
+
+async function readMyBattleResultsPreview(size: number) {
+  const response = await fetch(`/api/me/battle-results?page=0&size=${size}`, {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as MyBattleResultsResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
+export default function IdeShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
+  const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
+  const [session, setSession] = useState<SessionResponse>({
+    authenticated: false,
+    member: null,
+  });
+  const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
+  const [resultsPreviewMessage, setResultsPreviewMessage] = useState(
+    "로그인 후 최근 전적을 확인할 수 있습니다.",
+  );
+  const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    void (async () => {
+      const nextSession = await readSession();
+
+      if (!active) {
+        return;
+      }
+
+      setSession(nextSession);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [pathname]);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!session.authenticated) {
+      setRecentResults([]);
+      setResultsPreviewError(null);
+      setResultsPreviewMessage("로그인 후 최근 전적을 확인할 수 있습니다.");
+      return () => {
+        active = false;
+      };
+    }
+
+    setResultsPreviewError(null);
+    setResultsPreviewMessage("최근 전적을 불러오는 중입니다.");
+
+    void (async () => {
+      const { ok, status, payload } = await readMyBattleResultsPreview(PREVIEW_RESULTS_SIZE);
+
+      if (!active) {
+        return;
+      }
+
+      if (status === 401 || payload?.resultCode === "MEMBER_401") {
+        setRecentResults([]);
+        setResultsPreviewError(null);
+        setResultsPreviewMessage(payload?.msg ?? "로그인이 필요합니다.");
+        return;
+      }
+
+      if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
+        setRecentResults([]);
+        setResultsPreviewError(payload?.msg ?? "최근 전적을 불러오지 못했습니다.");
+        setResultsPreviewMessage(payload?.msg ?? "전적 조회에 실패했습니다.");
+        return;
+      }
+
+      const loaded = payload.data.battleResults;
+      setRecentResults(loaded);
+      setResultsPreviewError(null);
+      setResultsPreviewMessage(
+        loaded.length > 0 ? payload.msg : "아직 완료한 배틀 전적이 없습니다.",
+      );
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [session.authenticated]);
+
+  async function handleLogout() {
+    setIsLoggingOut(true);
+
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+      setSession({
+        authenticated: false,
+        member: null,
+      });
+      router.refresh();
+    } finally {
+      setIsLoggingOut(false);
+    }
+  }
+
+  const previewPlayedCount = recentResults.length;
+  const previewSolvedCount = recentResults.filter((item) => item.solved).length;
+  const previewWinRate =
+    previewPlayedCount > 0 ? Math.round((previewSolvedCount / previewPlayedCount) * 100) : 0;
+  const previewScoreDelta = recentResults.reduce((acc, item) => acc + item.scoreDelta, 0);
+  const previewScoreDeltaLabel =
+    previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
+  const layoutColumnsClass = isQuickMenuOpen
+    ? isProfilePanelOpen
+      ? "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_38px]"
+    : isProfilePanelOpen
+      ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_250px] xl:grid-cols-[48px_minmax(0,1fr)_290px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_38px]";
+
+  const projectTreeItems = useMemo<QuickMenuTreeItem[]>(() => {
+    const isCurrent = (href: string) =>
+      href === "/" ? pathname === "/" : pathname === href || pathname.startsWith(`${href}/`);
+
+    return [
+      {
+        key: "root",
+        label: "BRACKET {}",
+        depth: 0,
+        icon: "root",
+        hasChildren: true,
+        expanded: true,
+      },
+      {
+        key: "quick-menu",
+        label: "퀵메뉴",
+        depth: 1,
+        icon: "folderAccent",
+        hasChildren: true,
+        expanded: true,
+        rowTone: "amber",
+      },
+      {
+        key: "home-screen",
+        label: "메인",
+        depth: 2,
+        icon: "class",
+        rowTone: isCurrent("/") ? "selected" : undefined,
+        href: "/",
+      },
+      {
+        key: "problem-list",
+        label: "문제 목록",
+        depth: 2,
+        icon: "class",
+        rowTone: isCurrent("/problems") ? "selected" : undefined,
+        href: "/problems",
+      },
+      {
+        key: "spectate-list",
+        label: "관전",
+        depth: 2,
+        icon: "class",
+        rowTone: isCurrent("/spectate") ? "selected" : undefined,
+        href: "/spectate",
+      },
+      {
+        key: "mypage",
+        label: "마이페이지",
+        depth: 2,
+        icon: "class",
+        rowTone: isCurrent("/mypage") ? "selected" : undefined,
+        href: "/mypage",
+      },
+    ];
+  }, [pathname]);
+
+  const isHome = pathname === "/";
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
+      <div className={`grid h-full w-full ${layoutColumnsClass}`}>
+        <QuickMenuPane
+          isQuickMenuOpen={isQuickMenuOpen}
+          onToggleQuickMenu={() => setIsQuickMenuOpen((current) => !current)}
+          sessionAuthenticated={session.authenticated}
+          projectTreeItems={projectTreeItems}
+        />
+
+        <section className="min-h-0 overflow-hidden bg-[#1e1f22]">
+          {isHome ? (
+            <div className="h-full min-h-0">{children}</div>
+          ) : (
+            <div className="h-full overflow-y-auto">
+              <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">{children}</div>
+            </div>
+          )}
+        </section>
+
+        <ProfilePane
+          isProfilePanelOpen={isProfilePanelOpen}
+          onToggleProfilePanel={() => setIsProfilePanelOpen((current) => !current)}
+          session={session}
+          previewPlayedCount={previewPlayedCount}
+          previewSolvedCount={previewSolvedCount}
+          previewWinRate={previewWinRate}
+          previewScoreDeltaLabel={previewScoreDeltaLabel}
+          resultsPreviewMessage={resultsPreviewMessage}
+          resultsPreviewError={resultsPreviewError}
+          isBusy={isLoggingOut}
+          onLogout={() => {
+            void handleLogout();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -220,7 +220,12 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
     ];
   }, [pathname]);
 
-  const isHome = pathname === "/";
+  const isFullBleedCenter =
+    pathname === "/" ||
+    pathname === "/signup" ||
+    pathname === "/login" ||
+    pathname === "/problems" ||
+    pathname === "/mypage";
 
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
@@ -233,7 +238,7 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
         />
 
         <section className="min-h-0 overflow-hidden bg-[#1e1f22]">
-          {isHome ? (
+          {isFullBleedCenter ? (
             <div className="h-full min-h-0">{children}</div>
           ) : (
             <div className="h-full overflow-y-auto">

--- a/src/features/login/screen.tsx
+++ b/src/features/login/screen.tsx
@@ -9,7 +9,6 @@ import type {
   AuthMutationResponse,
   LoginRequest,
 } from "@/shared/api/contracts";
-import { PageHero, Panel, StatusPill } from "@/shared/ui";
 
 const initialForm: LoginRequest = {
   email: "",
@@ -54,100 +53,106 @@ export default function LoginScreen() {
   }
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Login"
-        title="로그인 후 바로 메인에서 큐를 잡는 구조"
-        description="백엔드 로그인은 HttpOnly 쿠키를 발급합니다. 프론트는 자체 BFF를 통해 세션을 중계하고, 성공 후 메인 또는 원래 가려던 보호 화면으로 되돌립니다."
-        actions={
-          <>
-            <StatusPill tone="success">POST /api/auth/login</StatusPill>
-            <StatusPill>JWT cookie proxy</StatusPill>
-          </>
-        }
-      />
+    <form onSubmit={handleSubmit} className="h-full min-h-0">
+      <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+              <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                <rect
+                  x="3.4"
+                  y="7.1"
+                  width="9.2"
+                  height="6.1"
+                  rx="1.2"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+                <path
+                  d="M5.5 7.1V5.8a2.5 2.5 0 0 1 5 0v1.3"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
+                <circle cx="8" cy="10.2" r="0.8" fill="currentColor" />
+              </svg>
+            </span>
+            <span>login-request.json</span>
+            <span className="text-zinc-500">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+          </div>
+        </div>
 
-      <div className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
-        <Panel
-          title="로그인"
-          description="현재 백엔드 계약은 email, password 두 필드만 받습니다."
-        >
-          <form className="space-y-4" onSubmit={handleSubmit}>
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">이메일</span>
-              <input
-                type="email"
-                value={form.email}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, email: event.target.value }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none ring-0 transition focus:border-zinc-500"
-                placeholder="duel@example.com"
-                required
-              />
-            </label>
+        <div className="flex-1 overflow-auto bg-[#1e1f22]">
+          <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
+            <div className="mb-6">
+              <h1 className="text-xl font-semibold text-zinc-100">로그인</h1>
+              <p className="mt-1 text-sm text-zinc-400">
+                이메일과 비밀번호를 입력해 계정에 로그인합니다.
+              </p>
+            </div>
 
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">비밀번호</span>
-              <input
-                type="password"
-                value={form.password}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, password: event.target.value }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none ring-0 transition focus:border-zinc-500"
-                placeholder="비밀번호를 입력하세요"
-                required
-              />
-            </label>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-2 sm:col-span-2">
+                <span className="text-sm font-medium text-zinc-200">이메일</span>
+                <input
+                  type="email"
+                  value={form.email}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, email: event.target.value }))
+                  }
+                  placeholder="duel@example.com"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+              </label>
+
+              <label className="space-y-2 sm:col-span-2">
+                <span className="text-sm font-medium text-zinc-200">비밀번호</span>
+                <input
+                  type="password"
+                  value={form.password}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, password: event.target.value }))
+                  }
+                  placeholder="비밀번호를 입력하세요"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+              </label>
+            </div>
+
+            <div
+              className={`mt-5 rounded-md border px-3 py-2 text-sm ${
+                error
+                  ? "border-rose-400/60 bg-rose-900/25 text-rose-200"
+                  : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+              }`}
+            >
+              {error ?? message}
+            </div>
 
             <button
               type="submit"
               disabled={isPending}
-              className="inline-flex w-full items-center justify-center rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
             >
               {isPending ? "로그인 중..." : "로그인"}
             </button>
-          </form>
-        </Panel>
 
-        <div className="space-y-6">
-          <Panel title="다음 단계" description="로그인 이후 실제 이동 흐름">
-            <ul className="space-y-3 text-sm leading-7 text-zinc-700">
-              <li>메인 `/`에서 카테고리와 난이도를 고르고 매칭을 시작합니다.</li>
-              <li>현재 큐 API는 userId 쿼리를 요구하므로 프론트가 JWT subject를 읽어 중계합니다.</li>
-              <li>매칭 응답 메시지에 `roomId`가 포함되면 해당 배틀룸으로 자동 이동합니다.</li>
-            </ul>
-          </Panel>
-
-          <Panel title="보조 링크" description="아직 없는 기능은 명시적으로 분리합니다.">
-            <div className="flex flex-col gap-3 text-sm">
+            <div className="mt-3 text-sm text-zinc-400">
+              아직 계정이 없다면{" "}
               <Link
                 href="/signup"
-                className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 font-medium text-zinc-900 transition hover:border-zinc-500"
+                className="font-medium text-violet-300 transition hover:text-violet-200"
               >
-                회원가입 하기
+                회원가입
               </Link>
-              <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
-                비밀번호 찾기: 백엔드 계약 준비 전
-              </div>
-              <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
-                소셜 로그인: 추후 확장 예정
-              </div>
+              으로 이동하세요.
             </div>
-          </Panel>
-
-          <div
-            className={`rounded-2xl border px-4 py-3 text-sm ${
-              error
-                ? "border-rose-300 bg-rose-50 text-rose-900"
-                : "border-zinc-300 bg-white text-zinc-700"
-            }`}
-          >
-            {error ?? message}
           </div>
         </div>
-      </div>
-    </div>
+      </main>
+    </form>
   );
 }

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -9,14 +9,6 @@ import type {
   PageInfo,
   SessionResponse,
 } from "@/shared/api/contracts";
-import {
-  EmptyPanel,
-  MetricCard,
-  MetricGrid,
-  PageHero,
-  Panel,
-  StatusPill,
-} from "@/shared/ui";
 import { formatDateTime } from "@/shared/utils/format-date-time";
 import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
@@ -70,64 +62,62 @@ function formatScoreDelta(scoreDelta: number) {
   return `${sign}${scoreDelta}`;
 }
 
-function ScoreDeltaText({ scoreDelta }: { scoreDelta: number }) {
-  const toneClass =
-    scoreDelta > 0
-      ? "text-emerald-700"
-      : scoreDelta < 0
-        ? "text-rose-700"
-        : "text-zinc-600";
+function toneForScore(scoreDelta: number) {
+  if (scoreDelta > 0) {
+    return "text-emerald-300";
+  }
 
-  return <span className={`font-semibold ${toneClass}`}>{formatScoreDelta(scoreDelta)}</span>;
+  if (scoreDelta < 0) {
+    return "text-rose-300";
+  }
+
+  return "text-zinc-300";
 }
 
 function ResultCard({ item }: { item: MyBattleResultItem }) {
   return (
     <Link
       href={`/battle/results/${item.roomId}`}
-      className="block rounded-2xl border border-zinc-300 bg-zinc-50 p-5 transition hover:border-zinc-500 hover:bg-white"
+      className="block rounded-md border border-zinc-700 bg-[#2b2d30] p-4 transition hover:bg-zinc-700/35"
     >
-      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-        <div className="space-y-2">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-zinc-500">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="text-xs text-zinc-500">
             roomId {item.roomId} · problemId {item.problemId}
           </p>
-          <h3 className="text-xl font-semibold tracking-tight text-zinc-950">
-            {item.problemTitle}
-          </h3>
-          <p className="text-sm text-zinc-600">{formatDateTime(item.playedAt)} 플레이</p>
+          <h3 className="mt-1 text-base font-semibold text-zinc-100">{item.problemTitle}</h3>
+          <p className="mt-1 text-xs text-zinc-400">{formatDateTime(item.playedAt)} 플레이</p>
         </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <StatusPill tone={item.solved ? "success" : "warn"}>
+        <div className="flex items-center gap-2 text-xs">
+          <span
+            className={`inline-flex h-6 items-center rounded-full border px-2 font-semibold ${
+              item.solved
+                ? "border-emerald-400/60 bg-emerald-900/30 text-emerald-200"
+                : "border-amber-400/60 bg-amber-900/30 text-amber-200"
+            }`}
+          >
             {item.solved ? "성공" : "미해결"}
-          </StatusPill>
-          <StatusPill tone={item.finalRank === 1 ? "success" : "default"}>
+          </span>
+          <span className="inline-flex h-6 items-center rounded-full border border-zinc-600 bg-[#1f2128] px-2 font-semibold text-zinc-200">
             {formatRank(item.finalRank)}
-          </StatusPill>
+          </span>
         </div>
       </div>
 
-      <div className="mt-5 grid gap-3 rounded-2xl border border-zinc-200 bg-white p-4 text-sm text-zinc-700 md:grid-cols-3">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-            최종 순위
-          </p>
-          <p className="mt-2 text-base font-semibold text-zinc-950">{formatRank(item.finalRank)}</p>
+      <div className="mt-4 grid gap-2 text-sm sm:grid-cols-3">
+        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
+          <p className="text-xs text-zinc-500">최종 순위</p>
+          <p className="mt-1 font-semibold text-zinc-100">{formatRank(item.finalRank)}</p>
         </div>
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-            점수 변화
-          </p>
-          <p className="mt-2 text-base">
-            <ScoreDeltaText scoreDelta={item.scoreDelta} />
+        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
+          <p className="text-xs text-zinc-500">점수 변화</p>
+          <p className={`mt-1 font-semibold ${toneForScore(item.scoreDelta)}`}>
+            {formatScoreDelta(item.scoreDelta)}
           </p>
         </div>
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-            정답 처리 시각
-          </p>
-          <p className="mt-2 text-base font-medium text-zinc-950">
+        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
+          <p className="text-xs text-zinc-500">정답 처리 시각</p>
+          <p className="mt-1 font-medium text-zinc-100">
             {item.finishTime ? formatDateTime(item.finishTime) : "기록 없음"}
           </p>
         </div>
@@ -142,15 +132,15 @@ function LoadingRows() {
       {Array.from({ length: 3 }).map((_, index) => (
         <div
           key={index}
-          className="animate-pulse rounded-2xl border border-zinc-300 bg-zinc-50 p-5"
+          className="animate-pulse rounded-md border border-zinc-700 bg-[#2b2d30] p-4"
         >
-          <div className="h-3 w-32 rounded bg-zinc-200" />
-          <div className="mt-4 h-6 w-2/3 rounded bg-zinc-200" />
-          <div className="mt-3 h-4 w-40 rounded bg-zinc-200" />
-          <div className="mt-5 grid gap-3 md:grid-cols-3">
-            <div className="h-20 rounded-2xl bg-white" />
-            <div className="h-20 rounded-2xl bg-white" />
-            <div className="h-20 rounded-2xl bg-white" />
+          <div className="h-3 w-36 rounded bg-zinc-600" />
+          <div className="mt-3 h-4 w-2/3 rounded bg-zinc-600" />
+          <div className="mt-1 h-3 w-40 rounded bg-zinc-700" />
+          <div className="mt-4 grid gap-2 sm:grid-cols-3">
+            <div className="h-14 rounded-md bg-zinc-700" />
+            <div className="h-14 rounded-md bg-zinc-700" />
+            <div className="h-14 rounded-md bg-zinc-700" />
           </div>
         </div>
       ))}
@@ -269,154 +259,140 @@ export default function MyPageScreen() {
   const currentPage = pageInfo.totalPages > 0 ? pageInfo.page + 1 : 0;
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="My Page"
-        title="프로필과 전적 화면의 최소 운영 골격"
-        description="현재 백엔드에는 `/me`, 티어, 총점 API가 아직 없습니다. 그래서 세션 쿠키에서 복원 가능한 식별 정보는 먼저 보여주고, 내 전적 목록은 실제 API로 연결해 확인할 수 있도록 구성합니다."
-        actions={
-          <>
-            <StatusPill tone={session.authenticated ? "success" : "warn"}>
-              {session.authenticated ? "로그인 상태" : "로그인 필요"}
-            </StatusPill>
-            <StatusPill>Profile placeholder</StatusPill>
-          </>
-        }
-      />
-
-      <MetricGrid>
-        <MetricCard
-          label="닉네임"
-          value={session.member?.nickname ?? "게스트"}
-          hint="현재 로그인 사용자 기준"
-        />
-        <MetricCard
-          label="이메일"
-          value={session.member?.email ?? "-"}
-          hint="실제 members 조회 API 연동 전"
-        />
-        <MetricCard
-          label="티어"
-          value="연결 전"
-          hint="백엔드 프로필 API 필요"
-        />
-        <MetricCard
-          label="총점"
-          value="연결 전"
-          hint="전적/점수 API 필요"
-        />
-      </MetricGrid>
-
-      {session.authenticated ? (
-        <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
-          <Panel title="프로필 영역" description="현재 세션에서 바로 읽을 수 있는 정보">
-            <div className="space-y-3 text-sm leading-7 text-zinc-700">
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-                닉네임: {session.member?.nickname}
-              </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-                이메일: {session.member?.email}
-              </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-                역할: {formatRoleLabel(session.member?.role)}
-              </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
-                전적 상태: {error ?? message}
-              </div>
-            </div>
-          </Panel>
-
-          <Panel
-            title="전적 리스트 자리"
-            description="실제 전적 API를 연결해 최신 전적을 확인할 수 있도록 구성합니다."
-          >
-            <div className="mb-4 grid gap-3 md:grid-cols-3">
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                  전체 전적
-                </p>
-                <p className="mt-2 text-lg font-semibold text-zinc-950">{pageInfo.totalElements}</p>
-              </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                  현재 페이지
-                </p>
-                <p className="mt-2 text-lg font-semibold text-zinc-950">
-                  {currentPage > 0 ? `${currentPage} / ${pageInfo.totalPages}` : "-"}
-                </p>
-              </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
-                  로드된 전적
-                </p>
-                <p className="mt-2 text-lg font-semibold text-zinc-950">
-                  {loadedCount}개{session.authenticated ? ` / 해결 ${solvedCount}개` : ""}
-                </p>
-              </div>
-            </div>
-
-            {error ? (
-              <div className="mb-4 rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900">
-                {error}
-              </div>
-            ) : null}
-
-            {isLoading ? (
-              <LoadingRows />
-            ) : battleResults.length === 0 ? (
-              <EmptyPanel
-                title="아직 전적이 없습니다"
-                description="배틀을 한 번 이상 완료하면 이곳에서 최근 전적을 확인할 수 있습니다."
+    <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+        <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+          <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+              <path
+                d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
+                stroke="currentColor"
+                strokeWidth="1.2"
               />
-            ) : (
-              <div className="space-y-3">
-                {battleResults.map((item) => (
-                  <ResultCard key={`${item.roomId}-${item.problemId}`} item={item} />
-                ))}
-              </div>
-            )}
-
-            {!isLoading && battleResults.length > 0 ? (
-              <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-sm text-zinc-600">
-                  {loadedCount}개 로드됨 / 전체 {pageInfo.totalElements}개
-                </p>
-                {pageInfo.hasNext ? (
-                  <button
-                    type="button"
-                    onClick={handleLoadMore}
-                    disabled={isLoadingMore}
-                    className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-                  >
-                    {isLoadingMore ? "불러오는 중..." : "다음 전적 더 보기"}
-                  </button>
-                ) : (
-                  <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
-                    마지막 페이지입니다.
-                  </div>
-                )}
-              </div>
-            ) : null}
-          </Panel>
+              <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+              <path d="M5.2 8.2h5.6M5.2 10.2h5.6" stroke="currentColor" strokeWidth="1.1" />
+            </svg>
+          </span>
+          <span>my-page.json</span>
+          <span className="text-zinc-500">×</span>
+          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
         </div>
-      ) : (
-        <Panel title="로그인이 필요합니다" description="내 전적 화면은 로그인한 사용자만 볼 수 있습니다.">
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href="/login?next=/mypage"
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
-            >
-              로그인하러 가기
-            </Link>
-            <Link
-              href="/signup"
-              className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm font-medium text-zinc-900"
-            >
-              회원가입
-            </Link>
+      </div>
+
+      <div className="flex-1 overflow-auto bg-[#1e1f22]">
+        <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-zinc-700/70 pb-3">
+            <div>
+              <h1 className="text-xl font-semibold text-zinc-100">마이페이지</h1>
+              <p className="mt-1 text-sm text-zinc-400">
+                내 계정 정보와 최근 배틀 전적을 확인합니다.
+              </p>
+            </div>
+            {session.authenticated ? (
+              <p className="text-xs text-zinc-500">
+                {pageInfo.totalElements > 0
+                  ? `총 ${pageInfo.totalElements}개 · ${currentPage}/${pageInfo.totalPages} 페이지`
+                  : "전적 데이터 준비 중"}
+              </p>
+            ) : null}
           </div>
-        </Panel>
-      )}
-    </div>
+
+          {!session.authenticated ? (
+            <div className="space-y-4 rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4">
+              <p className="text-sm text-zinc-300">{message}</p>
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href="/login?next=/mypage"
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                >
+                  로그인
+                </Link>
+                <Link
+                  href="/signup"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-zinc-700 bg-[#1e1f22] px-4 text-sm font-medium text-zinc-200 transition hover:bg-zinc-700/30"
+                >
+                  회원가입
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
+                  <p className="text-xs text-zinc-500">닉네임</p>
+                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                    {session.member?.nickname ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
+                  <p className="text-xs text-zinc-500">이메일</p>
+                  <p className="mt-1 truncate text-base font-semibold text-zinc-100">
+                    {session.member?.email ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
+                  <p className="text-xs text-zinc-500">역할</p>
+                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                    {formatRoleLabel(session.member?.role)}
+                  </p>
+                </div>
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
+                  <p className="text-xs text-zinc-500">해결 / 전체</p>
+                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                    {solvedCount} / {loadedCount}
+                  </p>
+                </div>
+              </div>
+
+              {error ? (
+                <div className="rounded-md border border-rose-400/60 bg-rose-900/25 px-3 py-2 text-sm text-rose-200">
+                  {error}
+                </div>
+              ) : (
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2 text-sm text-zinc-300">
+                  {message}
+                </div>
+              )}
+
+              {isLoading ? (
+                <LoadingRows />
+              ) : battleResults.length === 0 ? (
+                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-6 text-center text-sm text-zinc-400">
+                  아직 전적이 없습니다. 배틀을 완료하면 이곳에서 확인할 수 있습니다.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {battleResults.map((item) => (
+                    <ResultCard key={`${item.roomId}-${item.problemId}`} item={item} />
+                  ))}
+                </div>
+              )}
+
+              {!isLoading && battleResults.length > 0 ? (
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-sm text-zinc-400">
+                    {loadedCount}개 로드됨 / 전체 {pageInfo.totalElements}개
+                  </p>
+                  {pageInfo.hasNext ? (
+                    <button
+                      type="button"
+                      onClick={handleLoadMore}
+                      disabled={isLoadingMore}
+                      className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                    >
+                      {isLoadingMore ? "불러오는 중..." : "다음 전적 더 보기"}
+                    </button>
+                  ) : (
+                    <div className="inline-flex h-10 items-center rounded-md border border-zinc-700 bg-[#2b2d30] px-4 text-sm text-zinc-400">
+                      마지막 페이지입니다.
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
   );
 }

--- a/src/features/problems/screen.tsx
+++ b/src/features/problems/screen.tsx
@@ -8,7 +8,6 @@ import type {
   ProblemListResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
-import { ApiCallout, MetricCard, MetricGrid, PageHero, Panel, StatusPill } from "@/shared/ui";
 
 const PROBLEM_PAGE_SIZE = 20;
 const MAX_PAGE_BUTTONS = 7;
@@ -149,81 +148,82 @@ export default function ProblemsScreen() {
   const pageTokens = getPageTokens(problemPage, totalPages);
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Problems"
-        title="문제 전체 조회 페이지"
-        description="문제 목록은 메인이 아니라 독립 화면에서 조회합니다. 네비게이션에서 바로 들어와 페이지 단위로 문제를 확인할 수 있습니다."
-        actions={
-          <>
-            <StatusPill tone={session.authenticated ? "success" : "warn"}>
-              {session.authenticated ? "로그인 상태" : "로그인 필요"}
-            </StatusPill>
-            <StatusPill>{`size ${PROBLEM_PAGE_SIZE}`}</StatusPill>
-          </>
-        }
-      />
+    <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+        <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+          <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+              <path
+                d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+              <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
+              <path d="M5.2 8.2h5.6M5.2 10.2h5.6" stroke="currentColor" strokeWidth="1.1" />
+            </svg>
+          </span>
+          <span>problem-list.json</span>
+          <span className="text-zinc-500">×</span>
+          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+        </div>
+      </div>
 
-      {!sessionLoaded ? (
-        <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
-          <p className="text-sm text-zinc-600">잠시만 기다려주세요.</p>
-        </Panel>
-      ) : !session.authenticated ? (
-        <Panel title="로그인이 필요합니다" description="문제 전체 조회는 보호된 API로 동작합니다.">
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href="/login?next=/problems"
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
-            >
-              로그인하러 가기
-            </Link>
-            <Link
-              href="/"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
-            >
-              메인으로 돌아가기
-            </Link>
+      <div className="flex-1 overflow-auto bg-[#1e1f22]">
+        <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-zinc-700/70 pb-3">
+            <div>
+              <h1 className="text-xl font-semibold text-zinc-100">문제 목록</h1>
+              <p className="mt-1 text-sm text-zinc-400">문제를 선택해 개인 풀이 화면으로 이동합니다.</p>
+            </div>
+            {session.authenticated ? (
+              <p className="text-xs text-zinc-500">
+                {problemPageInfo
+                  ? `총 ${problemPageInfo.totalElements.toLocaleString()}개 · ${problemPageInfo.page + 1}/${problemPageInfo.totalPages} 페이지`
+                  : isProblemLoading
+                    ? "문제 목록을 불러오는 중입니다."
+                    : ""}
+              </p>
+            ) : null}
           </div>
-        </Panel>
-      ) : (
-        <>
-          <MetricGrid>
-            <MetricCard
-              label="총 문제 수"
-              value={
-                problemPageInfo ? problemPageInfo.totalElements.toLocaleString() : "-"
-              }
-            />
-            <MetricCard
-              label="현재 페이지"
-              value={problemPageInfo ? `${problemPageInfo.page + 1}` : "-"}
-            />
-            <MetricCard
-              label="전체 페이지"
-              value={problemPageInfo ? `${problemPageInfo.totalPages}` : "-"}
-            />
-            <MetricCard label="페이지 크기" value={`${PROBLEM_PAGE_SIZE}`} />
-          </MetricGrid>
 
-          <Panel
-            title="문제 목록"
-            description="`GET /api/problems?page&size`를 통해 백엔드 문제 목록을 조회합니다."
-          >
-            <div className="space-y-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <p className="text-sm text-zinc-600">
+          {!sessionLoaded ? (
+            <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4 text-sm text-zinc-300">
+              세션 상태를 확인하는 중입니다.
+            </div>
+          ) : !session.authenticated ? (
+            <div className="space-y-4 rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4">
+              <p className="text-sm text-zinc-300">
+                문제 목록 조회는 로그인 후 이용할 수 있습니다.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Link
+                  href="/login?next=/problems"
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                >
+                  로그인
+                </Link>
+                <Link
+                  href="/"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-zinc-700 bg-[#1e1f22] px-4 text-sm font-medium text-zinc-200 transition hover:bg-zinc-700/30"
+                >
+                  메인으로
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm text-zinc-400">
                   {isProblemLoading
                     ? "문제 목록을 불러오는 중입니다."
-                    : problemPageInfo
-                      ? `${problemPageInfo.totalElements.toLocaleString()}개 문제 / ${problemPageInfo.page + 1}페이지`
-                      : "문제 목록을 불러오지 못했습니다."}
+                    : "문제를 선택한 뒤 열기를 눌러 개인 풀이를 시작하세요."}
                 </p>
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
                     onClick={() => setProblemPage((current) => Math.max(0, current - 1))}
                     disabled={!canMovePrevProblemPage}
-                    className="rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                    className="inline-flex h-9 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-200 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
                   >
                     이전
                   </button>
@@ -231,116 +231,115 @@ export default function ProblemsScreen() {
                     type="button"
                     onClick={() => setProblemPage((current) => current + 1)}
                     disabled={!canMoveNextProblemPage}
-                    className="rounded-xl border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                    className="inline-flex h-9 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-200 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
                   >
                     다음
                   </button>
                 </div>
               </div>
 
-              <div className="flex flex-wrap items-center gap-2">
-                {pageTokens.map((token, index) =>
-                  token === "ellipsis" ? (
-                    <span key={`ellipsis-${index}`} className="px-2 text-sm text-zinc-500">
-                      ...
-                    </span>
-                  ) : (
-                    <button
-                      key={token}
-                      type="button"
-                      onClick={() => setProblemPage(token)}
-                      disabled={isProblemLoading}
-                      className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition ${
-                        token === problemPage
-                          ? "border-zinc-950 bg-zinc-950 text-white"
-                          : "border-zinc-300 bg-white text-zinc-900 hover:border-zinc-500"
-                      } disabled:cursor-not-allowed disabled:text-zinc-400`}
-                    >
-                      {token + 1}
-                    </button>
-                  ),
-                )}
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="w-full overflow-x-auto sm:w-auto">
+                  <div className="inline-flex min-w-max items-center gap-1.5">
+                    {pageTokens.map((token, index) =>
+                      token === "ellipsis" ? (
+                        <span
+                          key={`ellipsis-${index}`}
+                          className="inline-flex h-8 w-8 items-center justify-center text-sm text-zinc-500"
+                        >
+                          ...
+                        </span>
+                      ) : (
+                        <button
+                          key={token}
+                          type="button"
+                          onClick={() => setProblemPage(token)}
+                          disabled={isProblemLoading}
+                          className={`inline-flex h-8 w-9 items-center justify-center rounded-md border text-sm font-semibold transition ${
+                            token === problemPage
+                              ? "border-violet-400/60 bg-[#9146ff] text-white shadow-[0_0_0_1px_rgba(167,139,250,0.3)]"
+                              : "border-zinc-700 bg-[#2b2d30] text-zinc-200 hover:bg-zinc-700/40"
+                          } disabled:cursor-not-allowed disabled:text-zinc-500`}
+                        >
+                          {token + 1}
+                        </button>
+                      ),
+                    )}
+                  </div>
+                </div>
+                {problemPageInfo ? (
+                  <p className="text-xs text-zinc-500">
+                    현재 {problemPageInfo.page + 1} / {problemPageInfo.totalPages}
+                  </p>
+                ) : null}
               </div>
 
               {problemError ? (
-                <div className="rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+                <div className="rounded-md border border-rose-400/60 bg-rose-900/25 px-3 py-2 text-sm text-rose-200">
                   {problemError}
                 </div>
               ) : null}
 
-              <div className="overflow-hidden rounded-2xl border border-zinc-300">
-                <table className="min-w-full border-collapse bg-white text-sm">
-                  <thead className="bg-zinc-100 text-zinc-700">
-                    <tr>
-                      <th className="px-4 py-3 text-left font-semibold">ID</th>
-                      <th className="px-4 py-3 text-left font-semibold">제목</th>
-                      <th className="px-4 py-3 text-left font-semibold">난이도</th>
-                      <th className="px-4 py-3 text-left font-semibold">레이팅</th>
-                      <th className="px-4 py-3 text-left font-semibold">시간 제한</th>
-                      <th className="px-4 py-3 text-left font-semibold">메모리 제한</th>
-                      <th className="px-4 py-3 text-left font-semibold">개인 풀이</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {problemRows.length > 0 ? (
-                      problemRows.map((problem) => (
-                        <tr key={problem.problemId} className="border-t border-zinc-200">
-                          <td className="px-4 py-3 font-medium text-zinc-900">
-                            {problem.problemId}
-                          </td>
-                          <td className="px-4 py-3 text-zinc-700">
-                            <Link
-                              href={`/problems/${problem.problemId}`}
-                              className="font-medium text-zinc-900 underline-offset-4 hover:underline"
-                            >
-                              {problem.title}
-                            </Link>
-                          </td>
-                          <td className="px-4 py-3 text-zinc-700">{problem.difficulty}</td>
-                          <td className="px-4 py-3 text-zinc-700">{problem.difficultyRating}</td>
-                          <td className="px-4 py-3 text-zinc-700">{problem.timeLimitMs}ms</td>
-                          <td className="px-4 py-3 text-zinc-700">{problem.memoryLimitMb}MB</td>
-                          <td className="px-4 py-3">
-                            <Link
-                              href={`/problems/${problem.problemId}`}
-                              className="rounded-lg border border-zinc-300 bg-zinc-50 px-3 py-1.5 text-xs font-medium text-zinc-900 transition hover:border-zinc-500"
-                            >
-                              열기
-                            </Link>
+              <div className="overflow-hidden rounded-md border border-zinc-700">
+                <div className="overflow-x-auto">
+                  <table className="min-w-full border-collapse text-sm">
+                    <thead className="bg-[#2b2d30] text-zinc-300">
+                      <tr>
+                        <th className="px-4 py-3 text-left font-semibold">ID</th>
+                        <th className="px-4 py-3 text-left font-semibold">제목</th>
+                        <th className="px-4 py-3 text-left font-semibold">난이도</th>
+                        <th className="px-4 py-3 text-left font-semibold">레이팅</th>
+                        <th className="px-4 py-3 text-left font-semibold">시간 제한</th>
+                        <th className="px-4 py-3 text-left font-semibold">메모리 제한</th>
+                        <th className="px-4 py-3 text-left font-semibold">개인 풀이</th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-[#1e1f22]">
+                      {problemRows.length > 0 ? (
+                        problemRows.map((problem) => (
+                          <tr key={problem.problemId} className="border-t border-zinc-700">
+                            <td className="px-4 py-3 font-medium text-zinc-100">
+                              {problem.problemId}
+                            </td>
+                            <td className="px-4 py-3 text-zinc-200">
+                              <Link
+                                href={`/problems/${problem.problemId}`}
+                                className="font-medium text-zinc-100 underline-offset-4 hover:text-violet-300 hover:underline"
+                              >
+                                {problem.title}
+                              </Link>
+                            </td>
+                            <td className="px-4 py-3 text-zinc-300">{problem.difficulty}</td>
+                            <td className="px-4 py-3 text-zinc-300">{problem.difficultyRating}</td>
+                            <td className="px-4 py-3 text-zinc-300">{problem.timeLimitMs}ms</td>
+                            <td className="px-4 py-3 text-zinc-300">{problem.memoryLimitMb}MB</td>
+                            <td className="px-4 py-3">
+                              <Link
+                                href={`/problems/${problem.problemId}`}
+                                className="inline-flex h-8 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-xs font-medium text-zinc-200 transition hover:bg-zinc-700/40"
+                              >
+                                열기
+                              </Link>
+                            </td>
+                          </tr>
+                        ))
+                      ) : (
+                        <tr className="border-t border-zinc-700">
+                          <td colSpan={7} className="px-4 py-6 text-center text-zinc-500">
+                            {isProblemLoading
+                              ? "목록을 불러오는 중입니다."
+                              : "표시할 문제가 없습니다."}
                           </td>
                         </tr>
-                      ))
-                    ) : (
-                      <tr className="border-t border-zinc-200">
-                        <td colSpan={7} className="px-4 py-6 text-center text-zinc-500">
-                          {isProblemLoading
-                            ? "목록을 불러오는 중입니다."
-                            : "표시할 문제가 없습니다."}
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             </div>
-          </Panel>
-
-          <Panel title="연결 포인트" description="문제 목록 화면에서 사용하는 API 경로">
-            <div className="grid gap-4 lg:grid-cols-2">
-              <ApiCallout
-                method="GET"
-                path="/api/problems?page={page}&size={size}"
-                note="프론트 BFF에서 문제 목록을 페이지네이션으로 조회합니다."
-              />
-              <ApiCallout
-                method="GET"
-                path="/api/v1/problems?page={page}&size={size}"
-                note="백엔드 실제 문제 목록 엔드포인트입니다."
-              />
-            </div>
-          </Panel>
-        </>
-      )}
-    </div>
+          )}
+        </div>
+      </div>
+    </main>
   );
 }

--- a/src/features/signup/screen.tsx
+++ b/src/features/signup/screen.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
 import type { ApiErrorResponse, JoinRequest } from "@/shared/api/contracts";
-import { MetricCard, MetricGrid, PageHero, Panel, StatusPill } from "@/shared/ui";
 
 const initialForm: JoinRequest = {
   email: "",
@@ -54,142 +53,145 @@ export default function SignupScreen() {
   }
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Signup"
-        title="백엔드 JoinRequest 그대로 받는 회원가입 화면"
-        description="이메일, 비밀번호, 비밀번호 확인, 닉네임 네 필드만 실제 계약에 맞춰 보냅니다. 중복 확인과 소셜 가입은 아직 계약이 없어 UI에 넣지 않습니다."
-        actions={
-          <>
-            <StatusPill tone="success">POST /api/auth/signup</StatusPill>
-            <StatusPill>Validation by backend</StatusPill>
-          </>
-        }
-      />
+    <form onSubmit={handleSubmit} className="h-full min-h-0">
+      <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+              <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                <path
+                  d="M5.3 6.1a2.1 2.1 0 1 0 0-4.2 2.1 2.1 0 0 0 0 4.2Z"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+                <path
+                  d="M2.7 11.8c.3-1.8 1.4-2.9 2.7-2.9s2.4 1.1 2.7 2.9"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
+                <path
+                  d="M11.2 5.2v3m-1.5-1.5h3"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </span>
+            <span>join-request.json</span>
+            <span className="text-zinc-500">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+          </div>
+        </div>
 
-      <MetricGrid>
-        <MetricCard label="필수 필드" value="4" hint="email, password, passwordConfirm, name" />
-        <MetricCard
-          label="비밀번호 규칙"
-          value="8-12"
-          hint="영문, 숫자, 특수문자 포함"
-        />
-        <MetricCard label="자동 이동" value="/login" hint="가입 성공 후 로그인 화면으로 이동" />
-        <MetricCard
-          label="현재 범위"
-          value="기본 가입"
-          hint="중복 확인, 비밀번호 찾기 제외"
-        />
-      </MetricGrid>
+        <div className="flex-1 overflow-auto bg-[#1e1f22]">
+          <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
+            <div className="mb-6">
+              <h1 className="text-xl font-semibold text-zinc-100">회원가입</h1>
+              <p className="mt-1 text-sm text-zinc-400">
+                이메일, 비밀번호, 닉네임을 입력해 계정을 생성합니다.
+              </p>
+            </div>
 
-      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-        <Panel title="회원가입 폼" description="실제 백엔드 DTO 이름에 맞춰 입력합니다.">
-          <form className="space-y-4" onSubmit={handleSubmit}>
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">이메일</span>
-              <input
-                type="email"
-                value={form.email}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, email: event.target.value }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-                placeholder="rookie@example.com"
-                required
-              />
-            </label>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-2 sm:col-span-2">
+                <span className="text-sm font-medium text-zinc-200">이메일</span>
+                <input
+                  type="email"
+                  value={form.email}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, email: event.target.value }))
+                  }
+                  placeholder="rookie@example.com"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+              </label>
 
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">비밀번호</span>
-              <input
-                type="password"
-                value={form.password}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, password: event.target.value }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-                placeholder="영문, 숫자, 특수문자 포함"
-                required
-              />
-            </label>
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-zinc-200">비밀번호</span>
+                <input
+                  type="password"
+                  value={form.password}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, password: event.target.value }))
+                  }
+                  placeholder="영문, 숫자, 특수문자 포함"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+                <p className="text-xs text-zinc-500">
+                  8~12자, 영문/숫자/특수문자를 포함해주세요.
+                </p>
+              </label>
 
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">비밀번호 확인</span>
-              <input
-                type="password"
-                value={form.passwordConfirm}
-                onChange={(event) =>
-                  setForm((current) => ({
-                    ...current,
-                    passwordConfirm: event.target.value,
-                  }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-                placeholder="비밀번호를 다시 입력하세요"
-                required
-              />
-            </label>
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-zinc-200">비밀번호 확인</span>
+                <input
+                  type="password"
+                  value={form.passwordConfirm}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      passwordConfirm: event.target.value,
+                    }))
+                  }
+                  placeholder="비밀번호를 다시 입력하세요"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+              </label>
 
-            <label className="block space-y-2">
-              <span className="text-sm font-medium text-zinc-700">닉네임</span>
-              <input
-                type="text"
-                value={form.name}
-                onChange={(event) =>
-                  setForm((current) => ({ ...current, name: event.target.value }))
-                }
-                className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-                placeholder="2~20자 닉네임"
-                required
-              />
-            </label>
+              <label className="space-y-2 sm:col-span-2">
+                <span className="text-sm font-medium text-zinc-200">닉네임</span>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                  placeholder="2~20자 닉네임"
+                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  required
+                />
+              </label>
+            </div>
+
+            <div
+              className={`mt-5 rounded-md border px-3 py-2 text-sm ${
+                error
+                  ? "border-rose-400/60 bg-rose-900/25 text-rose-200"
+                  : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+              }`}
+            >
+              {error
+                ? error
+                : passwordMatched
+                  ? message
+                  : "비밀번호와 비밀번호 확인이 일치해야 회원가입을 진행할 수 있습니다."}
+            </div>
 
             <button
               type="submit"
               disabled={isPending || !passwordMatched}
-              className="inline-flex w-full items-center justify-center rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
             >
-              {isPending ? "가입 처리 중..." : "회원가입 완료"}
+              {isPending ? "가입 중..." : "회원가입"}
             </button>
-          </form>
-        </Panel>
 
-        <div className="space-y-6">
-          <Panel title="실시간 체크" description="프론트에서 최소한으로 보여주는 확인 상태">
-            <div className="space-y-3 text-sm text-zinc-700">
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3">
-                비밀번호 확인 일치 여부: {passwordMatched ? "일치" : "미일치"}
-              </div>
-              <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
-                이메일 중복 확인: 백엔드 계약 준비 전
-              </div>
-              <div className="rounded-2xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-3 text-zinc-600">
-                닉네임 중복 확인: 백엔드 계약 준비 전
-              </div>
-            </div>
-          </Panel>
-
-          <Panel title="이동 경로" description="가입 후 사용자가 바로 이어서 할 행동">
-            <div className="flex flex-col gap-3 text-sm">
+            <div className="mt-3 text-sm text-zinc-400">
+              이미 계정이 있다면{" "}
               <Link
                 href="/login"
-                className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 font-medium text-zinc-900 transition hover:border-zinc-500"
+                className="font-medium text-violet-300 transition hover:text-violet-200"
               >
-                로그인 페이지로 돌아가기
+                로그인
               </Link>
-              <div
-                className={`rounded-2xl border px-4 py-3 ${
-                  error
-                    ? "border-rose-300 bg-rose-50 text-rose-900"
-                    : "border-zinc-300 bg-white text-zinc-700"
-                }`}
-              >
-                {error ?? message}
-              </div>
+              으로 이동하세요.
             </div>
-          </Panel>
+          </div>
         </div>
-      </div>
-    </div>
+      </main>
+    </form>
   );
 }


### PR DESCRIPTION
## 작업 개요

- 메인/로그인/회원가입/문제목록/마이페이지를 IDE 패널 톤으로 통일하고, 전역 셸 구조를 정리했습니다.
- 상단 글로벌 네비 항목은 제거하고 `BRACKET {}`만 남겨 UI 복잡도를 줄였습니다.

## 영향 범위

- route: `/`, `/login`, `/signup`, `/problems`, `/mypage`
- feature: 홈 메인 패널, 인증 화면, 문제 목록, 마이페이지 UI
- api/bff: 변경 없음 (기존 API 호출 로직 유지)

## 작업 내용

- [x] 전역 좌/우 패널을 레이아웃 셸로 공통화
- [x] 로그인/회원가입/문제목록/마이페이지 화면 톤 통일
- [x] 메인 탭 라벨 `.env.queue.match`로 조정 및 코드 라인 계산 보정
- [x] 상단 글로벌 네비 텍스트 링크 제거

## 변경 사항

- `src/features/layout/ide-shell.tsx`
  - 전역 셸에서 페이지별 중앙 패널 렌더링 방식 정리(풀폭 페이지 확장)
- `src/app/layout.tsx`
  - 헤더에서 네비 링크 제거, 브랜드 텍스트만 유지
- `src/features/home/screen.tsx`
  - 에디터 라인 수 계산 로직 보정(큰 화면 대응)
- `src/features/home/components/queue-editor-pane.tsx`
  - 탭 라벨을 `.env.queue.match`로 변경
- `src/features/login/screen.tsx`
  - 탭형 헤더 + 다크 폼 레이아웃으로 재구성
- `src/features/signup/screen.tsx`
  - 탭형 헤더 + 다크 폼 레이아웃으로 재구성, 상단 실행형 버튼 제거
- `src/features/problems/screen.tsx`
  - 탭형 헤더 + 다크 목록/페이지네이션 레이아웃으로 재구성
- `src/features/my-page/screen.tsx`
  - 탭형 헤더 + 다크 전적 카드 레이아웃으로 재구성

## 테스트 및 확인

- [ ] `npm run lint` (현재 dev의 ESLint 설정/의존성 문제로 실행 실패)
- [x] `npx tsc --noEmit`
- [x] 주요 라우트 수동 확인
- [x] API/BFF 연동 확인

## 관련 이슈

- close #

## 스크린샷 / 영상

- UI 리팩터 전/후 스크린샷은 코멘트로 첨부 예정

## 참고 자료

- 없음
