### PR TITLE
[fix] 초기 렌더 지연 및 세션 동기화 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { cookies } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
+
+import type { SessionResponse } from "@/shared/api/contracts";
+import {
+  FRONTEND_ACCESS_TOKEN_COOKIE,
+  getSessionMemberFromToken,
+} from "@/shared/auth/session";
+
 import "./globals.css";
 import "katex/dist/katex.min.css";
 import IdeShell from "@/features/layout/ide-shell";
@@ -24,11 +32,19 @@ export const metadata: Metadata = {
     "실제 백엔드 API와 화면 구조를 맞추는 Algo Battle 프론트엔드.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(FRONTEND_ACCESS_TOKEN_COOKIE)?.value;
+  const member = token ? getSessionMemberFromToken(token) : null;
+  const initialSession: SessionResponse = {
+    authenticated: member !== null,
+    member,
+  };
+
   return (
     <html
       lang="ko"
@@ -44,7 +60,7 @@ export default function RootLayout({
             </div>
           </header>
           <main className="flex min-h-0 flex-1">
-            <IdeShell>{children}</IdeShell>
+            <IdeShell initialSession={initialSession}>{children}</IdeShell>
           </main>
         </div>
       </body>

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -13,10 +13,10 @@ import type {
   RoomResponse,
   RunTestCaseResult,
   RunWsMessage,
-  SessionResponse,
   SubmissionResponse,
   SubmissionWsMessage,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 import {
   ApiCallout,
   DefinitionGrid,
@@ -55,24 +55,8 @@ function participantTone(status: string) {
   return "default" as const;
 }
 
-async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
-
-  if (!response.ok) {
-    return {
-      authenticated: false,
-      member: null,
-    } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
-
 export default function BattleRoomScreen({ roomId }: { roomId: string }) {
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
+  const { session, sessionLoaded, refreshSession } = useAppSession();
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [latestSubmission, setLatestSubmission] =
@@ -89,11 +73,18 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    void (async () => {
-      const nextSession = await readSession();
-      setSession(nextSession);
+    if (!sessionLoaded) {
+      return;
+    }
 
-      if (!nextSession.authenticated) {
+    let active = true;
+
+    void (async () => {
+      if (!session.authenticated) {
+        if (!active) {
+          return;
+        }
+        setRoom(null);
         setMessage("배틀룸은 로그인 후 접근할 수 있습니다.");
         return;
       }
@@ -103,9 +94,16 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       });
 
       if (!roomResponse.ok) {
+        if (roomResponse.status === 401) {
+          void refreshSession();
+        }
+
         const fallbackRoom = getBattleRoom(roomId);
 
         if (fallbackRoom) {
+          if (!active) {
+            return;
+          }
           setSource("fallback");
           setRoom(fallbackRoom);
           setProblem(getProblemDetail(fallbackRoom.problemId));
@@ -114,11 +112,17 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         }
 
         const payload = (await roomResponse.json().catch(() => null)) as ApiErrorResponse | null;
+        if (!active) {
+          return;
+        }
         setError(payload?.message ?? "배틀룸을 불러오지 못했습니다.");
         return;
       }
 
       const nextRoom = (await roomResponse.json()) as RoomResponse;
+      if (!active) {
+        return;
+      }
       setRoom(nextRoom);
       setSource("api");
 
@@ -127,14 +131,24 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       });
 
       if (problemResponse.ok) {
+        if (!active) {
+          return;
+        }
         setProblem((await problemResponse.json()) as ProblemDetailResponse);
         setMessage("실제 API 기반 배틀룸을 표시합니다.");
       } else {
+        if (!active) {
+          return;
+        }
         setProblem(getProblemDetail(nextRoom.problemId));
         setMessage("문제 상세 조회에 실패해 샘플 설명을 함께 표시합니다.");
       }
     })();
-  }, [roomId]);
+
+    return () => {
+      active = false;
+    };
+  }, [refreshSession, roomId, session.authenticated, sessionLoaded]);
 
   useEffect(() => {
     if (
@@ -181,7 +195,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         }
       })();
     });
-  }, [room, roomId, session]);
+  }, [room, roomId, session.authenticated, session.member?.memberId]);
 
   // WebSocket: BATTLE_STARTED 이벤트 수신 시 방 상태 자동 갱신
   useEffect(() => {
@@ -285,7 +299,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       stompClientRef.current = null;
       void client.deactivate();
     };
-  }, [roomId, session.authenticated]);
+  }, [roomId, session.authenticated, session.member?.memberId]);
 
   function handleSubmit() {
     if (!room) {
@@ -342,6 +356,19 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       }
       // 성공 시 결과는 WebSocket(RUN_RESULT)으로 수신
     })();
