### PR TITLE
feat: 메인 홈 매칭 흐름에 queue WebSocket 구독 추가

### DIFF
--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -2,11 +2,14 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
   Difficulty,
   MatchStateResponse,
+  MatchingWsMessage,
   QueueStateResponse,
   QueueStatusResponse,
 } from "@/shared/api/contracts";
@@ -35,9 +38,11 @@ type BusyAction =
   | "decline"
   | "join-room"
   | null;
+type SubscriptionHandle = { unsubscribe: () => void };
 
 const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
 const TAGS_CACHE_TTL_MS = 60_000;
+const MATCHING_PERSONAL_DESTINATION = "/user/queue/matching";
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
@@ -194,6 +199,48 @@ function getApiErrorMessage(
   return fallback;
 }
 
+function buildQueueTopicDestination(category: string, difficulty: string) {
+  const normalize = (value: string) => encodeURIComponent(value.trim().toUpperCase());
+
+  return `/topic/matching/queue/${normalize(category)}/${normalize(difficulty)}`;
+}
+
+function parseMatchingWsMessage(body: string): MatchingWsMessage | null {
+  try {
+    const payload = JSON.parse(body) as unknown;
+
+    if (!payload || typeof payload !== "object" || !("type" in payload)) {
+      return null;
+    }
+
+    const typed = payload as { type?: unknown };
+
+    if (
+      typed.type === "QUEUE_STATE_CHANGED" ||
+      typed.type === "READY_CHECK_STARTED"
+    ) {
+      return payload as MatchingWsMessage;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function logMatchingDebug(label: string, payload?: unknown) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (payload === undefined) {
+    console.log(`[matching] ${label}`);
+    return;
+  }
+
+  console.log(`[matching] ${label}`, payload);
+}
+
 export default function HomeScreen() {
   const router = useRouter();
   const { session, sessionLoaded } = useAppSession();
@@ -213,10 +260,20 @@ export default function HomeScreen() {
   const [now, setNow] = useState(Date.now());
 
   const joiningRoomIdRef = useRef<number | null>(null);
+  const stompClientRef = useRef<Client | null>(null);
+  const personalSubscriptionRef = useRef<SubscriptionHandle | null>(null);
+  const queueTopicSubscriptionRef = useRef<SubscriptionHandle | null>(null);
+  const queueTopicDestinationRef = useRef<string | null>(null);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
   const [editorLineCount, setEditorLineCount] = useState(28);
   const [editorLineHeight, setEditorLineHeight] = useState(32);
   const [editorFontSize, setEditorFontSize] = useState(13);
+
+  const clearQueueTopicSubscription = useCallback(() => {
+    queueTopicSubscriptionRef.current?.unsubscribe();
+    queueTopicSubscriptionRef.current = null;
+    queueTopicDestinationRef.current = null;
+  }, []);
 
   const resetFlow = useCallback((nextFeedback = DEFAULT_FEEDBACK) => {
     setQueueState(defaultQueueState);
@@ -307,6 +364,77 @@ export default function HomeScreen() {
     [router],
   );
 
+  const handleQueueStateChangedEvent = useCallback((nextQueueState: QueueStateResponse) => {
+    logMatchingDebug("ws QUEUE_STATE_CHANGED", nextQueueState);
+    setQueueState({
+      ...nextQueueState,
+      requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+    });
+    setQueueStartedAt((current) => current ?? new Date().toISOString());
+    setError(null);
+    setFeedback("대기열 인원이 갱신되었습니다.");
+  }, []);
+
+  const handleReadyCheckStartedEvent = useCallback(
+    (nextMatchState: MatchStateResponse | null) => {
+      logMatchingDebug("ws READY_CHECK_STARTED", nextMatchState);
+      clearQueueTopicSubscription();
+
+      setQueueState(defaultQueueState);
+      setQueueStartedAt(null);
+      setError(null);
+
+      if (nextMatchState) {
+        applyMatchSnapshot(nextMatchState);
+        return;
+      }
+
+      setModalMode("READY_CHECK");
+      setPollStage("MATCH");
+      setFeedback("ready-check 세션을 확인하는 중입니다.");
+    },
+    [applyMatchSnapshot, clearQueueTopicSubscription],
+  );
+
+  const syncQueueTopicSubscription = useCallback(
+    (categoryValue: string | null, difficultyValue: string | null) => {
+      if (!categoryValue || !difficultyValue) {
+        clearQueueTopicSubscription();
+        return;
+      }
+
+      const destination = buildQueueTopicDestination(categoryValue, difficultyValue);
+
+      if (
+        queueTopicDestinationRef.current === destination &&
+        queueTopicSubscriptionRef.current
+      ) {
+        return;
+      }
+
+      queueTopicSubscriptionRef.current?.unsubscribe();
+      queueTopicSubscriptionRef.current = null;
+      queueTopicDestinationRef.current = destination;
+
+      const client = stompClientRef.current;
+
+      if (!client?.connected) {
+        return;
+      }
+
+      queueTopicSubscriptionRef.current = client.subscribe(destination, (message) => {
+        const payload = parseMatchingWsMessage(message.body);
+
+        if (!payload || payload.type !== "QUEUE_STATE_CHANGED" || !payload.queue) {
+          return;
+        }
+
+        handleQueueStateChangedEvent(payload.queue);
+      });
+    },
+    [clearQueueTopicSubscription, handleQueueStateChangedEvent],
+  );
+
   useEffect(() => {
     const intervalId = window.setInterval(() => {
       setNow(Date.now());
@@ -316,6 +444,74 @@ export default function HomeScreen() {
       window.clearInterval(intervalId);
     };
   }, []);
+
+  useEffect(() => {
+    if (!sessionLoaded || !session.authenticated) {
+      personalSubscriptionRef.current?.unsubscribe();
+      personalSubscriptionRef.current = null;
+      clearQueueTopicSubscription();
+      stompClientRef.current = null;
+      return;
+    }
+
+    const client = new Client({
+      webSocketFactory: () => new SockJS("/ws"),
+      reconnectDelay: 3000,
+      onConnect: () => {
+        logMatchingDebug("ws connected");
+        personalSubscriptionRef.current?.unsubscribe();
+        personalSubscriptionRef.current = client.subscribe(
+          MATCHING_PERSONAL_DESTINATION,
+          (message) => {
+            const payload = parseMatchingWsMessage(message.body);
+
+            if (!payload || payload.type !== "READY_CHECK_STARTED") {
+              return;
+            }
+
+            handleReadyCheckStartedEvent(payload.match);
+          },
+        );
+
+        if (queueTopicDestinationRef.current) {
+          queueTopicSubscriptionRef.current?.unsubscribe();
+          queueTopicSubscriptionRef.current = client.subscribe(
+            queueTopicDestinationRef.current,
+            (message) => {
+              const payload = parseMatchingWsMessage(message.body);
+
+              if (
+                !payload ||
+                payload.type !== "QUEUE_STATE_CHANGED" ||
+                !payload.queue
+              ) {
+                return;
+              }
+
+              handleQueueStateChangedEvent(payload.queue);
+            },
+          );
+        }
+      },
+    });
+
+    client.activate();
+    stompClientRef.current = client;
+
+    return () => {
+      personalSubscriptionRef.current?.unsubscribe();
+      personalSubscriptionRef.current = null;
+      clearQueueTopicSubscription();
+      stompClientRef.current = null;
+      void client.deactivate();
+    };
+  }, [
+    clearQueueTopicSubscription,
+    handleQueueStateChangedEvent,
+    handleReadyCheckStartedEvent,
+    session.authenticated,
+    sessionLoaded,
+  ]);
 
   useEffect(() => {
     if (!session.authenticated) {
@@ -415,7 +611,12 @@ export default function HomeScreen() {
       }
 
       if (nextQueueState?.inQueue) {
-        setQueueState(nextQueueState);
+        setQueueState({
+          ...nextQueueState,
+          requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+        });
+        logMatchingDebug("poll matches/me status=IDLE", nextMatchState);
+        logMatchingDebug("poll matches/me status=IDLE", nextMatchState);
         setMatchState(defaultMatchState);
         setQueueStartedAt((current) => current ?? new Date().toISOString());
         setTerminalMessage(null);
@@ -440,6 +641,29 @@ export default function HomeScreen() {
   }, [applyMatchSnapshot, resetFlow, session.authenticated, sessionLoaded]);
 
   useEffect(() => {
+    if (
+      !session.authenticated ||
+      pollStage !== "QUEUE" ||
+      !queueState.inQueue ||
+      !queueState.category ||
+      !queueState.difficulty
+    ) {
+      clearQueueTopicSubscription();
+      return;
+    }
+
+    syncQueueTopicSubscription(queueState.category, queueState.difficulty);
+  }, [
+    clearQueueTopicSubscription,
+    pollStage,
+    queueState.category,
+    queueState.difficulty,
+    queueState.inQueue,
+    session.authenticated,
+    syncQueueTopicSubscription,
+  ]);
+
+  useEffect(() => {
     if (!session.authenticated || pollStage !== "QUEUE") {
       return;
     }
@@ -454,13 +678,19 @@ export default function HomeScreen() {
       }
 
       if (nextQueueState.inQueue) {
-        setQueueState(nextQueueState);
+        logMatchingDebug("poll queue/me inQueue=true", nextQueueState);
+        setQueueState({
+          ...nextQueueState,
+          requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+        });
         setModalMode("SEARCHING");
         setError(null);
         setFeedback("대기열에서 상대를 찾고 있습니다.");
         return;
       }
 
+      clearQueueTopicSubscription();
+      logMatchingDebug("poll queue/me inQueue=false -> switch to matches/me", nextQueueState);
       setQueueState(nextQueueState);
       setQueueStartedAt(null);
       setModalMode("READY_CHECK");
@@ -480,6 +710,8 @@ export default function HomeScreen() {
         return;
       }
 
+      logMatchingDebug("poll matches/me state", nextMatchState);
+      logMatchingDebug("poll matches/me state", nextMatchState);
       applyMatchSnapshot(nextMatchState);
     };
 
@@ -493,7 +725,7 @@ export default function HomeScreen() {
       active = false;
       window.clearInterval(intervalId);
     };
-  }, [applyMatchSnapshot, pollStage, session.authenticated]);
+  }, [applyMatchSnapshot, clearQueueTopicSubscription, pollStage, session.authenticated]);
 
   useEffect(() => {
     if (!session.authenticated || pollStage !== "MATCH") {
@@ -593,6 +825,7 @@ export default function HomeScreen() {
         setModalMode("SEARCHING");
         setPollStage("QUEUE");
         setFeedback(payload.message);
+        syncQueueTopicSubscription(payload.category, payload.difficulty);
         return;
       }
 
@@ -627,6 +860,7 @@ export default function HomeScreen() {
         return;
       }
 
+      clearQueueTopicSubscription();
       resetFlow(getApiErrorMessage(payload, "매칭 대기열에서 취소됐습니다."));
     } finally {
       setBusyAction(null);

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -85,6 +85,22 @@ export interface MatchStateResponse {
   message: string | null;
 }
 
+export interface QueueStateChangedWsMessage {
+  type: "QUEUE_STATE_CHANGED";
+  queue: QueueStateResponse | null;
+  match: null;
+}
+
+export interface ReadyCheckStartedWsMessage {
+  type: "READY_CHECK_STARTED";
+  queue: null;
+  match: MatchStateResponse | null;
+}
+
+export type MatchingWsMessage =
+  | QueueStateChangedWsMessage
+  | ReadyCheckStartedWsMessage;
+
 export interface ParticipantInfo {
   userId: number;
   nickname: string;


### PR DESCRIPTION
refs #37 
closes #37 

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈의 v2 매칭 흐름에 <strong>matching WebSocket 1단계</strong>를 추가한 작업입니다.
기존에는 SEARCHING 단계에서 <code>GET /api/v2/queue/me</code> polling만으로 대기열 상태를 갱신하고 있었는데,
이번 변경에서는 <strong>STOMP/WebSocket 구독을 함께 사용</strong>해
같은 queueKey의 대기 인원 변화와 ready-check 시작 handoff를 더 빠르게 반영하도록 했습니다.
</p>

<p>
중요한 점은 이번 PR이 polling을 제거하는 작업은 아니라는 점입니다.
이번 단계에서는 기존 REST 흐름을 그대로 유지하면서,
</p>

<ul>
  <li>SEARCHING 단계의 <code>waitingCount</code>는 WebSocket으로 즉시 반영</li>
  <li>ready-check 시작은 개인 채널 이벤트로 즉시 handoff 시도</li>
  <li>동시에 <code>queue/me</code>, <code>matches/me</code> polling은 fallback/source of truth로 유지</li>
</ul>

<p>
즉 이번 PR의 방향은 <strong>polling 기반 흐름 위에 WebSocket 실시간 반영을 얹는 것</strong>입니다.
</p>

<hr />

<h3>1) matching WebSocket payload 타입 추가</h3>
<p>
먼저 <code>src/shared/api/contracts.ts</code>에 matching WebSocket 메시지 타입을 추가했습니다.
이번 1단계에서 실제로 처리하는 이벤트는 두 가지입니다.
</p>

<ul>
  <li><code>QUEUE_STATE_CHANGED</code></li>
  <li><code>READY_CHECK_STARTED</code></li>
</ul>

<pre><code class="language-ts">export interface QueueStateChangedWsMessage {
  type: "QUEUE_STATE_CHANGED";
  queue: QueueStateResponse | null;
  match: null;
}

export interface ReadyCheckStartedWsMessage {
  type: "READY_CHECK_STARTED";
  queue: null;
  match: MatchStateResponse | null;
}

export type MatchingWsMessage =
  | QueueStateChangedWsMessage
  | ReadyCheckStartedWsMessage;</code></pre>

<p>
이 타입을 기준으로 홈 화면에서 수신 메시지를 안전하게 분기할 수 있도록 정리했습니다.
</p>

<hr />

<h3>2) 홈 매칭 화면에서 STOMP 연결 생성</h3>
<p>
<code>src/features/home/screen.tsx</code>에서 홈 화면 진입 후
세션이 확인된 상태라면 matching 전용 STOMP 연결을 생성하도록 구현했습니다.
</p>

<ul>
  <li>연결 방식: <code>STOMP over SockJS</code></li>
  <li>endpoint: <code>/ws</code></li>
  <li>재연결: <code>reconnectDelay: 3000</code></li>
</ul>

<pre><code class="language-ts">const client = new Client({
  webSocketFactory: () => new SockJS("/ws"),
  reconnectDelay: 3000,
  onConnect: () => {
    ...
  },
});</code></pre>

<p>
즉 홈 화면이 열려 있고 로그인 상태가 확인되면,
프론트는 matching 관련 WebSocket 수신을 준비합니다.
</p>

<hr />

<h3>3) 개인 채널 <code>/user/queue/matching</code> 구독 추가</h3>
<p>
연결이 성공하면 먼저 개인 채널 <code>/user/queue/matching</code>을 구독하도록 구현했습니다.
이 채널은 queue topic과 달리 사용자 개인에게 오는 matching 이벤트를 받기 위한 채널입니다.
</p>

<p>
이번 1단계에서 이 채널로 처리하는 이벤트는 <code>READY_CHECK_STARTED</code> 하나입니다.
</p>

<pre><code class="language-ts">const MATCHING_PERSONAL_DESTINATION = "/user/queue/matching";

personalSubscriptionRef.current = client.subscribe(
  MATCHING_PERSONAL_DESTINATION,
  (message) => {
    const payload = parseMatchingWsMessage(message.body);

    if (!payload || payload.type !== "READY_CHECK_STARTED") {
      return;
    }

    handleReadyCheckStartedEvent(payload.match);
  },
);</code></pre>

<p>
즉 개인 채널은 “queue 대기 인원 전체 broadcast”가 아니라,
<strong>내 ready-check 시작 handoff</strong>를 받기 위한 용도입니다.
</p>

<hr />

<h3>4) queue join 성공 시 queue topic 구독 시작</h3>
<p>
기존처럼 사용자가 매칭 시작 버튼을 누르면
<code>POST /api/queue/join</code>을 먼저 호출합니다.
join이 성공하면 SEARCHING 상태로 전환하면서,
현재 queueKey에 해당하는 topic 구독도 함께 시작하도록 구현했습니다.
</p>

<p>
구독 경로는 다음 규칙으로 생성합니다.
</p>

<pre><code class="language-ts">function buildQueueTopicDestination(category: string, difficulty: string) {
  const normalize = (value: string) => encodeURIComponent(value.trim().toUpperCase());
  return `/topic/matching/queue/${normalize(category)}/${normalize(difficulty)}`;
}</code></pre>

<p>
예를 들어:
</p>

<ul>
  <li>category = <code>DP</code></li>
  <li>difficulty = <code>EASY</code></li>
</ul>

<p>
이면 구독 대상은 대략
<code>/topic/matching/queue/DP/EASY</code>
형태가 됩니다.
</p>

<hr />

<h3>5) <code>QUEUE_STATE_CHANGED</code> 수신 시 waitingCount 즉시 갱신</h3>
<p>
queue topic에서 <code>QUEUE_STATE_CHANGED</code>를 수신하면,
기존 SEARCHING UI를 재사용해서 <code>waitingCount</code>를 즉시 갱신하도록 구현했습니다.
</p>

<pre><code class="language-ts">if (!payload || payload.type !== "QUEUE_STATE_CHANGED" || !payload.queue) {
  return;
}

handleQueueStateChangedEvent(payload.queue);</code></pre>

<p>
이벤트 수신 후에는:
</p>

<ul>
  <li><code>queueState.waitingCount</code> 갱신</li>
  <li><code>requiredCount</code> 보정</li>
  <li>queue 시작 시각 유지</li>
  <li>기존 SEARCHING 모달 UI 그대로 사용</li>
</ul>

<p>
즉 WebSocket이 들어와도 홈 UI를 새로 만들지 않고,
기존 queue 상태 렌더링 로직을 그대로 재사용하는 방향으로 정리했습니다.
</p>

<hr />

<h3>6) <code>READY_CHECK_STARTED</code> 수신 시 queue → ready-check 전환</h3>
<p>
개인 채널에서 <code>READY_CHECK_STARTED</code>를 받으면,
프론트는 queue SEARCHING 상태를 즉시 종료하고 ready-check 단계로 전환합니다.
</p>

<p>
이때 수행하는 일은 다음과 같습니다.
</p>

<ol>
  <li>queue topic 구독 해제</li>
  <li>queueState 초기화</li>
  <li>queueStartedAt 초기화</li>
  <li>에러 상태 초기화</li>
  <li>수신한 <code>match</code> payload가 있으면 즉시 <code>applyMatchSnapshot()</code> 적용</li>
  <li>payload가 없으면 <code>matches/me</code> polling 단계로 넘겨 fallback 복구</li>
</ol>

<p>
즉 이상적인 경우에는 WebSocket 이벤트 하나로 ready-check 화면으로 바로 넘어가고,
이벤트 payload가 비어 있거나 일부 값이 늦게 반영되는 경우에도 기존 <code>matches/me</code> 흐름으로 이어갈 수 있게 해두었습니다.
</p>

<hr />

<h3>7) 기존 polling 흐름은 그대로 유지</h3>
<p>
이번 PR에서 가장 중요한 구현 원칙은
<strong>기존 REST 복구 흐름을 깨뜨리지 않는 것</strong>이었습니다.
따라서 아래 polling은 그대로 유지했습니다.
</p>

<ul>
  <li><code>GET /api/queue/me</code> polling</li>
  <li><code>GET /api/matches/me</code> polling</li>
</ul>

<p>
즉 현재 실제 동작은 아래와 같습니다.
</p>

<pre><code class="language-text">SEARCHING
  → queue/me polling 유지
  → queue topic WebSocket도 수신
  → waitingCount는 WebSocket으로 더 빠르게 갱신 가능

queue/me.inQueue === false
  → queue topic 구독 해제
  → matches/me polling으로 전환

READY_CHECK
  → matches/me polling 유지
  → accept/decline은 여전히 HTTP
</code></pre>

<p>
즉 이번 단계는 “polling 제거”가 아니라
<strong>polling + WebSocket 병행 구조</strong>입니다.
</p>

<hr />

<h3>8) 구독 생명주기 정리</h3>
<p>
이번 PR에서는 queue topic이 잘못 남아 있지 않도록
구독 해제 타이밍도 함께 정리했습니다.
</p>

<ul>
  <li>queue cancel 성공 시 queue topic 해제</li>
  <li>queue/me에서 <code>inQueue=false</code> 감지 시 queue topic 해제</li>
  <li><code>READY_CHECK_STARTED</code> 수신 시 queue topic 해제</li>
  <li>세션이 사라지거나 홈 화면에서 cleanup될 때 구독 해제</li>
</ul>

<p>
이를 위해 <code>clearQueueTopicSubscription()</code> helper를 두고,
구독 정리 로직을 한 곳에서 재사용하도록 했습니다.
</p>

<hr />

<h3>9) 새로고침 / 재진입 fallback 유지</h3>
<p>
이번 1단계는 WebSocket이 모든 상태를 책임지는 구조가 아니므로,
새로고침이나 재진입 시에는 여전히 REST 기반 상태 복구를 사용합니다.
</p>

<ul>
  <li>홈 진입 시 <code>queue/me</code>, <code>matches/me</code> 동시 조회</li>
  <li>queue 상태면 SEARCHING 복원</li>
  <li>match 상태면 ready-check / room 준비 상태 복원</li>
</ul>

<p>
즉 WebSocket은 “그 이후 변화”를 빠르게 반영하는 역할이고,
초기 상태 복원은 여전히 REST가 source of truth입니다.
</p>

<hr />

<h3>10) 브라우저 콘솔 확인용 matching debug log 추가</h3>
<p>
실제 WebSocket 이벤트가 들어오는지와 polling fallback이 언제 동작하는지 구분하기 위해,
브라우저 콘솔에 matching debug log도 추가했습니다.
</p>

<p>
예상 로그 예시는 다음과 같습니다.
</p>

<ul>
  <li><code>[matching] ws connected</code></li>
  <li><code>[matching] ws QUEUE_STATE_CHANGED ...</code></li>
  <li><code>[matching] ws READY_CHECK_STARTED ...</code></li>
  <li><code>[matching] poll queue/me inQueue=true ...</code></li>
  <li><code>[matching] poll queue/me inQueue=false -&gt; switch to matches/me ...</code></li>
</ul>

<p>
이 로그를 통해 reviewer나 개발자가 실제로
</p>

<ul>
  <li>대기 인원 변화가 WebSocket으로 들어왔는지</li>
  <li>ready-check 전환이 WebSocket handoff인지 polling fallback인지</li>
</ul>

<p>
를 구분할 수 있도록 했습니다.
</p>

<hr />

<h3>11) 변경 파일</h3>
<ul>
  <li><code>src/features/home/screen.tsx</code></li>
  <li><code>src/shared/api/contracts.ts</code></li>
</ul>

<p>
이번 PR에서는 기존에 이미 들어와 있던 <code>/ws</code> rewrite 및 STOMP 인프라를 그대로 활용했고,
실제 홈 매칭 화면 로직과 payload 타입 정의만 수정했습니다.
</p>

<hr />

<h3>12) 테스트 / 확인 포인트</h3>
<ol>
  <li>로그인 상태에서 홈 진입 시 STOMP 연결이 생성되고 <code>/user/queue/matching</code> 구독이 시작되는지 확인</li>
  <li>queue join 성공 후 현재 queueKey에 맞는 topic 구독이 시작되는지 확인</li>
  <li>다른 사용자가 같은 queue에 들어오면 <code>QUEUE_STATE_CHANGED</code> 수신으로 waitingCount가 즉시 반영되는지 확인</li>
  <li>4명 충족 시 <code>READY_CHECK_STARTED</code> 수신으로 ready-check 전환이 polling 이전에 가능한지 확인</li>
  <li>queue cancel 성공 시 topic 구독이 해제되고 SEARCHING UI가 종료되는지 확인</li>
  <li>새로고침 후에도 기존 <code>queue/me</code>, <code>matches/me</code> 복구 흐름이 깨지지 않는지 확인</li>
  <li>matching debug log로 WebSocket 수신 경로와 polling fallback 경로를 구분할 수 있는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx tsc --noEmit</code> 기준으로 통과했습니다.
</p>

<p>
참고로 이 PR 범위에서는
</p>

<ul>
  <li>accept/decline WebSocket 전송</li>
  <li>ROOM_READY / CANCELLED / EXPIRED의 WebSocket 실시간 반영</li>
  <li>battle room 내부 WebSocket 흐름 변경</li>
</ul>

<p>
은 포함하지 않았습니다.
</p>


## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
