### PR TITLE
[feat] accessToken 만료 시 refreshToken으로 자동 재발급 처리

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -13,7 +13,9 @@ import {
 } from "@/shared/api/backend";
 import {
   extractAccessTokenFromSetCookie,
+  extractRefreshTokenFromSetCookie,
   FRONTEND_ACCESS_TOKEN_COOKIE,
+  FRONTEND_REFRESH_TOKEN_COOKIE,
   getSessionMemberFromToken,
   ONE_YEAR_IN_SECONDS,
 } from "@/shared/auth/session";
@@ -42,7 +44,9 @@ export async function POST(request: Request) {
       );
     }
 
-    const token = extractAccessTokenFromSetCookie(response.headers.get("set-cookie"));
+    const setCookieHeader = response.headers.get("set-cookie");
+    const token = extractAccessTokenFromSetCookie(setCookieHeader);
+    const refreshToken = extractRefreshTokenFromSetCookie(setCookieHeader);
     const member = token ? getSessionMemberFromToken(token) : null;
 
     if (!token || !member) {
@@ -63,6 +67,18 @@ export async function POST(request: Request) {
       path: "/",
       maxAge: ONE_YEAR_IN_SECONDS,
     });
+
+    if (refreshToken) {
+      cookieStore.set({
+        name: FRONTEND_REFRESH_TOKEN_COOKIE,
+        value: refreshToken,
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        maxAge: ONE_YEAR_IN_SECONDS,
+      });
+    }
 
     const result: AuthMutationResponse = {
       message: body?.msg ?? "로그인 성공",

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
 import { fetchBackend } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
+import { FRONTEND_ACCESS_TOKEN_COOKIE, FRONTEND_REFRESH_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function POST() {
   const cookieStore = await cookies();
@@ -20,6 +20,7 @@ export async function POST() {
   }
 
   cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+  cookieStore.delete(FRONTEND_REFRESH_TOKEN_COOKIE);
 
   return NextResponse.json({
     message: "로그아웃되었습니다.",

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -3,17 +3,60 @@ import { cookies } from "next/headers";
 
 import type { SessionResponse } from "@/shared/api/contracts";
 import {
+  fetchBackend,
+  readJsonBody,
+} from "@/shared/api/backend";
+import {
   FRONTEND_ACCESS_TOKEN_COOKIE,
+  FRONTEND_REFRESH_TOKEN_COOKIE,
+  ONE_YEAR_IN_SECONDS,
+  extractAccessTokenFromSetCookie,
   getSessionMemberFromToken,
 } from "@/shared/auth/session";
 
 export async function GET() {
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
+  let member = token ? getSessionMemberFromToken(token) : null;
 
   if (token && !member) {
-    cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+    // accessToken이 만료된 경우 reissue 시도
+    const refreshToken = cookieStore.get(FRONTEND_REFRESH_TOKEN_COOKIE)?.value;
+
+    if (refreshToken) {
+      try {
+        const reissueResponse = await fetchBackend("/api/v1/auth/reissue", {
+          method: "POST",
+          refreshToken,
+        });
+
+        if (reissueResponse.ok) {
+          const newToken = extractAccessTokenFromSetCookie(reissueResponse.headers.get("set-cookie"));
+
+          if (newToken) {
+            cookieStore.set({
+              name: FRONTEND_ACCESS_TOKEN_COOKIE,
+              value: newToken,
+              httpOnly: true,
+              sameSite: "lax",
+              secure: process.env.NODE_ENV === "production",
+              path: "/",
+              maxAge: ONE_YEAR_IN_SECONDS,
+            });
+            member = getSessionMemberFromToken(newToken);
+          }
+        } else {
+          await readJsonBody(reissueResponse); // body drain
+          cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+          cookieStore.delete(FRONTEND_REFRESH_TOKEN_COOKIE);
+        }
+      } catch {
+        cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+        cookieStore.delete(FRONTEND_REFRESH_TOKEN_COOKIE);
+      }
+    } else {
+      cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+    }
   }
 
   const payload: SessionResponse = {

--- a/src/app/api/battle/rooms/[roomId]/join/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/join/route.ts
@@ -21,7 +21,7 @@ export async function POST(
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
   const memberId = token ? getMemberIdFromToken(token) : null;
 
-  if (!token || !memberId) {
+  if (!memberId) {
     return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 

--- a/src/app/api/battle/rooms/[roomId]/join/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/join/route.ts
@@ -3,13 +3,13 @@ import { cookies } from "next/headers";
 
 import type { JoinRoomResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
 import {
   FRONTEND_ACCESS_TOKEN_COOKIE,
-  getSessionMemberFromToken,
+  getMemberIdFromToken,
 } from "@/shared/auth/session";
 
 export async function POST(
@@ -19,18 +19,17 @@ export async function POST(
   const { roomId } = await context.params;
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
+  const memberId = token ? getMemberIdFromToken(token) : null;
 
-  if (!token || !member) {
+  if (!token || !memberId) {
     return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 
   try {
-    const response = await fetchBackend(`/api/v1/battle/rooms/${roomId}/join`, {
+    const response = await fetchBackendWithReissue(`/api/v1/battle/rooms/${roomId}/join`, {
       method: "POST",
-      token,
-      body: { memberId: member.memberId },
-    });
+      body: { memberId },
+    }, cookieStore);
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/battle/rooms/[roomId]/result/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/result/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { BattleResultResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function GET(
   _request: Request,
@@ -15,16 +14,13 @@ export async function GET(
 ) {
   const { roomId } = await context.params;
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend(`/api/v1/battle/rooms/${roomId}/result`, {
-      token,
-    });
+    const response = await fetchBackendWithReissue(`/api/v1/battle/rooms/${roomId}/result`, {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/battle/rooms/[roomId]/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { RoomResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function GET(
   _request: Request,
@@ -15,14 +14,13 @@ export async function GET(
 ) {
   const { roomId } = await context.params;
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend(`/api/v1/battle/rooms/${roomId}`, { token });
+    const response = await fetchBackendWithReissue(`/api/v1/battle/rooms/${roomId}`, {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/battle/rooms/route.ts
+++ b/src/app/api/battle/rooms/route.ts
@@ -3,22 +3,20 @@ import { cookies } from "next/headers";
 
 import type { RoomListResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function GET() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend("/api/v1/battle/rooms", { token });
+    const response = await fetchBackendWithReissue("/api/v1/battle/rooms", {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/matches/[matchId]/accept/route.ts
+++ b/src/app/api/matches/[matchId]/accept/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const defaultMatchState: MatchStateResponse = {
   status: "IDLE",
@@ -22,17 +21,15 @@ export async function POST(
 ) {
   const { matchId } = await context.params;
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend(`/api/v2/matches/${matchId}/accept`, {
+    const response = await fetchBackendWithReissue(`/api/v2/matches/${matchId}/accept`, {
       method: "POST",
-      token,
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/matches/[matchId]/decline/route.ts
+++ b/src/app/api/matches/[matchId]/decline/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const defaultMatchState: MatchStateResponse = {
   status: "IDLE",
@@ -22,17 +21,15 @@ export async function POST(
 ) {
   const { matchId } = await context.params;
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend(`/api/v2/matches/${matchId}/decline`, {
+    const response = await fetchBackendWithReissue(`/api/v2/matches/${matchId}/decline`, {
       method: "POST",
-      token,
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/matches/me/route.ts
+++ b/src/app/api/matches/me/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { MatchStateResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const defaultMatchState: MatchStateResponse = {
   status: "IDLE",
@@ -18,14 +17,13 @@ const defaultMatchState: MatchStateResponse = {
 
 export async function GET() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend("/api/v2/matches/me", { token });
+    const response = await fetchBackendWithReissue("/api/v2/matches/me", {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/members/me/battle-results/route.ts
+++ b/src/app/api/members/me/battle-results/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { MyBattleResultsResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 function buildFallbackPageInfo(pageParam: string | null, sizeParam: string | null) {
   const page = Number(pageParam ?? "0");
@@ -28,27 +27,25 @@ export async function GET(request: Request) {
   const size = url.searchParams.get("size") ?? "20";
 
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json(
-      {
-        resultCode: "MEMBER_401",
-        msg: "로그인이 필요합니다.",
-        data: null,
-      } satisfies MyBattleResultsResponse,
-      { status: 401 },
-    );
-  }
 
   try {
-    const response = await fetchBackend("/api/v1/members/me/battle-results", {
-      token,
+    const response = await fetchBackendWithReissue("/api/v1/members/me/battle-results", {
       searchParams: {
         page,
         size,
       },
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json(
+        {
+          resultCode: "MEMBER_401",
+          msg: "로그인이 필요합니다.",
+          data: null,
+        } satisfies MyBattleResultsResponse,
+        { status: 401 },
+      );
+    }
 
     const body = await readJsonBody<MyBattleResultsResponse>(response.clone());
 

--- a/src/app/api/problems/[problemId]/route.ts
+++ b/src/app/api/problems/[problemId]/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { ProblemDetailResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function GET(
   _request: Request,
@@ -15,14 +14,13 @@ export async function GET(
 ) {
   const { problemId } = await context.params;
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend(`/api/v1/problems/${problemId}`, { token });
+    const response = await fetchBackendWithReissue(`/api/v1/problems/${problemId}`, {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/problems/[problemId]/run/route.ts
+++ b/src/app/api/problems/[problemId]/run/route.ts
@@ -6,11 +6,10 @@ import type {
   SoloRunResponse,
 } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function POST(
   request: Request,
@@ -24,11 +23,6 @@ export async function POST(
   }
 
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   let payload: SoloRunRequest;
 
@@ -43,15 +37,18 @@ export async function POST(
   }
 
   try {
-    const response = await fetchBackend("/api/v1/solo/run", {
+    const response = await fetchBackendWithReissue("/api/v1/solo/run", {
       method: "POST",
-      token,
       body: {
         problemId: parsedProblemId,
         code: payload.code,
         language: payload.language,
       },
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/problems/[problemId]/submit/route.ts
+++ b/src/app/api/problems/[problemId]/submit/route.ts
@@ -6,11 +6,10 @@ import type {
   SubmissionResponse,
 } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function POST(
   request: Request,
@@ -24,11 +23,6 @@ export async function POST(
   }
 
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   let payload: SoloSubmitRequest;
 
@@ -43,15 +37,18 @@ export async function POST(
   }
 
   try {
-    const response = await fetchBackend("/api/v1/solo/submissions", {
+    const response = await fetchBackendWithReissue("/api/v1/solo/submissions", {
       method: "POST",
-      token,
       body: {
         problemId: parsedProblemId,
         code: payload.code,
         language: payload.language,
       },
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/problems/route.ts
+++ b/src/app/api/problems/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { ProblemListResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const DEFAULT_PAGE = 0;
 const DEFAULT_SIZE = 20;
@@ -28,21 +27,19 @@ function parsePositiveInteger(value: string | null, fallback: number) {
 
 export async function GET(request: Request) {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   const { searchParams } = new URL(request.url);
   const page = parsePositiveInteger(searchParams.get("page"), DEFAULT_PAGE);
   const size = parsePositiveInteger(searchParams.get("size"), DEFAULT_SIZE);
 
   try {
-    const response = await fetchBackend("/api/v1/problems", {
-      token,
+    const response = await fetchBackendWithReissue("/api/v1/problems", {
       searchParams: { page, size },
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/queue/cancel/route.ts
+++ b/src/app/api/queue/cancel/route.ts
@@ -3,27 +3,24 @@ import { cookies } from "next/headers";
 
 import type { QueueStatusResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const DEFAULT_REQUIRED_COUNT = 4;
 
 export async function DELETE() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend("/api/v2/queue/cancel", {
+    const response = await fetchBackendWithReissue("/api/v2/queue/cancel", {
       method: "DELETE",
-      token,
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/queue/join/route.ts
+++ b/src/app/api/queue/join/route.ts
@@ -3,21 +3,15 @@ import { cookies } from "next/headers";
 
 import type { QueueJoinRequest, QueueStatusResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const DEFAULT_REQUIRED_COUNT = 4;
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   let payload: QueueJoinRequest;
 
@@ -28,11 +22,14 @@ export async function POST(request: Request) {
   }
 
   try {
-    const response = await fetchBackend("/api/v2/queue/join", {
+    const response = await fetchBackendWithReissue("/api/v2/queue/join", {
       method: "POST",
-      token,
       body: payload,
-    });
+    }, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/queue/me/route.ts
+++ b/src/app/api/queue/me/route.ts
@@ -3,11 +3,10 @@ import { cookies } from "next/headers";
 
 import type { QueueStateResponse } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
-import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 const DEFAULT_REQUIRED_COUNT = 4;
 
@@ -21,14 +20,13 @@ const inactiveQueueState: QueueStateResponse = {
 
 export async function GET() {
   const cookieStore = await cookies();
-  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!token) {
-    return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
-  }
 
   try {
-    const response = await fetchBackend("/api/v2/queue/me", { token });
+    const response = await fetchBackendWithReissue("/api/v2/queue/me", {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/run/route.ts
+++ b/src/app/api/run/route.ts
@@ -3,20 +3,16 @@ import { cookies } from "next/headers";
 
 import type { RunPayload } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
 } from "@/shared/api/backend";
-import {
-  FRONTEND_ACCESS_TOKEN_COOKIE,
-  getSessionMemberFromToken,
-} from "@/shared/auth/session";
+import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
 
-  if (!token || !member) {
+  if (!token) {
     return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 
@@ -29,15 +25,14 @@ export async function POST(request: Request) {
   }
 
   try {
-    const response = await fetchBackend("/api/v1/run", {
+    const response = await fetchBackendWithReissue("/api/v1/run", {
       method: "POST",
-      token,
       body: {
         roomId: payload.roomId,
         code: payload.code,
         language: payload.language,
       },
-    });
+    }, cookieStore);
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/submissions/route.ts
+++ b/src/app/api/submissions/route.ts
@@ -6,21 +6,21 @@ import type {
   SubmitPayload,
 } from "@/shared/api/contracts";
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
 import {
   FRONTEND_ACCESS_TOKEN_COOKIE,
-  getSessionMemberFromToken,
+  getMemberIdFromToken,
 } from "@/shared/auth/session";
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
   const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
-  const member = token ? getSessionMemberFromToken(token) : null;
+  const memberId = token ? getMemberIdFromToken(token) : null;
 
-  if (!token || !member) {
+  if (!token || !memberId) {
     return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
   }
 
@@ -33,16 +33,15 @@ export async function POST(request: Request) {
   }
 
   try {
-    const response = await fetchBackend("/api/v1/submissions", {
+    const response = await fetchBackendWithReissue("/api/v1/submissions", {
       method: "POST",
-      token,
       body: {
         roomId: payload.roomId,
-        memberId: member.memberId,
+        memberId,
         code: payload.code,
         language: payload.language,
       },
-    });
+    }, cookieStore);
 
     if (!response.ok) {
       return NextResponse.json(

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
 import {
-  fetchBackend,
+  fetchBackendWithReissue,
   getErrorMessage,
   readJsonBody,
 } from "@/shared/api/backend";
@@ -82,7 +82,7 @@ export async function GET() {
   }
 
   try {
-    const response = await fetchBackend("/api/v1/tags", { token });
+    const response = await fetchBackendWithReissue("/api/v1/tags", {}, cookieStore);
 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -50,7 +50,7 @@ export default function QueueEditorPane({
   terminalMessage,
 }: QueueEditorPaneProps) {
   return (
-    <main className="min-h-0 border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+    <main className="h-full overflow-hidden border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
       <div className="flex h-full min-h-0 flex-col">
         <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
           <div className="flex h-full items-end gap-0.5 pt-1">

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -371,9 +371,7 @@ export default function HomeScreen() {
 
     const updateEditorMetrics = () => {
       const { lineHeight, fontSize } = resolveEditorMetrics(window.innerWidth);
-      const fallbackHeight = Math.max(window.innerHeight - 180, lineHeight);
-      const measuredHeight = editorPane.getBoundingClientRect().height;
-      const usableHeight = Math.max(measuredHeight, fallbackHeight);
+      const usableHeight = Math.max(window.innerHeight - 180, lineHeight);
       const safetyBufferLines = 8;
       const nextLineCount = Math.max(
         24,
@@ -387,15 +385,9 @@ export default function HomeScreen() {
 
     updateEditorMetrics();
 
-    const resizeObserver = new ResizeObserver(() => {
-      updateEditorMetrics();
-    });
-
-    resizeObserver.observe(editorPane);
     window.addEventListener("resize", updateEditorMetrics);
 
     return () => {
-      resizeObserver.disconnect();
       window.removeEventListener("resize", updateEditorMetrics);
     };
   }, []);

--- a/src/shared/api/backend.ts
+++ b/src/shared/api/backend.ts
@@ -1,3 +1,24 @@
+import {
+  FRONTEND_ACCESS_TOKEN_COOKIE,
+  FRONTEND_REFRESH_TOKEN_COOKIE,
+  extractAccessTokenFromSetCookie,
+  ONE_YEAR_IN_SECONDS,
+} from "@/shared/auth/session";
+
+interface CookieStore {
+  get(name: string): { value: string } | undefined;
+  set(cookie: {
+    name: string;
+    value: string;
+    httpOnly: boolean;
+    sameSite: "lax";
+    secure: boolean;
+    path: string;
+    maxAge: number;
+  }): void;
+  delete(name: string): void;
+}
+
 const DEFAULT_BACKEND_BASE_URL = "http://localhost:8080";
 
 export function getBackendBaseUrl() {
@@ -25,12 +46,14 @@ export async function fetchBackend(
   path: string,
   {
     token,
+    refreshToken,
     headers,
     body,
     method = "GET",
     searchParams,
   }: {
     token?: string;
+    refreshToken?: string;
     headers?: HeadersInit;
     body?: BodyInit | object;
     method?: string;
@@ -41,6 +64,12 @@ export async function fetchBackend(
 
   if (token) {
     requestHeaders.set("Cookie", `accessToken=${token}`);
+  }
+
+  if (refreshToken) {
+    const existing = requestHeaders.get("Cookie");
+    const rtCookie = `refreshToken=${refreshToken}`;
+    requestHeaders.set("Cookie", existing ? `${existing}; ${rtCookie}` : rtCookie);
   }
 
   const init: RequestInit = {
@@ -86,6 +115,53 @@ export async function readJsonBody<T>(response: Response) {
   } catch {
     return null;
   }
+}
+
+export async function fetchBackendWithReissue(
+  path: string,
+  options: {
+    headers?: HeadersInit;
+    body?: BodyInit | object;
+    method?: string;
+    searchParams?: Record<string, string | number | undefined>;
+  } = {},
+  cookieStore: CookieStore,
+): Promise<Response> {
+  const accessToken = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
+  const response = await fetchBackend(path, { ...options, token: accessToken });
+
+  if (response.status !== 401) return response;
+
+  const refreshToken = cookieStore.get(FRONTEND_REFRESH_TOKEN_COOKIE)?.value;
+
+  if (!refreshToken) return response;
+
+  const reissueResponse = await fetchBackend("/api/v1/auth/reissue", {
+    method: "POST",
+    refreshToken,
+  });
+
+  if (!reissueResponse.ok) {
+    cookieStore.delete(FRONTEND_ACCESS_TOKEN_COOKIE);
+    cookieStore.delete(FRONTEND_REFRESH_TOKEN_COOKIE);
+    return response;
+  }
+
+  const newToken = extractAccessTokenFromSetCookie(reissueResponse.headers.get("set-cookie"));
+
+  if (!newToken) return response;
+
+  cookieStore.set({
+    name: FRONTEND_ACCESS_TOKEN_COOKIE,
+    value: newToken,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: ONE_YEAR_IN_SECONDS,
+  });
+
+  return fetchBackend(path, { ...options, token: newToken });
 }
 
 export async function getErrorMessage(response: Response) {

--- a/src/shared/auth/session.ts
+++ b/src/shared/auth/session.ts
@@ -1,6 +1,7 @@
 import type { SessionMember } from "@/shared/api/contracts";
 
 export const FRONTEND_ACCESS_TOKEN_COOKIE = "accessToken";
+export const FRONTEND_REFRESH_TOKEN_COOKIE = "refreshToken";
 export const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 
 interface JwtPayload {
@@ -65,4 +66,33 @@ export function extractAccessTokenFromSetCookie(
   }
 
   return decodeURIComponent(matched[1]);
+}
+
+export function extractRefreshTokenFromSetCookie(
+  setCookieHeader: string | null,
+): string | null {
+  if (!setCookieHeader) {
+    return null;
+  }
+
+  const matched = setCookieHeader.match(/(?:^|,\s*)refreshToken=([^;]+)/);
+
+  if (!matched?.[1]) {
+    return null;
+  }
+
+  return decodeURIComponent(matched[1]);
+}
+
+// exp 만료 여부와 무관하게 토큰에서 memberId만 추출 — 만료된 토큰에서도 사용 가능
+export function getMemberIdFromToken(token: string): number | null {
+  const payload = decodeJwtPayload(token);
+
+  if (!payload?.sub) {
+    return null;
+  }
+
+  const memberId = Number(payload.sub);
+
+  return Number.isFinite(memberId) ? memberId : null;
 }


### PR DESCRIPTION
## 작업 개요

accessToken 만료 시 refreshToken으로 자동 재발급 처리

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- [x] accessToken 만료 시 refreshToken으로 자동 재발급되도록 처리
- [x] 로그인 시 refresh토큰생성, 로그아웃 시 refresh토큰삭제 연동

## 변경 사항

- FRONTEND_REFRESH_TOKEN_COOKIE, extractRefreshTokenFromSetCookie, getMemberIdFromToken 추가
- fetchBackend에 refreshToken 파라미터 추가, fetchBackendWithReissue 추가
- 로그인 시 refreshToken 쿠키 저장, 로그아웃 시 refreshToken 쿠키 삭제
- 나머지 route를 fetchBackend → fetchBackendWithReissue 교체

## 테스트 및 확인

- [x] accessToken 만료 시간 이후에도 api동작 확인
- [x] 로그인 시 토큰 생성, 로그아웃 시 토큰삭제 확인

## 관련 이슈

- close #34 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
