### PR TITLE
[feat] WebSocket 연결 시 1회용 토큰을 STOMP CONNECT 헤더에 주입

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -194,6 +194,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
       // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
       beforeConnect: async () => {
+        // 재연결 시 이전 연결에서 소비된 토큰이 재사용되지 않도록 먼저 초기화
+        client.connectHeaders = {};
         try {
           const res = await fetch("/api/v1/ws/token", { method: "POST" });
           if (res.ok) {

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -190,6 +190,20 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     const client = new Client({
       webSocketFactory: () => new SockJS("/ws"),
       reconnectDelay: 3000,
+      // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
+      // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
+      // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
+      beforeConnect: async () => {
+        try {
+          const res = await fetch("/api/v1/ws/token", { method: "POST" });
+          if (res.ok) {
+            const data = (await res.json()) as { token: string };
+            client.connectHeaders = { "X-WS-Token": data.token };
+          }
+        } catch {
+          console.warn("[WS] 토큰 발급 실패, 쿠키 기반 인증으로 폴백");
+        }
+      },
       onConnect: () => {
         client.subscribe(`/topic/room/${roomId}`, (message) => {
           let payload: unknown;

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -381,6 +381,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
       // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
       beforeConnect: async () => {
+        // 재연결 시 이전 연결에서 소비된 토큰이 재사용되지 않도록 먼저 초기화
+        client.connectHeaders = {};
         try {
           const res = await fetch("/api/v1/ws/token", { method: "POST" });
           if (res.ok) {

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -377,6 +377,20 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     const client = new Client({
       webSocketFactory: () => new SockJS("/ws"),
       reconnectDelay: 3000,
+      // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
+      // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
+      // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
+      beforeConnect: async () => {
+        try {
+          const res = await fetch("/api/v1/ws/token", { method: "POST" });
+          if (res.ok) {
+            const data = (await res.json()) as { token: string };
+            client.connectHeaders = { "X-WS-Token": data.token };
+          }
+        } catch {
+          console.warn("[WS] 토큰 발급 실패, 쿠키 기반 인증으로 폴백");
+        }
+      },
       onConnect: () => {
         client.subscribe(`/topic/solo/${memberId}`, (message) => {
           let payload: unknown;

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -104,6 +104,20 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
     const client = new Client({
       webSocketFactory: () => new SockJS("/ws"),
       reconnectDelay: 3000,
+      // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
+      // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
+      // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
+      beforeConnect: async () => {
+        try {
+          const res = await fetch("/api/v1/ws/token", { method: "POST" });
+          if (res.ok) {
+            const data = (await res.json()) as { token: string };
+            client.connectHeaders = { "X-WS-Token": data.token };
+          }
+        } catch {
+          console.warn("[WS] 토큰 발급 실패, 쿠키 기반 인증으로 폴백");
+        }
+      },
       onConnect: () => {
         client.subscribe(`/topic/room/${roomId}/spectate`, (frame) => {
           let payload: unknown;

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -108,6 +108,8 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
       // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
       // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
       beforeConnect: async () => {
+        // 재연결 시 이전 연결에서 소비된 토큰이 재사용되지 않도록 먼저 초기화
+        client.connectHeaders = {};
         try {
           const res = await fetch("/api/v1/ws/token", { method: "POST" });
           if (res.ok) {


### PR DESCRIPTION
## 작업 개요

- WebSocket 연결 시 1회용 토큰을 STOMP CONNECT 헤더에 주입

## 영향 범위


## 작업 내용

- [ ] WebSocket 연결 시 1회용 토큰을 STOMP CONNECT 헤더에 주입

## 변경 사항

배포 환경(cross-origin)에서 쿠키 자동 전송이 불가한 문제를 해결하기 위해 beforeConnect 훅에서 POST /api/v1/ws/token을 호출해 X-WS-Token 헤더를 설정.
재연결 시마다 새 토큰을 발급하므로 1회용 토큰의 보안 특성을 유지.
토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.

대상: battle-room, spectate-room, problem-solo

## 테스트 및 확인


## 관련 이슈

- close #31 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