+  }
+
+  if (!sessionLoaded && !room) {
+    return (
+      <div className="space-y-8">
+        <PageHero
+          eyebrow="Battle Room"
+          title="세션을 확인하는 중입니다."
+          description="잠시만 기다려주세요."
+          actions={<StatusPill>Session</StatusPill>}
+        />
+      </div>
+    );
   }
 
   if (!session.authenticated && !room) {

--- a/src/features/home/components/quick-menu-pane.tsx
+++ b/src/features/home/components/quick-menu-pane.tsx
@@ -289,7 +289,7 @@ export default function QuickMenuPane({
                       : item.href;
 
                 return (
-                  <Link key={item.key} href={href}>
+                  <Link key={item.key} href={href} prefetch={false}>
                     {content}
                   </Link>
                 );
@@ -303,4 +303,3 @@ export default function QuickMenuPane({
     </aside>
   );
 }
-

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -9,8 +9,8 @@ import type {
   MatchStateResponse,
   QueueStateResponse,
   QueueStatusResponse,
-  SessionResponse,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 
 import {
   DEFAULT_REQUIRED_COUNT,
@@ -52,22 +52,6 @@ const defaultMatchState: MatchStateResponse = {
   room: null,
   message: null,
 };
-
-async function readSession() {
-  const response = await fetch("/api/auth/session", {
-    cache: "no-store",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    return {
-      authenticated: false,
-      member: null,
-    } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
 
 async function readQueueState() {
   const response = await fetch("/api/queue/me", {
@@ -178,10 +162,7 @@ function getApiErrorMessage(
 
 export default function HomeScreen() {
   const router = useRouter();
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
+  const { session, sessionLoaded } = useAppSession();
   const [queueState, setQueueState] = useState(defaultQueueState);
   const [matchState, setMatchState] = useState(defaultMatchState);
   const [category, setCategory] = useState<QueueCategoryValue>("dp");
@@ -386,18 +367,14 @@ export default function HomeScreen() {
   }, []);
 
   useEffect(() => {
+    if (!sessionLoaded) {
+      return;
+    }
+
     let active = true;
 
     void (async () => {
-      const nextSession = await readSession();
-
-      if (!active) {
-        return;
-      }
-
-      setSession(nextSession);
-
-      if (!nextSession.authenticated) {
+      if (!session.authenticated) {
         resetFlow();
         return;
       }
@@ -434,7 +411,7 @@ export default function HomeScreen() {
     return () => {
       active = false;
     };
-  }, [applyMatchSnapshot, resetFlow]);
+  }, [applyMatchSnapshot, resetFlow, session.authenticated, sessionLoaded]);
 
   useEffect(() => {
     if (!session.authenticated || pollStage !== "QUEUE") {

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -37,6 +37,7 @@ type BusyAction =
   | null;
 
 const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
+const TAGS_CACHE_TTL_MS = 60_000;
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
@@ -52,6 +53,12 @@ const defaultMatchState: MatchStateResponse = {
   room: null,
   message: null,
 };
+
+let tagCategoriesCache: {
+  expiresAt: number;
+  categories: QueueCategoryOption[];
+} | null = null;
+let tagCategoriesInFlight: Promise<QueueCategoryOption[] | null> | null = null;
 
 async function readQueueState() {
   const response = await fetch("/api/queue/me", {
@@ -80,29 +87,56 @@ async function readMatchState() {
 }
 
 async function readTagCategories() {
-  const response = await fetch("/api/tags", {
-    cache: "no-store",
-  });
+  const now = Date.now();
 
-  if (!response.ok) {
-    return null;
+  if (tagCategoriesCache && tagCategoriesCache.expiresAt > now) {
+    return tagCategoriesCache.categories;
   }
 
-  const payload = (await response.json().catch(() => null)) as QueueCategoryOption[] | null;
-
-  if (!Array.isArray(payload) || payload.length === 0) {
-    return null;
+  if (tagCategoriesInFlight) {
+    return tagCategoriesInFlight;
   }
 
-  const normalized = payload
-    .map((item) => ({
-      value: (item.value ?? "").trim(),
-      label: (item.label ?? "").trim(),
-      disabled: item.disabled ?? false,
-    }))
-    .filter((item) => item.value.length > 0 && item.label.length > 0);
+  const task = (async () => {
+    const response = await fetch("/api/tags");
 
-  return normalized.length > 0 ? normalized : null;
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json().catch(() => null)) as QueueCategoryOption[] | null;
+
+    if (!Array.isArray(payload) || payload.length === 0) {
+      return null;
+    }
+
+    const normalized = payload
+      .map((item) => ({
+        value: (item.value ?? "").trim(),
+        label: (item.label ?? "").trim(),
+        disabled: item.disabled ?? false,
+      }))
+      .filter((item) => item.value.length > 0 && item.label.length > 0);
+
+    if (normalized.length === 0) {
+      return null;
+    }
+
+    tagCategoriesCache = {
+      expiresAt: Date.now() + TAGS_CACHE_TTL_MS,
+      categories: normalized,
+    };
+
+    return normalized;
+  })();
+
+  tagCategoriesInFlight = task;
+
+  try {
+    return await task;
+  } finally {
+    tagCategoriesInFlight = null;
+  }
 }
 
 async function postMatchDecision(matchId: number, action: "accept" | "decline") {

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   MyBattleResultItem,
@@ -48,16 +48,20 @@ async function readMyBattleResultsPreview(size: number) {
   };
 }
 
-export default function IdeShell({ children }: { children: React.ReactNode }) {
+export default function IdeShell({
+  children,
+  initialSession,
+}: {
+  children: React.ReactNode;
+  initialSession: SessionResponse;
+}) {
   const pathname = usePathname();
   const router = useRouter();
+  const isFirstRouteSyncRef = useRef(true);
   const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
   const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
-  const [sessionLoaded, setSessionLoaded] = useState(false);
+  const [session, setSession] = useState<SessionResponse>(initialSession);
+  const [sessionLoaded, setSessionLoaded] = useState(true);
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
   const [resultsPreviewMessage, setResultsPreviewMessage] = useState(
     "로그인 후 최근 전적을 확인할 수 있습니다.",
@@ -73,6 +77,11 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (isFirstRouteSyncRef.current) {
+      isFirstRouteSyncRef.current = false;
+      return;
+    }
+
     void refreshSession();
   }, [pathname, refreshSession]);
 

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -57,7 +57,7 @@ export default function IdeShell({
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const isFirstRouteSyncRef = useRef(true);
+  const refreshInFlightRef = useRef<Promise<SessionResponse> | null>(null);
   const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
   const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
   const [session, setSession] = useState<SessionResponse>(initialSession);
@@ -70,20 +70,47 @@ export default function IdeShell({
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const refreshSession = useCallback(async () => {
-    const nextSession = await readSession();
-    setSession(nextSession);
-    setSessionLoaded(true);
-    return nextSession;
+    // 중복 요청으로 세션 상태가 흔들리지 않도록 in-flight 요청을 재사용한다.
+    if (refreshInFlightRef.current) {
+      return refreshInFlightRef.current;
+    }
+
+    const task = (async () => {
+      const nextSession = await readSession();
+      setSession(nextSession);
+      setSessionLoaded(true);
+      return nextSession;
+    })();
+
+    refreshInFlightRef.current = task;
+
+    try {
+      return await task;
+    } finally {
+      refreshInFlightRef.current = null;
+    }
   }, []);
 
   useEffect(() => {
-    if (isFirstRouteSyncRef.current) {
-      isFirstRouteSyncRef.current = false;
-      return;
-    }
+    // 라우트 이동마다 재조회하지 않고, 탭 복귀 시점에만 세션을 최신화한다.
+    const onWindowFocus = () => {
+      void refreshSession();
+    };
 
-    void refreshSession();
-  }, [pathname, refreshSession]);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refreshSession();
+      }
+    };
+
+    window.addEventListener("focus", onWindowFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", onWindowFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [refreshSession]);
 
   useEffect(() => {
     let active = true;
@@ -108,6 +135,8 @@ export default function IdeShell({
       }
 
       if (status === 401 || payload?.resultCode === "MEMBER_401") {
+        // 401은 서버가 인증 만료/무효를 확정한 신호이므로 전역 세션을 즉시 재동기화한다.
+        void refreshSession();
         setRecentResults([]);
         setResultsPreviewError(null);
         setResultsPreviewMessage(payload?.msg ?? "로그인이 필요합니다.");
@@ -132,7 +161,7 @@ export default function IdeShell({
     return () => {
       active = false;
     };
-  }, [session.authenticated]);
+  }, [refreshSession, session.authenticated]);
 
   async function handleLogout() {
     setIsLoggingOut(true);

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type {
   MyBattleResultItem,
@@ -13,6 +13,7 @@ import ProfilePane from "@/features/home/components/profile-pane";
 import QuickMenuPane, {
   type QuickMenuTreeItem,
 } from "@/features/home/components/quick-menu-pane";
+import SessionContext from "@/features/layout/session-context";
 
 const PREVIEW_RESULTS_SIZE = 5;
 
@@ -56,6 +57,7 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
     authenticated: false,
     member: null,
   });
+  const [sessionLoaded, setSessionLoaded] = useState(false);
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
   const [resultsPreviewMessage, setResultsPreviewMessage] = useState(
     "로그인 후 최근 전적을 확인할 수 있습니다.",
@@ -63,23 +65,16 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
   const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
+  const refreshSession = useCallback(async () => {
+    const nextSession = await readSession();
+    setSession(nextSession);
+    setSessionLoaded(true);
+    return nextSession;
+  }, []);
+
   useEffect(() => {
-    let active = true;
-
-    void (async () => {
-      const nextSession = await readSession();
-
-      if (!active) {
-        return;
-      }
-
-      setSession(nextSession);
-    })();
-
-    return () => {
-      active = false;
-    };
-  }, [pathname]);
+    void refreshSession();
+  }, [pathname, refreshSession]);
 
   useEffect(() => {
     let active = true;
@@ -142,6 +137,7 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
         authenticated: false,
         member: null,
       });
+      setSessionLoaded(true);
       router.refresh();
     } finally {
       setIsLoggingOut(false);
@@ -228,41 +224,43 @@ export default function IdeShell({ children }: { children: React.ReactNode }) {
     pathname === "/mypage";
 
   return (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
-      <div className={`grid h-full w-full ${layoutColumnsClass}`}>
-        <QuickMenuPane
-          isQuickMenuOpen={isQuickMenuOpen}
-          onToggleQuickMenu={() => setIsQuickMenuOpen((current) => !current)}
-          sessionAuthenticated={session.authenticated}
-          projectTreeItems={projectTreeItems}
-        />
+    <SessionContext.Provider value={{ session, sessionLoaded, refreshSession }}>
+      <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
+        <div className={`grid h-full w-full ${layoutColumnsClass}`}>
+          <QuickMenuPane
+            isQuickMenuOpen={isQuickMenuOpen}
+            onToggleQuickMenu={() => setIsQuickMenuOpen((current) => !current)}
+            sessionAuthenticated={session.authenticated}
+            projectTreeItems={projectTreeItems}
+          />
 
-        <section className="min-h-0 overflow-hidden bg-[#1e1f22]">
-          {isFullBleedCenter ? (
-            <div className="h-full min-h-0">{children}</div>
-          ) : (
-            <div className="h-full overflow-y-auto">
-              <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">{children}</div>
-            </div>
-          )}
-        </section>
+          <section className="min-h-0 overflow-hidden bg-[#1e1f22]">
+            {isFullBleedCenter ? (
+              <div className="h-full min-h-0">{children}</div>
+            ) : (
+              <div className="h-full overflow-y-auto">
+                <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">{children}</div>
+              </div>
+            )}
+          </section>
 
-        <ProfilePane
-          isProfilePanelOpen={isProfilePanelOpen}
-          onToggleProfilePanel={() => setIsProfilePanelOpen((current) => !current)}
-          session={session}
-          previewPlayedCount={previewPlayedCount}
-          previewSolvedCount={previewSolvedCount}
-          previewWinRate={previewWinRate}
-          previewScoreDeltaLabel={previewScoreDeltaLabel}
-          resultsPreviewMessage={resultsPreviewMessage}
-          resultsPreviewError={resultsPreviewError}
-          isBusy={isLoggingOut}
-          onLogout={() => {
-            void handleLogout();
-          }}
-        />
+          <ProfilePane
+            isProfilePanelOpen={isProfilePanelOpen}
+            onToggleProfilePanel={() => setIsProfilePanelOpen((current) => !current)}
+            session={session}
+            previewPlayedCount={previewPlayedCount}
+            previewSolvedCount={previewSolvedCount}
+            previewWinRate={previewWinRate}
+            previewScoreDeltaLabel={previewScoreDeltaLabel}
+            resultsPreviewMessage={resultsPreviewMessage}
+            resultsPreviewError={resultsPreviewError}
+            isBusy={isLoggingOut}
+            onLogout={() => {
+              void handleLogout();
+            }}
+          />
+        </div>
       </div>
-    </div>
+    </SessionContext.Provider>
   );
 }

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -68,6 +68,15 @@ export default function IdeShell({
   );
   const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const applySession = useCallback((nextSession: SessionResponse) => {
+    setSession(nextSession);
+    setSessionLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    // router.refresh() 이후 서버에서 내려준 초기 세션을 클라이언트 전역 상태에 반영한다.
+    applySession(initialSession);
+  }, [applySession, initialSession]);
 
   const refreshSession = useCallback(async () => {
     // 중복 요청으로 세션 상태가 흔들리지 않도록 in-flight 요청을 재사용한다.
@@ -171,11 +180,10 @@ export default function IdeShell({
         method: "POST",
         credentials: "include",
       });
-      setSession({
+      applySession({
         authenticated: false,
         member: null,
       });
-      setSessionLoaded(true);
       router.refresh();
     } finally {
       setIsLoggingOut(false);
@@ -262,7 +270,7 @@ export default function IdeShell({
     pathname === "/mypage";
 
   return (
-    <SessionContext.Provider value={{ session, sessionLoaded, refreshSession }}>
+    <SessionContext.Provider value={{ session, sessionLoaded, refreshSession, applySession }}>
       <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
         <div className={`grid h-full w-full ${layoutColumnsClass}`}>
           <QuickMenuPane

--- a/src/features/layout/session-context.tsx
+++ b/src/features/layout/session-context.tsx
@@ -8,6 +8,7 @@ interface SessionContextValue {
   session: SessionResponse;
   sessionLoaded: boolean;
   refreshSession: () => Promise<SessionResponse>;
+  applySession: (nextSession: SessionResponse) => void;
 }
 
 const defaultSession: SessionResponse = {
@@ -19,6 +20,7 @@ const SessionContext = createContext<SessionContextValue>({
   session: defaultSession,
   sessionLoaded: false,
   refreshSession: async () => defaultSession,
+  applySession: () => undefined,
 });
 
 export function useAppSession() {

--- a/src/features/layout/session-context.tsx
+++ b/src/features/layout/session-context.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+import type { SessionResponse } from "@/shared/api/contracts";
+
+interface SessionContextValue {
+  session: SessionResponse;
+  sessionLoaded: boolean;
+  refreshSession: () => Promise<SessionResponse>;
+}
+
+const defaultSession: SessionResponse = {
+  authenticated: false,
+  member: null,
+};
+
+const SessionContext = createContext<SessionContextValue>({
+  session: defaultSession,
+  sessionLoaded: false,
+  refreshSession: async () => defaultSession,
+});
+
+export function useAppSession() {
+  return useContext(SessionContext);
+}
+
+export default SessionContext;

--- a/src/features/login/screen.tsx
+++ b/src/features/login/screen.tsx
@@ -9,6 +9,7 @@ import type {
   AuthMutationResponse,
   LoginRequest,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 
 const initialForm: LoginRequest = {
   email: "",
@@ -17,6 +18,7 @@ const initialForm: LoginRequest = {
 
 export default function LoginScreen() {
   const router = useRouter();
+  const { applySession } = useAppSession();
   const searchParams = useSearchParams();
   const nextPath = searchParams.get("next") || "/";
   const [form, setForm] = useState(initialForm);
@@ -46,6 +48,10 @@ export default function LoginScreen() {
 
         const payload = (await response.json()) as AuthMutationResponse;
         setMessage(payload.message);
+        applySession({
+          authenticated: payload.authenticated,
+          member: payload.member,
+        });
         router.push(nextPath);
         router.refresh();
       })();

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -7,8 +7,8 @@ import type {
   MyBattleResultItem,
   MyBattleResultsResponse,
   PageInfo,
-  SessionResponse,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 import { formatDateTime } from "@/shared/utils/format-date-time";
 import { formatRoleLabel } from "@/shared/utils/format-role-label";
 
@@ -21,22 +21,6 @@ const defaultPageInfo: PageInfo = {
   totalPages: 0,
   hasNext: false,
 };
-
-async function readSession() {
-  const response = await fetch("/api/auth/session", {
-    cache: "no-store",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    return {
-      authenticated: false,
-      member: null,
-    } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
 
 async function readMyBattleResults(page: number, size: number) {
   const response = await fetch(`/api/members/me/battle-results?page=${page}&size=${size}`, {
@@ -149,10 +133,7 @@ function LoadingRows() {
 }
 
 export default function MyPageScreen() {
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
+  const { session, sessionLoaded, refreshSession } = useAppSession();
   const [battleResults, setBattleResults] = useState<MyBattleResultItem[]>([]);
   const [pageInfo, setPageInfo] = useState(defaultPageInfo);
   const [message, setMessage] = useState("내 전적을 불러오는 중입니다.");
@@ -161,18 +142,14 @@ export default function MyPageScreen() {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
+    if (!sessionLoaded) {
+      return;
+    }
+
     let active = true;
 
     void (async () => {
-      const nextSession = await readSession();
-
-      if (!active) {
-        return;
-      }
-
-      setSession(nextSession);
-
-      if (!nextSession.authenticated) {
+      if (!session.authenticated) {
         setIsLoading(false);
         setMessage("로그인 후 내 전적을 확인할 수 있습니다.");
         return;
@@ -185,10 +162,7 @@ export default function MyPageScreen() {
       }
 
       if (status === 401 || payload?.resultCode === "MEMBER_401") {
-        setSession({
-          authenticated: false,
-          member: null,
-        });
+        void refreshSession();
         setBattleResults([]);
         setPageInfo(defaultPageInfo);
         setError(null);
@@ -216,7 +190,7 @@ export default function MyPageScreen() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [refreshSession, session.authenticated, sessionLoaded]);
 
   async function handleLoadMore() {
     if (!session.authenticated || !pageInfo.hasNext || isLoadingMore) {
@@ -229,10 +203,7 @@ export default function MyPageScreen() {
     const { ok, status, payload } = await readMyBattleResults(nextPage, pageInfo.size);
 
     if (status === 401 || payload?.resultCode === "MEMBER_401") {
-      setSession({
-        authenticated: false,
-        member: null,
-      });
+      void refreshSession();
       setBattleResults([]);
       setPageInfo(defaultPageInfo);
       setError(null);

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -9,7 +9,6 @@ import SockJS from "sockjs-client";
 import type {
   ApiErrorResponse,
   ProblemDetailResponse,
-  SessionResponse,
   SoloRunRequest,
   SoloRunResponse,
   SoloSubmitRequest,
@@ -18,6 +17,7 @@ import type {
   SubmissionResponse,
   SubmissionWsMessage,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 import {
   DefinitionGrid,
   MathText,
@@ -207,19 +207,6 @@ function resolveDefaultLanguage(problem: ProblemDetailResponse | null) {
   return languages[0];
 }
 
-async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
-
-  if (!response.ok) {
-    return {
-      authenticated: false,
-      member: null,
-    } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
-
 async function readProblem(problemId: string) {
   const response = await fetch(`/api/problems/${problemId}`, { cache: "no-store" });
 
@@ -238,11 +225,7 @@ async function readProblem(problemId: string) {
 }
 
 export default function ProblemSoloScreen({ problemId }: { problemId: string }) {
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
-  const [sessionLoaded, setSessionLoaded] = useState(false);
+  const { session, sessionLoaded } = useAppSession();
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [problemError, setProblemError] = useState<string | null>(null);
   const [isProblemLoading, setIsProblemLoading] = useState(true);
@@ -259,14 +242,6 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
   const runTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    void (async () => {
-      const nextSession = await readSession();
-      setSession(nextSession);
-      setSessionLoaded(true);
-    })();
-  }, []);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1280px)");

--- a/src/features/problems/screen.tsx
+++ b/src/features/problems/screen.tsx
@@ -6,24 +6,11 @@ import { useEffect, useState } from "react";
 import type {
   ApiErrorResponse,
   ProblemListResponse,
-  SessionResponse,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 
 const PROBLEM_PAGE_SIZE = 20;
 const MAX_PAGE_BUTTONS = 7;
-
-async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
-
-  if (!response.ok) {
-    return {
-      authenticated: false,
-      member: null,
-    } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
 
 async function readProblemList(page: number) {
   const searchParams = new URLSearchParams({
@@ -77,23 +64,11 @@ function getPageTokens(currentPage: number, totalPages: number) {
 }
 
 export default function ProblemsScreen() {
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
-  const [sessionLoaded, setSessionLoaded] = useState(false);
+  const { session, sessionLoaded } = useAppSession();
   const [problemPage, setProblemPage] = useState(0);
   const [problemList, setProblemList] = useState<ProblemListResponse | null>(null);
   const [problemError, setProblemError] = useState<string | null>(null);
   const [isProblemLoading, setIsProblemLoading] = useState(false);
-
-  useEffect(() => {
-    void (async () => {
-      const nextSession = await readSession();
-      setSession(nextSession);
-      setSessionLoaded(true);
-    })();
-  }, []);
 
   useEffect(() => {
     if (!sessionLoaded) {

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -10,8 +10,8 @@ import type {
   CodeUpdateWsMessage,
   ProblemDetailResponse,
   RoomResponse,
-  SessionResponse,
 } from "@/shared/api/contracts";
+import { useAppSession } from "@/features/layout/session-context";
 import {
   CodeWindow,
   MetricCard,
@@ -23,21 +23,8 @@ import {
 
 import { getSpectateRoom } from "./data";
 
-async function readSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
-
-  if (!response.ok) {
-    return { authenticated: false, member: null } satisfies SessionResponse;
-  }
-
-  return (await response.json()) as SessionResponse;
-}
-
 export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
-  const [session, setSession] = useState<SessionResponse>({
-    authenticated: false,
-    member: null,
-  });
+  const { session, sessionLoaded, refreshSession } = useAppSession();
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [message, setMessage] = useState("관전 정보를 불러오는 중입니다.");
@@ -49,21 +36,37 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
 
   // 세션 및 방 정보 로드
   useEffect(() => {
-    void (async () => {
-      const nextSession = await readSession();
-      setSession(nextSession);
+    if (!sessionLoaded) {
+      return;
+    }
 
-      if (!nextSession.authenticated) {
+    let active = true;
+
+    void (async () => {
+      if (!session.authenticated) {
+        if (!active) {
+          return;
+        }
         setRequiresLogin(true);
         setMessage("관전 상세는 로그인 후 접근할 수 있습니다.");
         return;
       }
+
+      if (!active) {
+        return;
+      }
+
+      setRequiresLogin(false);
 
       const response = await fetch(`/api/battle/rooms/${roomId}`, {
         cache: "no-store",
       });
 
       if (response.status === 401) {
+        void refreshSession();
+        if (!active) {
+          return;
+        }
         setRequiresLogin(true);
         setMessage("관전 상세는 로그인 후 접근할 수 있습니다.");
         return;
@@ -73,16 +76,25 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         const fallback = getSpectateRoom(roomId);
 
         if (fallback) {
+          if (!active) {
+            return;
+          }
           setMessage("백엔드 연결 실패로 샘플 관전 데이터를 표시합니다.");
           return;
         }
 
         const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+        if (!active) {
+          return;
+        }
         setError(payload?.message ?? "관전 상세를 불러오지 못했습니다.");
         return;
       }
 
       const nextRoom = (await response.json()) as RoomResponse;
+      if (!active) {
+        return;
+      }
       setRoom(nextRoom);
 
       const problemResponse = await fetch(`/api/problems/${nextRoom.problemId}`, {
@@ -90,12 +102,22 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
       });
 
       if (problemResponse.ok) {
+        if (!active) {
+          return;
+        }
         setProblem((await problemResponse.json()) as ProblemDetailResponse);
       }
 
+      if (!active) {
+        return;
+      }
       setMessage("실시간 관전 중입니다.");
     })();
-  }, [roomId]);
+
+    return () => {
+      active = false;
+    };
+  }, [refreshSession, roomId, session.authenticated, sessionLoaded]);
 
   // WebSocket: /topic/room/{roomId}/spectate 구독
   useEffect(() => {


### PR DESCRIPTION
## 작업 개요

초기 렌더 시 불필요 호출을 줄이고, 로그인 직후 세션 반영 지연 문제를 수정했습니다.

## 커밋별 변경

### 1) 세션 단일화
- 페이지별 세션 조회를 IdeShell 전역 세션 기준으로 통합

### 2) 초기 세션 서버 주입
- layout 서버에서 쿠키 기반 초기 세션을 IdeShell에 주입

### 3) 동기화 기준 정리
- 중복 요청 방지, focus/visibility 갱신, 401 재동기화 기준 반영

### 4) 로그인 직후 즉시 반영
- 로그인 응답 payload를 전역 세션에 즉시 반영

### 5) 호출 최적화
- 퀵메뉴 Link prefetch 비활성화
- `/api/tags` 60초 TTL + in-flight dedupe 적용

## 영향 범위

- route: `/`, `/login`, `/problems`, `/mypage`, `/spectate`, `/battle/rooms/[roomId]`
- feature: 전역 세션 처리, 초기 렌더 최적화

## 테스트 및 확인

- [x] `npx tsc --noEmit`
- [x] 로그인 후 보호 페이지 즉시 접근 수동 확인
- [ ] `npm run lint` (저장소 ESLint import 경로 이슈로 실패)

## 관련 이슈

- close #33
