### PR TITLE
[fix] 프록시 룰 누락으로 인한 404 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,14 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: "/api/v1/:path*",
+        destination: `${BACKEND_BASE_URL}/api/v1/:path*`,
+      },
+      {
+        source: "/api/v2/:path*",
+        destination: `${BACKEND_BASE_URL}/api/v2/:path*`,
+      },
+      {
         source: "/ws/:path*",
         destination: `${BACKEND_BASE_URL}/ws/:path*`,
       },


### PR DESCRIPTION
## 작업 개요

- next.config.ts에 /api/v1/ws/token 엔드포인트 프록시 룰 누락으로 인해 배틀룸 입장 시 WebSocket 1회용 토큰 발급 요청이 404로 실패하던 문제 수정             
  - 초기 수정에서 /api/:path* 전체를 프록시하여 기존 Next.js BFF API 라우트(/api/matches/, /api/queue/ 등)가 우회되고 인증 없이 백엔드로 직접 전달되어 403 발생 → rewrite 범위를 /api/v1/:path*, /api/v2/:path*로 한정하여 해결   

## 영향 범위


## 작업 내용

- [ ] 프록시 룰 추가

## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인


## 관련 이슈

- close #39 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
