### PR TITLE
[refactor] 배틀/솔로 UI 정리 및 전역 토큰 리스킨 적용

### DIFF
--- a/src/app/api/battle/rooms/[roomId]/state/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/state/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { BattleRoomStateResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET(
+  _request: Request,
+  context: RouteContext<"/api/battle/rooms/[roomId]/state">,
+) {
+  const { roomId } = await context.params;
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(`/api/v1/battle/rooms/${roomId}/state`, {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    const body = await readJsonBody<BattleRoomStateResponse>(response);
+    return NextResponse.json(body);
+  } catch {
+    return NextResponse.json(
+      { message: "배틀룸 상태를 가져오지 못했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,33 +1,33 @@
 @import "tailwindcss";
 
 :root {
-  --background: #0f1118;
+  --background: #111315;
   --foreground: #e5e7eb;
-  --panel: #171c26;
+  --panel: #1a1d21;
   --app-header-h: 56px;
 
   /* Graphite Dark + Purple Accent */
-  --app-bg-base: #0f1118;
-  --app-bg-surface: #171c26;
-  --app-bg-elevated: #1f2633;
-  --app-bg-rail: #1a1f2b;
-  --app-bg-header: #121722;
-  --app-bg-shell-gradient: radial-gradient(circle at 14% 0%, rgba(145, 70, 255, 0.18), transparent 38%),
-    radial-gradient(circle at 86% 100%, rgba(145, 70, 255, 0.09), transparent 44%),
-    linear-gradient(180deg, #0f1118 0%, #111624 48%, #0d1018 100%);
+  --app-bg-base: #111315;
+  --app-bg-surface: #1a1d21;
+  --app-bg-elevated: #23272d;
+  --app-bg-rail: #16191d;
+  --app-bg-header: #171a1f;
+  --app-bg-shell-gradient: radial-gradient(circle at 14% 0%, rgba(155, 92, 255, 0.2), transparent 38%),
+    radial-gradient(circle at 86% 100%, rgba(155, 92, 255, 0.08), transparent 44%),
+    linear-gradient(180deg, #111315 0%, #15181d 48%, #101215 100%);
 
   --app-text-primary: #e5e7eb;
-  --app-text-secondary: #a7b0bf;
-  --app-text-muted: #7d8596;
-  --app-text-dim: #6b7280;
+  --app-text-secondary: #b6bbc6;
+  --app-text-muted: #8e95a3;
+  --app-text-dim: #6e7685;
 
-  --app-border: #3f475a;
-  --app-border-strong: #59627a;
+  --app-border: #343941;
+  --app-border-strong: #454c57;
 
-  --app-accent: #9146ff;
-  --app-accent-hover: #7f39fa;
-  --app-accent-soft: #c8adff;
-  --app-accent-glow: rgba(145, 70, 255, 0.22);
+  --app-accent: #9b5cff;
+  --app-accent-hover: #8c4dff;
+  --app-accent-soft: #c8abff;
+  --app-accent-glow: rgba(155, 92, 255, 0.28);
 
   --app-success: #34d399;
   --app-warn: #fbbf24;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,16 +1,88 @@
 @import "tailwindcss";
 
 :root {
-  --background: #0f1115;
+  --background: #0f1118;
   --foreground: #e5e7eb;
-  --panel: #171a21;
+  --panel: #171c26;
   --app-header-h: 56px;
+
+  /* Graphite Dark + Purple Accent */
+  --app-bg-base: #0f1118;
+  --app-bg-surface: #171c26;
+  --app-bg-elevated: #1f2633;
+  --app-bg-rail: #1a1f2b;
+  --app-bg-header: #121722;
+  --app-bg-shell-gradient: radial-gradient(circle at 14% 0%, rgba(145, 70, 255, 0.18), transparent 38%),
+    radial-gradient(circle at 86% 100%, rgba(145, 70, 255, 0.09), transparent 44%),
+    linear-gradient(180deg, #0f1118 0%, #111624 48%, #0d1018 100%);
+
+  --app-text-primary: #e5e7eb;
+  --app-text-secondary: #a7b0bf;
+  --app-text-muted: #7d8596;
+  --app-text-dim: #6b7280;
+
+  --app-border: #3f475a;
+  --app-border-strong: #59627a;
+
+  --app-accent: #9146ff;
+  --app-accent-hover: #7f39fa;
+  --app-accent-soft: #c8adff;
+  --app-accent-glow: rgba(145, 70, 255, 0.22);
+
+  --app-success: #34d399;
+  --app-warn: #fbbf24;
+  --app-danger: #fb7185;
+
+  /* IDE syntax accents */
+  --app-syntax-icon: #7dd48c;
+  --app-syntax-line-number: #606366;
+  --app-syntax-default: #a9b7c6;
+  --app-syntax-comment: #6a717d;
+  --app-syntax-keyword: #ffcc66;
+  --app-syntax-name: #9cdcfe;
+  --app-syntax-operator: #80889a;
+  --app-syntax-string: #ce9178;
+  --app-syntax-value: #9aa5b1;
+  --app-syntax-constant: #b5cea8;
+  --app-syntax-selected-border: #4e89ff;
+  --app-syntax-selected-bg: #2b3a52;
+  --app-syntax-selected-text: #dcdcaa;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-panel: var(--panel);
+  --color-app-base: var(--app-bg-base);
+  --color-app-surface: var(--app-bg-surface);
+  --color-app-elevated: var(--app-bg-elevated);
+  --color-app-rail: var(--app-bg-rail);
+  --color-app-header: var(--app-bg-header);
+  --color-app-primary: var(--app-text-primary);
+  --color-app-secondary: var(--app-text-secondary);
+  --color-app-muted: var(--app-text-muted);
+  --color-app-dim: var(--app-text-dim);
+  --color-app-border: var(--app-border);
+  --color-app-border-strong: var(--app-border-strong);
+  --color-app-accent: var(--app-accent);
+  --color-app-accent-hover: var(--app-accent-hover);
+  --color-app-accent-soft: var(--app-accent-soft);
+  --color-app-success: var(--app-success);
+  --color-app-warn: var(--app-warn);
+  --color-app-danger: var(--app-danger);
+  --color-app-syntax-icon: var(--app-syntax-icon);
+  --color-app-syntax-line-number: var(--app-syntax-line-number);
+  --color-app-syntax-default: var(--app-syntax-default);
+  --color-app-syntax-comment: var(--app-syntax-comment);
+  --color-app-syntax-keyword: var(--app-syntax-keyword);
+  --color-app-syntax-name: var(--app-syntax-name);
+  --color-app-syntax-operator: var(--app-syntax-operator);
+  --color-app-syntax-string: var(--app-syntax-string);
+  --color-app-syntax-value: var(--app-syntax-value);
+  --color-app-syntax-constant: var(--app-syntax-constant);
+  --color-app-syntax-selected-border: var(--app-syntax-selected-border);
+  --color-app-syntax-selected-bg: var(--app-syntax-selected-bg);
+  --color-app-syntax-selected-text: var(--app-syntax-selected-text);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -20,8 +92,8 @@
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--app-bg-base);
+  color: var(--app-text-primary);
   font-family: var(--font-geist-sans), sans-serif;
 }
 
@@ -36,6 +108,6 @@ pre {
 }
 
 ::selection {
-  background: #a78bfa;
-  color: #09090b;
+  background: var(--app-accent);
+  color: #0b0f16;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,8 +50,8 @@ export default async function RootLayout({
       lang="ko"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full">
-        <div className="flex min-h-screen flex-col bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
+      <body className="h-full overflow-hidden">
+        <div className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
           <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
             <div className="mx-auto flex h-full w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
               <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
@@ -59,7 +59,7 @@ export default async function RootLayout({
               </Link>
             </div>
           </header>
-          <main className="flex min-h-0 flex-1">
+          <main className="flex min-h-0 flex-1 overflow-hidden">
             <IdeShell initialSession={initialSession}>{children}</IdeShell>
           </main>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,10 +51,10 @@ export default async function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="h-full overflow-hidden">
-        <div className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[radial-gradient(circle_at_16%_0%,rgba(167,139,250,0.16),transparent_36%),radial-gradient(circle_at_82%_100%,rgba(139,92,246,0.1),transparent_44%),linear-gradient(180deg,#0f1115_0%,#12141b_48%,#0d0f13_100%)] text-zinc-100">
-          <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-violet-400/20 bg-[#12141c]/88 text-zinc-100 shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
+        <div className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[image:var(--app-bg-shell-gradient)] text-app-primary">
+          <header className="sticky top-0 z-20 h-[var(--app-header-h)] border-b border-app-accent/25 bg-app-header/90 text-app-primary shadow-[0_10px_24px_-18px_rgba(0,0,0,0.82)] backdrop-blur">
             <div className="mx-auto flex h-full w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
-              <Link href="/" className="text-sm font-semibold tracking-tight text-zinc-100">
+              <Link href="/" className="text-sm font-semibold tracking-tight text-app-primary">
                 BRACKET {"{}"}
               </Link>
             </div>

--- a/src/features/battle-result/screen.tsx
+++ b/src/features/battle-result/screen.tsx
@@ -73,13 +73,13 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/battle/results/${roomId}`)}`}
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
             >
               메인으로 돌아가기
             </Link>
@@ -99,7 +99,7 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
           actions={<StatusPill tone="danger">Load failed</StatusPill>}
         />
         <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-700">{error ?? message}</p>
+          <p className="text-sm leading-7 text-app-secondary">{error ?? message}</p>
         </Panel>
       </div>
     );
@@ -121,7 +121,7 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
         }
       />
 
-      <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-700">
+      <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm text-app-secondary">
         {error ?? message}
       </div>
 
@@ -161,7 +161,7 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
           title="정산 정책 메모"
           description="현재 백엔드 서비스에 정의된 점수 정책"
         >
-          <ul className="space-y-3 text-sm leading-7 text-zinc-700">
+          <ul className="space-y-3 text-sm leading-7 text-app-secondary">
             <li>1등 +100, 2등 +70, 3등 +40, 4등 +20</li>
             <li>WA 1회당 20초 패널티가 순위 계산에 반영됩니다.</li>
             <li>AC가 없는 참여자는 뒤 순위로 밀립니다.</li>

--- a/src/features/battle-room/code-editor.tsx
+++ b/src/features/battle-room/code-editor.tsx
@@ -55,16 +55,16 @@ export default function BattleCodeEditor({
 
   return (
     <div
-      className={`flex min-h-0 flex-col overflow-hidden rounded-2xl border border-zinc-700 bg-zinc-950 ${className}`.trim()}
+      className={`flex min-h-0 flex-col overflow-hidden rounded-2xl border border-app-border bg-app-base ${className}`.trim()}
     >
-      <div className="flex h-12 items-center gap-3 border-b border-zinc-700 bg-zinc-900 px-4">
-        <span className="font-mono text-lg font-semibold text-emerald-400">&lt;/&gt;</span>
-        <span className="ml-2 text-sm font-semibold text-zinc-100">Code</span>
+      <div className="flex h-12 items-center gap-3 border-b border-app-border bg-app-base px-4">
+        <span className="font-mono text-lg font-semibold text-app-success">&lt;/&gt;</span>
+        <span className="ml-2 text-sm font-semibold text-app-primary">Code</span>
         <div className="relative ml-1">
           <select
             value={language}
             onChange={(event) => onLanguageChange(event.target.value)}
-            className="h-8 min-w-[7.5rem] appearance-none rounded-md border border-zinc-700 bg-zinc-900 px-2 pr-7 text-sm text-zinc-100 outline-none transition focus:border-zinc-500"
+            className="h-8 min-w-[7.5rem] appearance-none rounded-md border border-app-border bg-app-base px-2 pr-7 text-sm text-app-primary outline-none transition focus:border-app-border-strong"
           >
             {languages.map((item) => (
               <option key={item} value={item}>
@@ -72,7 +72,7 @@ export default function BattleCodeEditor({
               </option>
             ))}
           </select>
-          <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-zinc-400">
+          <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-app-muted">
             ▼
           </span>
         </div>
@@ -81,7 +81,7 @@ export default function BattleCodeEditor({
             type="button"
             onClick={onRun}
             disabled={runDisabled || !onRun}
-            className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs font-semibold text-zinc-100 transition hover:border-zinc-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:text-zinc-500"
+            className="rounded-md border border-app-border-strong bg-app-base px-2.5 py-1 text-xs font-semibold text-app-primary transition hover:border-app-border-strong disabled:cursor-not-allowed disabled:border-app-border disabled:text-app-dim"
           >
             {runLabel}
           </button>
@@ -89,7 +89,7 @@ export default function BattleCodeEditor({
             type="button"
             onClick={onSubmit}
             disabled={submitDisabled || !onSubmit}
-            className="rounded-md border border-zinc-200 bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-900 transition hover:bg-white disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-800 disabled:text-zinc-500"
+            className="rounded-md border border-app-border bg-app-elevated px-2.5 py-1 text-xs font-semibold text-app-primary transition hover:bg-app-surface disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim"
           >
             {submitLabel}
           </button>
@@ -105,7 +105,7 @@ export default function BattleCodeEditor({
           theme="vs-dark"
           options={editorOptions}
           loading={
-            <div className="flex items-center justify-center text-sm text-zinc-300" style={{ height }}>
+            <div className="flex items-center justify-center text-sm text-app-secondary" style={{ height }}>
               에디터를 불러오는 중입니다.
             </div>
           }

--- a/src/features/battle-room/code-editor.tsx
+++ b/src/features/battle-room/code-editor.tsx
@@ -3,9 +3,13 @@
 import Editor from "@monaco-editor/react";
 
 interface BattleCodeEditorProps {
+  languages: string[];
   language: string;
+  onLanguageChange: (nextLanguage: string) => void;
   value: string;
   onChange: (nextValue: string) => void;
+  height?: string;
+  className?: string;
 }
 
 const editorOptions = {
@@ -27,26 +31,56 @@ const editorOptions = {
 };
 
 export default function BattleCodeEditor({
+  languages,
   language,
+  onLanguageChange,
   value,
   onChange,
+  height = "26rem",
+  className = "",
 }: BattleCodeEditorProps) {
+  const monacoLanguage = language === "python3" ? "python" : language;
+
   return (
-    <div className="overflow-hidden rounded-2xl border border-zinc-300 bg-zinc-950">
+    <div
+      className={`flex min-h-0 flex-col overflow-hidden rounded-2xl border border-zinc-700 bg-zinc-950 ${className}`.trim()}
+    >
+      <div className="flex h-12 items-center gap-3 border-b border-zinc-700 bg-zinc-900 px-4">
+        <span className="font-mono text-lg font-semibold text-emerald-400">&lt;/&gt;</span>
+        <span className="ml-2 text-sm font-semibold text-zinc-100">Code</span>
+        <div className="relative ml-1">
+          <select
+            value={language}
+            onChange={(event) => onLanguageChange(event.target.value)}
+            className="h-8 min-w-[7.5rem] appearance-none rounded-md border border-zinc-700 bg-zinc-900 px-2 pr-7 text-sm text-zinc-100 outline-none transition focus:border-zinc-500"
+          >
+            {languages.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+          <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-zinc-400">
+            ▼
+          </span>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1">
       <Editor
-        height="26rem"
-        defaultLanguage={language}
-        language={language}
+        height={height}
+        defaultLanguage={monacoLanguage}
+        language={monacoLanguage}
         value={value}
         onChange={(nextValue) => onChange(nextValue ?? "")}
         theme="vs-dark"
         options={editorOptions}
         loading={
-          <div className="flex h-[26rem] items-center justify-center text-sm text-zinc-300">
+          <div className="flex items-center justify-center text-sm text-zinc-300" style={{ height }}>
             에디터를 불러오는 중입니다.
           </div>
         }
       />
+      </div>
     </div>
   );
 }

--- a/src/features/battle-room/code-editor.tsx
+++ b/src/features/battle-room/code-editor.tsx
@@ -8,6 +8,12 @@ interface BattleCodeEditorProps {
   onLanguageChange: (nextLanguage: string) => void;
   value: string;
   onChange: (nextValue: string) => void;
+  onRun?: () => void;
+  onSubmit?: () => void;
+  runDisabled?: boolean;
+  submitDisabled?: boolean;
+  runLabel?: string;
+  submitLabel?: string;
   height?: string;
   className?: string;
 }
@@ -36,6 +42,12 @@ export default function BattleCodeEditor({
   onLanguageChange,
   value,
   onChange,
+  onRun,
+  onSubmit,
+  runDisabled = false,
+  submitDisabled = false,
+  runLabel = "Run",
+  submitLabel = "Submit",
   height = "26rem",
   className = "",
 }: BattleCodeEditorProps) {
@@ -64,22 +76,40 @@ export default function BattleCodeEditor({
             ▼
           </span>
         </div>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={runDisabled || !onRun}
+            className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs font-semibold text-zinc-100 transition hover:border-zinc-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:text-zinc-500"
+          >
+            {runLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={submitDisabled || !onSubmit}
+            className="rounded-md border border-zinc-200 bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-900 transition hover:bg-white disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-800 disabled:text-zinc-500"
+          >
+            {submitLabel}
+          </button>
+        </div>
       </div>
       <div className="min-h-0 flex-1">
-      <Editor
-        height={height}
-        defaultLanguage={monacoLanguage}
-        language={monacoLanguage}
-        value={value}
-        onChange={(nextValue) => onChange(nextValue ?? "")}
-        theme="vs-dark"
-        options={editorOptions}
-        loading={
-          <div className="flex items-center justify-center text-sm text-zinc-300" style={{ height }}>
-            에디터를 불러오는 중입니다.
-          </div>
-        }
-      />
+        <Editor
+          height={height}
+          defaultLanguage={monacoLanguage}
+          language={monacoLanguage}
+          value={value}
+          onChange={(nextValue) => onChange(nextValue ?? "")}
+          theme="vs-dark"
+          options={editorOptions}
+          loading={
+            <div className="flex items-center justify-center text-sm text-zinc-300" style={{ height }}>
+              에디터를 불러오는 중입니다.
+            </div>
+          }
+        />
       </div>
     </div>
   );

--- a/src/features/battle-room/data.ts
+++ b/src/features/battle-room/data.ts
@@ -1,7 +1,6 @@
 import type {
   ProblemDetailResponse,
   RoomResponse,
-  SubmissionResponse,
   SubmitPayload,
 } from "@/shared/api/contracts";
 
@@ -16,13 +15,6 @@ export const submitTemplate: SubmitPayload = {
   roomId: 302,
   code: `function solve(input) {\n  const values = input.trim().split(/\\s+/).map(Number);\n  const n = values[0];\n  const nums = values.slice(1, n + 1);\n  return String(nums.reduce((sum, value) => sum + value, 0));\n}`,
   language: "javascript",
-};
-
-export const latestSubmission: SubmissionResponse = {
-  submissionId: 9001,
-  result: "AC",
-  passedCount: 12,
-  totalCount: 12,
 };
 
 const room302Events: LiveEvent[] = [

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
@@ -18,22 +18,10 @@ import type {
   SubmissionWsMessage,
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
-import {
-  ApiCallout,
-  DefinitionGrid,
-  EventTimeline,
-  MathText,
-  MetricCard,
-  MetricGrid,
-  PageHero,
-  Panel,
-  StatusPill,
-} from "@/shared/ui";
-import { formatDateTime } from "@/shared/utils/format-date-time";
+import { DefinitionGrid, MathText, Panel, StatusPill } from "@/shared/ui";
 
 import {
   getBattleRoom,
-  getBattleRoomEvents,
   getProblemDetail,
   latestSubmission as fallbackSubmission,
   submitTemplate,
@@ -48,12 +36,131 @@ const BattleCodeEditor = dynamic(() => import("./code-editor"), {
   ),
 });
 
-function participantTone(status: string) {
-  if (status === "PLAYING" || status === "EXIT") {
-    return "success" as const;
+const MIN_LEFT_RATIO = 32;
+const MAX_LEFT_RATIO = 68;
+const MIN_TOP_RATIO = 28;
+const MAX_TOP_RATIO = 72;
+const fallbackLanguages = ["python3", "java", "javascript"];
+const defaultCodeByLanguage: Record<string, string> = {
+  javascript: `function solve(input) {\n  // TODO: implement\n}\n`,
+  java: `import java.io.*;\nimport java.util.*;\n\npublic class Main {\n  public static void main(String[] args) throws Exception {\n    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));\n    // TODO: implement\n  }\n}\n`,
+  python3: `def solve():\n    # TODO: implement\n    pass\n\nif __name__ == "__main__":\n    solve()\n`,
+  python: `def solve():\n    # TODO: implement\n    pass\n\nif __name__ == "__main__":\n    solve()\n`,
+};
+
+type LeftPanelTab = "description" | "submission";
+
+interface CaseBadgeState {
+  label: string;
+  tone: "pending" | "pass" | "fail";
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeVerdict(verdict: string | undefined) {
+  return (verdict ?? "").trim().toUpperCase();
+}
+
+function isPassVerdict(verdict: string | undefined) {
+  const normalized = normalizeVerdict(verdict);
+  return normalized === "AC" || normalized === "PASS";
+}
+
+function isWrongAnswerVerdict(verdict: string | undefined) {
+  const normalized = normalizeVerdict(verdict);
+  return normalized === "WA" || normalized === "WRONG_ANSWER" || normalized === "WRONG ANSWER";
+}
+
+function getCaseBadgeState(
+  result: RunTestCaseResult | undefined,
+  isPending: boolean,
+): CaseBadgeState | null {
+  if (isPending) {
+    return { label: "RUN", tone: "pending" };
   }
 
-  return "default" as const;
+  if (!result) {
+    return null;
+  }
+
+  if (isPassVerdict(result.status)) {
+    return { label: "PASS", tone: "pass" };
+  }
+
+  if (isWrongAnswerVerdict(result.status)) {
+    return { label: "WA", tone: "fail" };
+  }
+
+  return { label: normalizeVerdict(result.status) || "FAIL", tone: "fail" };
+}
+
+function resolveLanguages(problem: ProblemDetailResponse | null, currentLanguage: string) {
+  const base =
+    problem?.supportedLanguages && problem.supportedLanguages.length > 0
+      ? problem.supportedLanguages
+      : fallbackLanguages;
+
+  if (base.includes(currentLanguage)) {
+    return base;
+  }
+
+  return [currentLanguage, ...base];
+}
+
+function resolveStarterCode(problem: ProblemDetailResponse | null, language: string) {
+  const fromApi = problem?.starterCodes?.find((item) => item.language === language)?.code;
+
+  if (fromApi) {
+    return fromApi;
+  }
+
+  return defaultCodeByLanguage[language] ?? defaultCodeByLanguage.javascript;
+}
+
+function resolveDefaultLanguage(problem: ProblemDetailResponse | null, currentLanguage: string) {
+  const languages = resolveLanguages(problem, currentLanguage);
+
+  if (problem?.defaultLanguage && languages.includes(problem.defaultLanguage)) {
+    return problem.defaultLanguage;
+  }
+
+  return languages[0];
+}
+
+function getSubmitHeadline(isSubmitting: boolean, result: string | null | undefined) {
+  const code = normalizeVerdict(result ?? undefined);
+
+  if (isSubmitting) {
+    return "Submitting";
+  }
+
+  if (code === "JUDGING") {
+    return "Judging";
+  }
+
+  if (code === "AC" || code === "ACCEPTED") {
+    return "Accepted";
+  }
+
+  if (code === "WA" || code === "WRONG_ANSWER" || code === "WRONG ANSWER") {
+    return "Wrong Answer";
+  }
+
+  if (code === "CE" || code === "COMPILE_ERROR" || code === "COMPILE ERROR") {
+    return "Compile Error";
+  }
+
+  if (code === "RE" || code === "RUNTIME_ERROR" || code === "RUNTIME ERROR") {
+    return "Runtime Error";
+  }
+
+  if (code === "TLE" || code === "TIME_LIMIT_EXCEEDED" || code === "TIME LIMIT EXCEEDED") {
+    return "Time Limit Exceeded";
+  }
+
+  return code || "Submission";
 }
 
 export default function BattleRoomScreen({ roomId }: { roomId: string }) {
@@ -65,13 +172,65 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [code, setCode] = useState(submitTemplate.code);
   const [language, setLanguage] = useState(submitTemplate.language);
   const [runResults, setRunResults] = useState<RunTestCaseResult[] | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
+  const [selectedRunCaseIndex, setSelectedRunCaseIndex] = useState<number | null>(null);
+  const [runningCaseIndex, setRunningCaseIndex] = useState<number | null>(null);
+  const [leftPanelTab, setLeftPanelTab] = useState<LeftPanelTab>("description");
+  const [leftPaneRatio, setLeftPaneRatio] = useState(54);
+  const [rightTopPaneRatio, setRightTopPaneRatio] = useState(52);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState("배틀룸 정보를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
-  const [source, setSource] = useState<"api" | "fallback">("api");
   const hasAttemptedJoinRef = useRef(false);
   const stompClientRef = useRef<Client | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const splitContainerRef = useRef<HTMLDivElement | null>(null);
+  const rightColumnRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1280px)");
+    const body = document.body;
+    const html = document.documentElement;
+    const previousBodyOverflow = body.style.overflow;
+    const previousHtmlOverflow = html.style.overflow;
+
+    const syncOverflowLock = () => {
+      if (mediaQuery.matches) {
+        body.style.overflow = "hidden";
+        html.style.overflow = "hidden";
+        return;
+      }
+
+      body.style.overflow = previousBodyOverflow;
+      html.style.overflow = previousHtmlOverflow;
+    };
+
+    syncOverflowLock();
+    mediaQuery.addEventListener("change", syncOverflowLock);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncOverflowLock);
+      body.style.overflow = previousBodyOverflow;
+      html.style.overflow = previousHtmlOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const sampleCaseCount = problem?.sampleCases?.length ?? 0;
+    const runCaseCount = runResults?.length ?? 0;
+    const totalCaseCount = Math.max(sampleCaseCount, runCaseCount);
+
+    if (totalCaseCount === 0) {
+      setSelectedRunCaseIndex(null);
+      return;
+    }
+
+    setSelectedRunCaseIndex((current) => {
+      if (current !== null && current >= 0 && current < totalCaseCount) {
+        return current;
+      }
+
+      return 0;
+    });
+  }, [problem, runResults]);
 
   useEffect(() => {
     if (!sessionLoaded) {
@@ -85,10 +244,15 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         if (!active) {
           return;
         }
+
         setRoom(null);
+        setProblem(null);
+        setError(null);
         setMessage("배틀룸은 로그인 후 접근할 수 있습니다.");
         return;
       }
+
+      setError(null);
 
       const roomResponse = await fetch(`/api/battle/rooms/${roomId}`, {
         cache: "no-store",
@@ -105,27 +269,36 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           if (!active) {
             return;
           }
-          setSource("fallback");
+          const fallbackProblem = getProblemDetail(fallbackRoom.problemId);
+          const nextLanguage = resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
+          const nextStarterCode = resolveStarterCode(fallbackProblem, nextLanguage);
           setRoom(fallbackRoom);
-          setProblem(getProblemDetail(fallbackRoom.problemId));
+          setProblem(fallbackProblem);
+          setLanguage(nextLanguage);
+          setCode(nextStarterCode);
           setMessage("백엔드 연결 실패로 샘플 배틀룸을 표시합니다.");
           return;
         }
 
         const payload = (await roomResponse.json().catch(() => null)) as ApiErrorResponse | null;
+
         if (!active) {
           return;
         }
+
+        setRoom(null);
+        setProblem(null);
         setError(payload?.message ?? "배틀룸을 불러오지 못했습니다.");
         return;
       }
 
       const nextRoom = (await roomResponse.json()) as RoomResponse;
+
       if (!active) {
         return;
       }
+
       setRoom(nextRoom);
-      setSource("api");
 
       const problemResponse = await fetch(`/api/problems/${nextRoom.problemId}`, {
         cache: "no-store",
@@ -135,13 +308,45 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         if (!active) {
           return;
         }
-        setProblem((await problemResponse.json()) as ProblemDetailResponse);
-        setMessage("실제 API 기반 배틀룸을 표시합니다.");
+
+        const nextProblem = (await problemResponse.json()) as ProblemDetailResponse;
+        const fallbackProblem = getProblemDetail(nextRoom.problemId);
+        const mergedProblem =
+          fallbackProblem
+            ? {
+                ...fallbackProblem,
+                ...nextProblem,
+                sampleCases:
+                  nextProblem.sampleCases && nextProblem.sampleCases.length > 0
+                    ? nextProblem.sampleCases
+                    : fallbackProblem.sampleCases,
+                starterCodes:
+                  nextProblem.starterCodes && nextProblem.starterCodes.length > 0
+                    ? nextProblem.starterCodes
+                    : fallbackProblem.starterCodes,
+                supportedLanguages:
+                  nextProblem.supportedLanguages && nextProblem.supportedLanguages.length > 0
+                    ? nextProblem.supportedLanguages
+                    : fallbackProblem.supportedLanguages,
+                defaultLanguage: nextProblem.defaultLanguage ?? fallbackProblem.defaultLanguage,
+              }
+            : nextProblem;
+        const nextLanguage = resolveDefaultLanguage(mergedProblem, submitTemplate.language);
+        const nextStarterCode = resolveStarterCode(mergedProblem, nextLanguage);
+        setProblem(mergedProblem);
+        setLanguage(nextLanguage);
+        setCode(nextStarterCode);
+        setMessage("");
       } else {
         if (!active) {
           return;
         }
-        setProblem(getProblemDetail(nextRoom.problemId));
+        const fallbackProblem = getProblemDetail(nextRoom.problemId);
+        const nextLanguage = resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
+        const nextStarterCode = resolveStarterCode(fallbackProblem, nextLanguage);
+        setProblem(fallbackProblem);
+        setLanguage(nextLanguage);
+        setCode(nextStarterCode);
         setMessage("문제 상세 조회에 실패해 샘플 설명을 함께 표시합니다.");
       }
     })();
@@ -156,12 +361,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   }, [roomId]);
 
   useEffect(() => {
-    if (
-      hasAttemptedJoinRef.current ||
-      !room ||
-      !session.authenticated ||
-      !session.member
-    ) {
+    if (hasAttemptedJoinRef.current || !room || !session.authenticated || !session.member) {
       return;
     }
 
@@ -179,59 +379,57 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
     hasAttemptedJoinRef.current = true;
 
-    startTransition(() => {
-      void (async () => {
-        const response = await fetch(`/api/battle/rooms/${roomId}/join`, {
-          method: "POST",
-        });
+    void (async () => {
+      const response = await fetch(`/api/battle/rooms/${roomId}/join`, {
+        method: "POST",
+      });
 
-        if (!response.ok) {
-          const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-          setError(payload?.message ?? "배틀룸 입장에 실패했습니다.");
-          hasAttemptedJoinRef.current = false;
-          return;
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+        setError(payload?.message ?? "배틀룸 입장에 실패했습니다.");
+        hasAttemptedJoinRef.current = false;
+        return;
+      }
+
+      const payload = (await response.json()) as JoinRoomResponse;
+      setMessage(`배틀룸 입장 처리 완료: ${payload.status}`);
+
+      const refreshed = await fetch(`/api/battle/rooms/${roomId}`, {
+        cache: "no-store",
+      });
+
+      if (refreshed.ok) {
+        setRoom((await refreshed.json()) as RoomResponse);
+      }
+
+      const stateResponse = await fetch(`/api/battle/rooms/${roomId}/state`, {
+        cache: "no-store",
+      });
+
+      if (stateResponse.ok) {
+        const stateData = (await stateResponse.json()) as BattleRoomStateResponse;
+
+        if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
+          setCode(stateData.myCode);
         }
-
-        const payload = (await response.json()) as JoinRoomResponse;
-        setMessage(`배틀룸 입장 처리 완료: ${payload.status}`);
-
-        const refreshed = await fetch(`/api/battle/rooms/${roomId}`, {
-          cache: "no-store",
-        });
-
-        if (refreshed.ok) {
-          setRoom((await refreshed.json()) as RoomResponse);
-        }
-
-        const stateResponse = await fetch(`/api/battle/rooms/${roomId}/state`, {
-          cache: "no-store",
-        });
-
-        if (stateResponse.ok) {
-          const stateData = (await stateResponse.json()) as BattleRoomStateResponse;
-          if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
-            setCode(stateData.myCode);
-          }
-        }
-      })();
-    });
+      }
+    })();
   }, [room, roomId, session.authenticated, session.member?.memberId]);
 
-  // WebSocket: BATTLE_STARTED 이벤트 수신 시 방 상태 자동 갱신
   useEffect(() => {
-    if (!session.authenticated) return;
+    if (!session.authenticated) {
+      return;
+    }
 
     const client = new Client({
       webSocketFactory: () => new SockJS("/ws"),
       reconnectDelay: 3000,
-      // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
-      // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.
-      // 토큰 발급 실패 시 쿠키 기반 인증(로컬 환경)으로 자동 폴백됨.
       beforeConnect: async () => {
-        // 재연결 시 이전 연결에서 소비된 토큰이 재사용되지 않도록 먼저 초기화
         client.connectHeaders = {};
+
         try {
           const res = await fetch("/api/v1/ws/token", { method: "POST" });
+
           if (res.ok) {
             const data = (await res.json()) as { token: string };
             client.connectHeaders = { "X-WS-Token": data.token };
@@ -243,10 +441,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       onConnect: () => {
         client.subscribe(`/topic/room/${roomId}`, (message) => {
           let payload: unknown;
+
           try {
             payload = JSON.parse(message.body) as unknown;
           } catch {
-            console.warn("[WS] 메시지 파싱 실패:", message.body);
             return;
           }
 
@@ -256,13 +454,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
           const type = (payload as { type: unknown }).type;
 
-          if (type === "BATTLE_STARTED") {
+          if (type === "BATTLE_STARTED" || type === "PARTICIPANT_DONE") {
             void fetch(`/api/battle/rooms/${roomId}`, { cache: "no-store" })
               .then((res) => (res.ok ? res.json() : null))
               .then((data: RoomResponse | null) => {
                 if (data) {
                   setRoom(data);
-                  setMessage("배틀이 시작됐습니다!");
                 }
               });
             return;
@@ -270,33 +467,36 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
           if (type === "SUBMISSION") {
             const msg = payload as SubmissionWsMessage;
+
             if (msg.userId === session.member?.memberId) {
+              setLeftPanelTab("submission");
               setLatestSubmission((prev) =>
                 prev
-                  ? { ...prev, result: msg.result, passedCount: msg.passedCount, totalCount: msg.totalCount }
-                  : { submissionId: 0, result: msg.result, passedCount: msg.passedCount, totalCount: msg.totalCount },
+                  ? {
+                      ...prev,
+                      result: msg.result,
+                      passedCount: msg.passedCount,
+                      totalCount: msg.totalCount,
+                    }
+                  : {
+                      submissionId: 0,
+                      result: msg.result,
+                      passedCount: msg.passedCount,
+                      totalCount: msg.totalCount,
+                    },
               );
+              setIsSubmitting(false);
               setMessage(`채점 완료: ${msg.result} (${msg.passedCount}/${msg.totalCount})`);
             }
-            return;
-          }
-
-          if (type === "PARTICIPANT_DONE") {
-            void fetch(`/api/battle/rooms/${roomId}`, { cache: "no-store" })
-              .then((res) => (res.ok ? res.json() : null))
-              .then((data: RoomResponse | null) => {
-                if (data) setRoom(data);
-              });
-            return;
           }
         });
 
         client.subscribe(`/topic/room/${roomId}/run`, (message) => {
           let payload: unknown;
+
           try {
             payload = JSON.parse(message.body) as unknown;
           } catch {
-            console.warn("[WS] run 메시지 파싱 실패:", message.body);
             return;
           }
 
@@ -305,9 +505,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           }
 
           const msg = payload as RunWsMessage;
+
           if (msg.type === "RUN_RESULT" && msg.userId === session.member?.memberId) {
             setRunResults(msg.results);
-            setIsRunning(false);
+            setRunningCaseIndex(null);
           }
         });
       },
@@ -315,54 +516,40 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
     client.activate();
     stompClientRef.current = client;
+
     return () => {
       stompClientRef.current = null;
       void client.deactivate();
     };
   }, [roomId, session.authenticated, session.member?.memberId]);
 
-  function handleSubmit() {
+  function handleLanguageChange(nextLanguage: string) {
+    setLanguage(nextLanguage);
+    setCode(resolveStarterCode(problem, nextLanguage));
+  }
+
+  function handleCodeChange(nextCode: string) {
+    setCode(nextCode);
+
+    if (stompClientRef.current?.connected && room?.status === "PLAYING") {
+      stompClientRef.current.publish({
+        destination: `/app/room/${roomId}/code`,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code: nextCode }),
+      });
+    }
+  }
+
+  async function handleRunCase(caseIndex: number) {
     if (!room) {
       return;
     }
 
     setError(null);
+    setSelectedRunCaseIndex(caseIndex);
+    setRunningCaseIndex(caseIndex);
 
-    startTransition(() => {
-      void (async () => {
-        const response = await fetch("/api/submissions", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            roomId: room.roomId,
-            code,
-            language,
-          }),
-        });
-
-        if (!response.ok) {
-          const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-          setError(payload?.message ?? "제출에 실패했습니다.");
-          return;
-        }
-
-        const payload = (await response.json()) as SubmissionResponse;
-        setLatestSubmission(payload);
-        setMessage(`제출 완료: ${payload.result ?? "채점 대기"}`);
-      })();
-    });
-  }
-
-  function handleRun() {
-    if (!room) return;
-
-    setError(null);
-    setIsRunning(true);
-    setRunResults(null);
-
-    void (async () => {
+    try {
       const response = await fetch("/api/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -372,36 +559,134 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       if (!response.ok) {
         const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
         setError(payload?.message ?? "실행 요청에 실패했습니다.");
-        setIsRunning(false);
+        setRunningCaseIndex((current) => (current === caseIndex ? null : current));
       }
-      // 성공 시 결과는 WebSocket(RUN_RESULT)으로 수신
-    })();
+    } catch {
+      setError("실행 요청 중 네트워크 오류가 발생했습니다.");
+      setRunningCaseIndex((current) => (current === caseIndex ? null : current));
+    }
+  }
+
+  async function handleSubmit() {
+    if (!room) {
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+    setLeftPanelTab("submission");
+
+    try {
+      const response = await fetch("/api/submissions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          roomId: room.roomId,
+          code,
+          language,
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+        setError(payload?.message ?? "제출에 실패했습니다.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      const payload = (await response.json()) as SubmissionResponse;
+      setLatestSubmission(payload);
+      setMessage(`제출 완료: ${payload.result ?? "채점 대기"}`);
+      setIsSubmitting(false);
+    } catch {
+      setError("제출 요청 중 네트워크 오류가 발생했습니다.");
+      setIsSubmitting(false);
+    }
+  }
+
+  function startVerticalResize(event: React.MouseEvent<HTMLDivElement>) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const container = splitContainerRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      const nextRatio = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+      setLeftPaneRatio(clamp(nextRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO));
+    };
+
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+    };
+
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  function startHorizontalResize(event: React.MouseEvent<HTMLDivElement>) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const rect = rightColumnRef.current?.getBoundingClientRect();
+
+      if (!rect) {
+        return;
+      }
+
+      const nextRatio = ((moveEvent.clientY - rect.top) / rect.height) * 100;
+      setRightTopPaneRatio(clamp(nextRatio, MIN_TOP_RATIO, MAX_TOP_RATIO));
+    };
+
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+    };
+
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "row-resize";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
   }
 
   if (!sessionLoaded && !room) {
     return (
-      <div className="space-y-8">
-        <PageHero
-          eyebrow="Battle Room"
-          title="세션을 확인하는 중입니다."
-          description="잠시만 기다려주세요."
-          actions={<StatusPill>Session</StatusPill>}
-        />
-      </div>
+      <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
+        <p className="text-sm text-zinc-600">잠시만 기다려주세요.</p>
+      </Panel>
     );
   }
 
   if (!session.authenticated && !room) {
     return (
       <div className="space-y-8">
-        <PageHero
-          eyebrow="Battle Room"
-          title="로그인 후 배틀룸에 입장할 수 있습니다."
-          description="배틀룸, 제출, 결과 조회는 모두 보호된 API 흐름입니다. 메인에서 로그인 후 큐를 잡고 배틀룸으로 이동하세요."
-          actions={<StatusPill tone="warn">로그인 필요</StatusPill>}
-        />
-
-        <Panel title="이동" description="보호 화면 진입 전 처리">
+        <div className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-white px-4 py-3">
+          <p className="text-sm font-medium text-zinc-700">
+            배틀룸은 로그인 후 이용할 수 있습니다.
+          </p>
+          <StatusPill tone="warn">로그인 필요</StatusPill>
+        </div>
+        <Panel title="이동" description="로그인 후 다시 배틀룸으로 돌아올 수 있습니다.">
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/battle/rooms/${roomId}`)}`}
@@ -424,382 +709,726 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!room) {
     return (
       <div className="space-y-8">
-        <PageHero
-          eyebrow="Battle Room"
-          title="배틀룸을 열지 못했습니다."
-          description="현재 roomId에 해당하는 방을 찾을 수 없습니다."
-          actions={<StatusPill tone="danger">Load failed</StatusPill>}
-        />
+        <div className="flex items-center justify-between rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3">
+          <p className="text-sm font-medium text-rose-900">
+            배틀룸 정보를 가져오지 못했습니다.
+          </p>
+          <StatusPill tone="danger">Load failed</StatusPill>
+        </div>
         <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-700">{error ?? message}</p>
+          <p className="text-sm leading-7 text-zinc-700">
+            {error ?? message}
+          </p>
         </Panel>
       </div>
     );
   }
 
-  const events = getBattleRoomEvents(roomId);
+  const languages = resolveLanguages(problem, language);
+  const sampleCases = problem?.sampleCases ?? [];
+  const caseCount = Math.max(sampleCases.length, runResults?.length ?? 0);
+  const activeSampleCase =
+    selectedRunCaseIndex !== null ? sampleCases[selectedRunCaseIndex] ?? null : null;
+  const activeRunCase =
+    selectedRunCaseIndex !== null && runResults
+      ? runResults[selectedRunCaseIndex] ?? null
+      : null;
+  const activeCaseInput = activeSampleCase?.input ?? activeRunCase?.input ?? "(empty)";
+  const activeCaseExpected =
+    activeSampleCase?.output ?? activeRunCase?.expectedOutput ?? "(empty)";
+  const activeRunCasePass = isPassVerdict(activeRunCase?.status);
+  const activeRunCaseWrongAnswer = isWrongAnswerVerdict(activeRunCase?.status);
+  const isPlayable = room.status === "PLAYING";
+  const latestResultCode = normalizeVerdict(latestSubmission?.result ?? undefined);
+  const submitHeadline = getSubmitHeadline(isSubmitting, latestSubmission?.result);
+  const submitIsAccepted = latestResultCode === "AC" || latestResultCode === "ACCEPTED";
+  const submitIsWaiting = isSubmitting || latestResultCode === "JUDGING";
+  const submitHasResult = Boolean(isSubmitting || latestSubmission?.result);
+  const submitCardClass = submitIsAccepted
+    ? "border-emerald-300 bg-emerald-50"
+    : submitIsWaiting
+      ? "border-amber-300 bg-amber-50"
+      : submitHasResult
+        ? "border-rose-300 bg-rose-50"
+        : "border-zinc-300 bg-zinc-50";
+  const submitHeadlineClass = submitIsAccepted
+    ? "text-emerald-700"
+    : submitIsWaiting
+      ? "text-amber-700"
+      : submitHasResult
+        ? "text-rose-700"
+        : "text-zinc-700";
+  const submitBadgeClass = submitIsAccepted
+    ? "bg-emerald-700/15 text-emerald-700"
+    : submitIsWaiting
+      ? "bg-amber-700/15 text-amber-700"
+      : "bg-rose-700/15 text-rose-700";
+  const submitProgressText =
+    latestSubmission &&
+    latestSubmission.passedCount !== null &&
+    latestSubmission.totalCount !== null
+      ? `${latestSubmission.passedCount}/${latestSubmission.totalCount} testcases passed`
+      : null;
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Battle Room"
-        title={`Room ${room.roomId} / ${room.status}`}
-        description="READY 상태 참여자는 화면 진입 시 자동으로 join 요청을 보냅니다. 문제 조회와 제출은 실제 API를 우선하고, 연결 실패 시에만 샘플 데이터를 보조로 사용합니다."
-        actions={
-          <>
-            <StatusPill tone={room.status === "PLAYING" ? "success" : "warn"}>
-              {room.status}
-            </StatusPill>
-            <StatusPill>problemId {room.problemId}</StatusPill>
-            <StatusPill>{source === "api" ? "API" : "Fallback"}</StatusPill>
-          </>
-        }
-      />
-
-      <MetricGrid>
-        <MetricCard label="Room ID" value={room.roomId} />
-        <MetricCard label="Max Players" value={room.maxPlayers} />
-        <MetricCard label="Participants" value={room.participants.length} />
-        <MetricCard label="Timer End" value={formatDateTime(room.timerEnd)} />
-      </MetricGrid>
-
-      <div
-        className={`rounded-2xl border px-4 py-3 text-sm ${
-          error
-            ? "border-rose-300 bg-rose-50 text-rose-900"
-            : "border-zinc-300 bg-white text-zinc-700"
-        }`}
-      >
-        {error ?? message}
-      </div>
-
-      <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
-        <Panel
-          title="참가자 상태"
-          description="`RoomResponse.participants`를 그대로 참가자 보드에 투영합니다."
+    <div className="space-y-6">
+      {error && (
+        <div
+          className="rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900"
         >
-          <div className="space-y-3">
-            {room.participants.map((participant) => (
-              <div
-                key={participant.userId}
-                className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3"
-              >
-                <div>
-                  <p className="font-medium text-zinc-950">{participant.nickname}</p>
-                  <p className="text-sm text-zinc-500">userId {participant.userId}</p>
+          {error}
+        </div>
+      )}
+
+      <div className="hidden h-[calc(100dvh-10.5rem)] min-h-0 lg:flex lg:flex-col lg:gap-4">
+        <div ref={splitContainerRef} className="flex min-h-0 flex-1">
+          <div className="h-full min-w-0" style={{ width: `${leftPaneRatio}%` }}>
+            <Panel title="문제 상세" className="flex h-full min-h-0 flex-col">
+              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("description")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "description"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Description
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("submission")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "submission"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Submission
+                    </button>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => void handleSubmit()}
+                    disabled={!isPlayable || isSubmitting}
+                    className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                  >
+                    {isSubmitting ? "Submitting..." : "Submit"}
+                  </button>
                 </div>
-                <StatusPill tone={participantTone(participant.status)}>
-                  {participant.status}
-                </StatusPill>
+
+                {leftPanelTab === "description" ? (
+                  <>
+                    <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Battle
+                      </p>
+                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                        {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
+                      </h1>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <StatusPill>{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
+                        <StatusPill>멀티 배틀</StatusPill>
+                      </div>
+                    </div>
+
+                    <DefinitionGrid
+                      items={[
+                        { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
+                        { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
+                      ]}
+                    />
+
+                    {problem ? (
+                      <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                            Content
+                          </p>
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                            {problem.content}
+                          </MathText>
+                        </div>
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                            Input
+                          </p>
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                            {problem.inputFormat}
+                          </MathText>
+                        </div>
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                            Output
+                          </p>
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                            {problem.outputFormat}
+                          </MathText>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                        문제 상세를 불러오는 중입니다.
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                    <div className="flex flex-wrap items-start gap-3">
+                      <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                        {submitHeadline}
+                      </p>
+                      {submitProgressText ? (
+                        <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                      ) : null}
+                      <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                        {submitHasResult && latestResultCode ? (
+                          <span
+                            className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}
+                          >
+                            {latestResultCode}
+                          </span>
+                        ) : null}
+                        <p className="text-xs text-zinc-600">language: {language}</p>
+                      </div>
+                    </div>
+
+                    <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Current Submission
+                      </p>
+                      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                        {code}
+                      </pre>
+                    </div>
+                  </div>
+                )}
               </div>
-            ))}
+            </Panel>
           </div>
-        </Panel>
 
-        <Panel
-          title="입장과 상태 변화"
-          description="현재 백엔드는 READY 참여자가 모두 PLAYING이 되면 배틀을 시작합니다."
-        >
-          <ul className="space-y-3 text-sm leading-7 text-zinc-700">
-            <li>메인에서 매칭 성사 메시지에 포함된 `roomId`를 읽어 이 화면으로 이동합니다.</li>
-            <li>이 화면은 내 참여자 상태가 `READY`이면 자동으로 `join` 요청을 한 번 보냅니다.</li>
-            <li>모든 참여자가 `PLAYING`으로 바뀌면 방 상태가 `PLAYING`이 되고 타이머가 시작됩니다.</li>
-          </ul>
-        </Panel>
-      </div>
-
-      {room.status === "WAITING" ? (
-        <div className="grid gap-6 xl:grid-cols-2">
-          <Panel
-            title="WAITING 상태"
-            description="아직 전원이 입장하지 않았을 때는 참여자 상태 위주로 보여줍니다."
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            onMouseDown={startVerticalResize}
+            className="group mx-1 flex w-3 cursor-col-resize items-center justify-center"
           >
-            <ul className="space-y-3 text-sm leading-7 text-zinc-700">
-              <li>문제는 이미 할당됐지만 실제 풀이 타이머는 아직 시작되지 않았을 수 있습니다.</li>
-              <li>현재 사용자에게 `READY`가 보이면 자동 입장 요청이 한 번 전송됩니다.</li>
-              <li>다른 참여자가 모두 들어오면 방 상태가 `PLAYING`으로 전환됩니다.</li>
-            </ul>
-          </Panel>
+            <div className="h-full w-px rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+          </div>
 
-          <Panel title="대기 상태 API" description="현재 화면에서 실제로 붙는 엔드포인트">
-            <div className="space-y-4">
-              <ApiCallout
-                method="GET"
-                path={`/api/battle/rooms/${room.roomId}`}
-                note="방 상태와 참여자 목록을 조회합니다."
-              />
-              <ApiCallout
-                method="POST"
-                path={`/api/battle/rooms/${room.roomId}/join`}
-                note="현재 참여자를 READY에서 PLAYING으로 전환합니다."
-              />
-              <ApiCallout
-                method="GET"
-                path={`/api/problems/${room.problemId}`}
-                note="문제 상세는 플레이 전에도 선조회할 수 있게 준비합니다."
+          <div
+            ref={rightColumnRef}
+            className="flex h-full min-w-0 flex-col"
+            style={{ width: `${100 - leftPaneRatio}%` }}
+          >
+            <div className="min-h-0" style={{ height: `${rightTopPaneRatio}%` }}>
+              <BattleCodeEditor
+                languages={languages}
+                language={language}
+                onLanguageChange={handleLanguageChange}
+                value={code}
+                onChange={handleCodeChange}
+                height="100%"
+                className="h-full"
               />
             </div>
-          </Panel>
-        </div>
-      ) : (
-        <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-          <div className="space-y-6">
-            <Panel
-              title="문제 상세"
-              description="백엔드 `ProblemDetailResponse`를 문제 본문 섹션으로 사용합니다."
+
+            <div
+              role="separator"
+              aria-orientation="horizontal"
+              onMouseDown={startHorizontalResize}
+              className="group my-1 flex h-3 cursor-row-resize items-center justify-center"
             >
-              {problem ? (
-                <div className="space-y-4">
-                  <DefinitionGrid
-                    items={[
-                      { label: "title", value: problem.title },
-                      { label: "difficulty", value: problem.difficulty },
-                      { label: "timeLimitMs", value: problem.timeLimitMs },
-                      { label: "memoryLimitMb", value: problem.memoryLimitMb },
-                    ]}
-                  />
+              <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+            </div>
+
+            <div className="min-h-0" style={{ height: `${100 - rightTopPaneRatio}%` }}>
+              <Panel title="TestCase" className="flex h-full min-h-0 flex-col">
+                <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+                  {caseCount > 0 ? (
+                    <>
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex flex-wrap gap-2">
+                          {Array.from({ length: caseCount }, (_, index) => {
+                            const caseResult = runResults?.[index];
+                            const badgeState = getCaseBadgeState(
+                              caseResult,
+                              runningCaseIndex === index,
+                            );
+                            const isSelected = selectedRunCaseIndex === index;
+                            const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
+                            const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
+                            const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
+                            const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+
+                            const colorClass = isSelected
+                              ? "border-zinc-900 bg-zinc-900 text-white"
+                              : badgeState?.tone === "pass"
+                                ? passClass
+                                : badgeState?.tone === "fail"
+                                  ? failClass
+                                  : badgeState?.tone === "pending"
+                                    ? pendingClass
+                                    : idleClass;
+
+                            return (
+                              <button
+                                key={`battle-case-${index}`}
+                                type="button"
+                                onClick={() => setSelectedRunCaseIndex(index)}
+                                className={`flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${colorClass}`}
+                              >
+                                <span>Case {index + 1}</span>
+                                {badgeState ? (
+                                  <span
+                                    className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
+                                      badgeState.tone === "pass"
+                                        ? "bg-emerald-700/15 text-emerald-700"
+                                        : badgeState.tone === "fail"
+                                          ? "bg-rose-700/15 text-rose-700"
+                                          : "bg-amber-700/15 text-amber-700"
+                                    }`}
+                                  >
+                                    {badgeState.label}
+                                  </span>
+                                ) : null}
+                              </button>
+                            );
+                          })}
+                        </div>
+
+                        <button
+                          type="button"
+                          onClick={() =>
+                            selectedRunCaseIndex !== null
+                              ? void handleRunCase(selectedRunCaseIndex)
+                              : null
+                          }
+                          disabled={!isPlayable || selectedRunCaseIndex === null || runningCaseIndex !== null}
+                          className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                        >
+                          {runningCaseIndex !== null ? "실행 중..." : isPlayable ? "▶ Run" : "대기 중"}
+                        </button>
+                      </div>
+
+                      {selectedRunCaseIndex !== null ? (
+                        <div className="grid gap-3 lg:grid-cols-[1fr_0.95fr]">
+                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                            <div>
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                                Input
+                              </p>
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                                {activeCaseInput}
+                              </MathText>
+                            </div>
+                            <div>
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                                Output
+                              </p>
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                                {activeCaseExpected}
+                              </MathText>
+                            </div>
+                          </div>
+
+                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                              Run Result
+                            </p>
+                            <div
+                              className={`rounded-xl border p-3 text-sm ${
+                                !activeRunCase
+                                  ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                                  : activeRunCasePass
+                                    ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                                    : "border-rose-200 bg-rose-50 text-rose-900"
+                              }`}
+                            >
+                              {runningCaseIndex === selectedRunCaseIndex ? (
+                                <p className="text-amber-700">실행 요청 중입니다...</p>
+                              ) : activeRunCase ? (
+                                <div className="space-y-2">
+                                  <p
+                                    className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
+                                      activeRunCasePass
+                                        ? "bg-emerald-700/15 text-emerald-700"
+                                        : "bg-rose-700/15 text-rose-700"
+                                    }`}
+                                  >
+                                    {activeRunCasePass
+                                      ? "PASS"
+                                      : activeRunCaseWrongAnswer
+                                        ? "WRONG ANSWER"
+                                        : normalizeVerdict(activeRunCase.status)}
+                                  </p>
+                                  {activeRunCase.stderr ? (
+                                    <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                                        Error
+                                      </p>
+                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                        {activeRunCase.stderr}
+                                      </pre>
+                                    </div>
+                                  ) : (
+                                    <div className="grid gap-2">
+                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                          Output
+                                        </p>
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                          {activeRunCase.actualOutput ?? "(empty)"}
+                                        </pre>
+                                      </div>
+                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                          Expected
+                                        </p>
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                          {activeRunCase.expectedOutput ?? "(empty)"}
+                                        </pre>
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              ) : (
+                                <p className="text-zinc-600">
+                                  아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
+                  ) : (
+                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      실행 가능한 샘플 케이스가 없습니다.
+                    </div>
+                  )}
+                </div>
+              </Panel>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6 lg:hidden">
+        <Panel title="문제 상세">
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => setLeftPanelTab("description")}
+                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                    leftPanelTab === "description"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                  }`}
+                >
+                  Description
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLeftPanelTab("submission")}
+                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                    leftPanelTab === "submission"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                  }`}
+                >
+                  Submission
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleSubmit()}
+                disabled={!isPlayable || isSubmitting}
+                className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+              >
+                {isSubmitting ? "Submitting..." : "Submit"}
+              </button>
+            </div>
+
+            {leftPanelTab === "description" ? (
+              <>
+                <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Battle
+                  </p>
+                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                    {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
+                  </h1>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <StatusPill>{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
+                    <StatusPill>멀티 배틀</StatusPill>
+                  </div>
+                </div>
+                <DefinitionGrid
+                  items={[
+                    { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
+                    { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
+                  ]}
+                />
+                {problem ? (
                   <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Content
                       </p>
-                      <p className="mt-2 text-sm leading-7 text-zinc-700">
-                        <MathText>{problem.content}</MathText>
-                      </p>
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        {problem.content}
+                      </MathText>
                     </div>
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Input
                       </p>
-                      <p className="mt-2 text-sm leading-7 text-zinc-700">
-                        <MathText>{problem.inputFormat}</MathText>
-                      </p>
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        {problem.inputFormat}
+                      </MathText>
                     </div>
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Output
                       </p>
-                      <p className="mt-2 text-sm leading-7 text-zinc-700">
-                        <MathText>{problem.outputFormat}</MathText>
-                      </p>
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        {problem.outputFormat}
+                      </MathText>
                     </div>
                   </div>
-                </div>
-              ) : (
-                <p className="text-sm text-zinc-600">문제 상세를 불러오지 못했습니다.</p>
-              )}
-            </Panel>
-
-            <Panel
-              title="실시간 이벤트 채널"
-              description="현재 소켓 연결은 아직 붙이지 않았고, 채널 경로와 이벤트 의미를 먼저 고정합니다."
-            >
-              <EventTimeline events={events} />
-            </Panel>
-          </div>
-
-          <div className="space-y-6">
-            <Panel
-              title="코드 에디터"
-              description="LeetCode처럼 Run과 Submit을 분리하되, 현재 실제 실행은 Submit만 연결되어 있습니다."
-            >
-              <div className="space-y-4">
-                <label className="block space-y-2">
-                  <span className="text-sm font-medium text-zinc-700">언어</span>
-                  <select
-                    value={language}
-                    onChange={(event) => setLanguage(event.target.value)}
-                    className="w-full rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm outline-none transition focus:border-zinc-500"
-                  >
-                    <option value="javascript">javascript</option>
-                    <option value="java">java</option>
-                    <option value="python">python</option>
-                  </select>
-                </label>
-
-                <div className="space-y-2">
-                  <span className="text-sm font-medium text-zinc-700">코드</span>
-                  <BattleCodeEditor
-                    language={language}
-                    value={code}
-                    onChange={(newCode) => {
-                      setCode(newCode);
-                      if (stompClientRef.current?.connected && room?.status === "PLAYING") {
-                        stompClientRef.current.publish({
-                          destination: `/app/room/${roomId}/code`,
-                          headers: { "content-type": "application/json" },
-                          body: JSON.stringify({ code: newCode }),
-                        });
-                      }
-                    }}
-                  />
+                ) : (
+                  <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                    문제 상세를 불러오는 중입니다.
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                <div className="flex flex-wrap items-start gap-3">
+                  <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                    {submitHeadline}
+                  </p>
+                  {submitProgressText ? (
+                    <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                  ) : null}
+                  <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                    {submitHasResult && latestResultCode ? (
+                      <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
+                        {latestResultCode}
+                      </span>
+                    ) : null}
+                    <p className="text-xs text-zinc-600">language: {language}</p>
+                  </div>
                 </div>
 
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <button
-                    type="button"
-                    onClick={handleRun}
-                    disabled={isRunning}
-                    className="w-full rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400"
-                  >
-                    {isRunning ? "실행 중..." : "Run"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSubmit}
-                    disabled={isPending}
-                    className="w-full rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-500"
-                  >
-                    {isPending ? "제출 중..." : "Submit"}
-                  </button>
+                <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Current Submission
+                  </p>
+                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                    {code}
+                  </pre>
                 </div>
               </div>
-            </Panel>
+            )}
+          </div>
+        </Panel>
 
-            <Panel
-              title="테스트 실행 결과"
-              description="Run을 누르면 문제의 샘플 테스트케이스를 실행하고 결과를 표시합니다."
-            >
-              {isRunning && (
-                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
-                  채점 서버에서 실행 중입니다...
+        <BattleCodeEditor
+          languages={languages}
+          language={language}
+          onLanguageChange={handleLanguageChange}
+          value={code}
+          onChange={handleCodeChange}
+        />
+
+        <Panel title="TestCase">
+          <div className="space-y-4">
+            {caseCount > 0 ? (
+              <>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap gap-2">
+                    {Array.from({ length: caseCount }, (_, index) => {
+                      const caseResult = runResults?.[index];
+                      const badgeState = getCaseBadgeState(
+                        caseResult,
+                        runningCaseIndex === index,
+                      );
+                      const isSelected = selectedRunCaseIndex === index;
+                      const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
+                      const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
+                      const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
+                      const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+
+                      const colorClass = isSelected
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : badgeState?.tone === "pass"
+                          ? passClass
+                          : badgeState?.tone === "fail"
+                            ? failClass
+                            : badgeState?.tone === "pending"
+                              ? pendingClass
+                              : idleClass;
+
+                      return (
+                        <button
+                          key={`battle-case-mobile-${index}`}
+                          type="button"
+                          onClick={() => setSelectedRunCaseIndex(index)}
+                          className={`flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${colorClass}`}
+                        >
+                          <span>Case {index + 1}</span>
+                          {badgeState ? (
+                            <span
+                              className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
+                                badgeState.tone === "pass"
+                                  ? "bg-emerald-700/15 text-emerald-700"
+                                  : badgeState.tone === "fail"
+                                    ? "bg-rose-700/15 text-rose-700"
+                                    : "bg-amber-700/15 text-amber-700"
+                              }`}
+                            >
+                              {badgeState.label}
+                            </span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      selectedRunCaseIndex !== null
+                        ? void handleRunCase(selectedRunCaseIndex)
+                        : null
+                    }
+                    disabled={!isPlayable || selectedRunCaseIndex === null || runningCaseIndex !== null}
+                    className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
+                  >
+                    {runningCaseIndex !== null ? "실행 중..." : isPlayable ? "▶ Run" : "대기 중"}
+                  </button>
                 </div>
-              )}
 
-              {!isRunning && runResults === null && (
-                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
-                  Run 버튼을 누르면 샘플 테스트케이스 결과가 여기에 표시됩니다.
-                </div>
-              )}
+                {selectedRunCaseIndex !== null ? (
+                  <div className="grid gap-3">
+                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Input
+                        </p>
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                          {activeCaseInput}
+                        </MathText>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Output
+                        </p>
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                          {activeCaseExpected}
+                        </MathText>
+                      </div>
+                    </div>
 
-              {!isRunning && runResults !== null && runResults.length === 0 && (
-                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
-                  이 문제에 샘플 테스트케이스가 없습니다.
-                </div>
-              )}
-
-              {!isRunning && runResults !== null && runResults.length > 0 && (
-                <div className="space-y-4">
-                  {runResults.map((result, index) => {
-                    const isPassed = result.status === "AC";
-                    return (
+                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Run Result
+                      </p>
                       <div
-                        key={index}
-                        className={`rounded-2xl border p-4 ${
-                          isPassed
-                            ? "border-emerald-300 bg-emerald-50"
-                            : "border-rose-300 bg-rose-50"
+                        className={`rounded-xl border p-3 text-sm ${
+                          !activeRunCase
+                            ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                            : activeRunCasePass
+                              ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                              : "border-rose-200 bg-rose-50 text-rose-900"
                         }`}
                       >
-                        <div className="mb-3 flex items-center justify-between">
-                          <span className="text-sm font-medium text-zinc-700">
-                            테스트케이스 {index + 1}
-                          </span>
-                          <span
-                            className={`rounded-full px-3 py-1 text-xs font-semibold ${
-                              isPassed
-                                ? "bg-emerald-100 text-emerald-800"
-                                : result.status === "CE"
-                                  ? "bg-amber-100 text-amber-800"
-                                  : "bg-rose-100 text-rose-800"
-                            }`}
-                          >
-                            {result.status}
-                          </span>
-                        </div>
-
-                        <div className="grid gap-3 sm:grid-cols-3">
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              Input
+                        {runningCaseIndex === selectedRunCaseIndex ? (
+                          <p className="text-amber-700">실행 요청 중입니다...</p>
+                        ) : activeRunCase ? (
+                          <div className="space-y-2">
+                            <p
+                              className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
+                                activeRunCasePass
+                                  ? "bg-emerald-700/15 text-emerald-700"
+                                  : "bg-rose-700/15 text-rose-700"
+                              }`}
+                            >
+                              {activeRunCasePass
+                                ? "PASS"
+                                : activeRunCaseWrongAnswer
+                                  ? "WRONG ANSWER"
+                                  : normalizeVerdict(activeRunCase.status)}
                             </p>
-                            <pre className="mt-1 whitespace-pre-wrap font-mono text-sm leading-6 text-zinc-700">
-                              {result.input || "-"}
-                            </pre>
+                            {activeRunCase.stderr ? (
+                              <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                                  Error
+                                </p>
+                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                  {activeRunCase.stderr}
+                                </pre>
+                              </div>
+                            ) : (
+                              <div className="grid gap-2">
+                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                    Output
+                                  </p>
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                    {activeRunCase.actualOutput ?? "(empty)"}
+                                  </pre>
+                                </div>
+                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                    Expected
+                                  </p>
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                    {activeRunCase.expectedOutput ?? "(empty)"}
+                                  </pre>
+                                </div>
+                              </div>
+                            )}
                           </div>
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              Expected
-                            </p>
-                            <pre className="mt-1 whitespace-pre-wrap font-mono text-sm leading-6 text-zinc-700">
-                              {result.expectedOutput || "-"}
-                            </pre>
-                          </div>
-                          <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                              Output
-                            </p>
-                            <pre className="mt-1 whitespace-pre-wrap font-mono text-sm leading-6 text-zinc-700">
-                              {result.actualOutput ?? "-"}
-                            </pre>
-                          </div>
-                        </div>
-
-                        {result.stderr && (
-                          <div className="mt-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-500">
-                              stderr
-                            </p>
-                            <pre className="mt-1 whitespace-pre-wrap font-mono text-sm leading-6 text-rose-700">
-                              {result.stderr}
-                            </pre>
-                          </div>
+                        ) : (
+                          <p className="text-zinc-600">
+                            아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
+                          </p>
                         )}
                       </div>
-                    );
-                  })}
-                </div>
-              )}
-            </Panel>
-
-            <Panel title="최근 제출 응답" description="실제 제출 결과를 이 영역에 바로 표시합니다.">
-              <DefinitionGrid
-                items={[
-                  { label: "submissionId", value: latestSubmission?.submissionId ?? "-" },
-                  { label: "result", value: latestSubmission?.result ?? "-" },
-                  { label: "passedCount", value: latestSubmission?.passedCount ?? "-" },
-                  { label: "totalCount", value: latestSubmission?.totalCount ?? "-" },
-                ]}
-              />
-            </Panel>
-
-            <Panel title="연결 엔드포인트" description="플레이 중 방에서 붙는 API와 소켓 경로">
-              <div className="space-y-4">
-                <ApiCallout
-                  method="GET"
-                  path={`/api/problems/${room.problemId}`}
-                  note="문제 상세를 단건으로 조회합니다."
-                />
-                <ApiCallout
-                  method="POST"
-                  path="/api/submissions"
-                  note="프론트가 JWT subject를 memberId로 읽어 제출 본문을 완성합니다."
-                />
-                <ApiCallout
-                  method="WS"
-                  path={`/topic/room/${room.roomId}`}
-                  note="배틀 시작, 제출, 참가자 종료, 정산 완료 이벤트를 수신할 경로입니다."
-                />
+                    </div>
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                실행 가능한 샘플 케이스가 없습니다.
               </div>
-            </Panel>
-
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href={`/battle/results/${room.roomId}`}
-                className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
-              >
-                결과 화면 보기
-              </Link>
-              <Link
-                href="/"
-                className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
-              >
-                메인으로 돌아가기
-              </Link>
-            </div>
+            )}
           </div>
+        </Panel>
+
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={`/battle/results/${room.roomId}`}
+            className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+          >
+            결과 화면 보기
+          </Link>
+          <Link
+            href="/"
+            className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+          >
+            메인으로 돌아가기
+          </Link>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -19,6 +19,10 @@ import type {
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
 import { DefinitionGrid, MathText, Panel, StatusPill } from "@/shared/ui";
+import {
+  readPreferredEditorLanguage,
+  writePreferredEditorLanguage,
+} from "@/shared/utils/editor-language";
 
 import {
   getBattleRoom,
@@ -43,6 +47,9 @@ const MAX_TOP_RATIO = 100;
 const LEFT_RATIO_SNAP_POINTS = [0, 22, 32, 50, 68, 78];
 const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76, 92, 100];
 const SPLIT_SNAP_GAP = 4;
+const DEFAULT_LEFT_PANE_RATIO = 50;
+const DEFAULT_RIGHT_TOP_PANE_RATIO = 100;
+const BATTLE_LAYOUT_STORAGE_KEY = "bracket:battle-editor-layout:v1";
 const fallbackLanguages = ["python3", "java", "javascript"];
 const defaultCodeByLanguage: Record<string, string> = {
   javascript: `function solve(input) {\n  // TODO: implement\n}\n`,
@@ -65,6 +72,40 @@ function clamp(value: number, min: number, max: number) {
 function snapRatio(value: number, points: number[], gap: number) {
   const nearest = points.find((point) => Math.abs(value - point) <= gap);
   return nearest ?? value;
+}
+
+function readStoredLayout() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(BATTLE_LAYOUT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as {
+      leftPaneRatio?: number;
+      rightTopPaneRatio?: number;
+    };
+
+    const leftPaneRatio =
+      typeof parsed.leftPaneRatio === "number"
+        ? clamp(parsed.leftPaneRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO)
+        : DEFAULT_LEFT_PANE_RATIO;
+    const rightTopPaneRatio =
+      typeof parsed.rightTopPaneRatio === "number"
+        ? clamp(parsed.rightTopPaneRatio, MIN_TOP_RATIO, MAX_TOP_RATIO)
+        : DEFAULT_RIGHT_TOP_PANE_RATIO;
+
+    return {
+      leftPaneRatio,
+      rightTopPaneRatio,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function normalizeVerdict(verdict: string | undefined) {
@@ -177,14 +218,25 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [latestSubmission, setLatestSubmission] =
     useState<SubmissionResponse | null>(fallbackSubmission);
-  const [code, setCode] = useState(submitTemplate.code);
-  const [language, setLanguage] = useState(submitTemplate.language);
+  const [language, setLanguage] = useState(
+    () => readPreferredEditorLanguage() ?? submitTemplate.language,
+  );
+  const [code, setCode] = useState(() => {
+    const preferredLanguage = readPreferredEditorLanguage() ?? submitTemplate.language;
+    return defaultCodeByLanguage[preferredLanguage] ?? submitTemplate.code;
+  });
   const [runResults, setRunResults] = useState<RunTestCaseResult[] | null>(null);
   const [selectedRunCaseIndex, setSelectedRunCaseIndex] = useState<number | null>(null);
   const [runningCaseIndex, setRunningCaseIndex] = useState<number | null>(null);
   const [leftPanelTab, setLeftPanelTab] = useState<LeftPanelTab>("description");
-  const [leftPaneRatio, setLeftPaneRatio] = useState(54);
-  const [rightTopPaneRatio, setRightTopPaneRatio] = useState(52);
+  const [leftPaneRatio, setLeftPaneRatio] = useState(() => {
+    const stored = readStoredLayout();
+    return stored?.leftPaneRatio ?? DEFAULT_LEFT_PANE_RATIO;
+  });
+  const [rightTopPaneRatio, setRightTopPaneRatio] = useState(() => {
+    const stored = readStoredLayout();
+    return stored?.rightTopPaneRatio ?? DEFAULT_RIGHT_TOP_PANE_RATIO;
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState("배틀룸 정보를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
@@ -249,6 +301,20 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   useEffect(() => {
     rightTopPaneRatioRef.current = rightTopPaneRatio;
   }, [rightTopPaneRatio]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      BATTLE_LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        leftPaneRatio,
+        rightTopPaneRatio,
+      }),
+    );
+  }, [leftPaneRatio, rightTopPaneRatio]);
 
   useEffect(() => {
     if (!sessionLoaded) {
@@ -544,6 +610,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   function handleLanguageChange(nextLanguage: string) {
     setLanguage(nextLanguage);
     setCode(resolveStarterCode(problem, nextLanguage));
+    writePreferredEditorLanguage(nextLanguage);
   }
 
   function handleCodeChange(nextCode: string) {
@@ -975,6 +1042,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     </div>
 
                     <DefinitionGrid
+                      compact
                       items={[
                         { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
                         { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
@@ -1134,8 +1202,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
                     {caseCount > 0 ? (
                       <>
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <div className="flex flex-wrap gap-2">
+                      <div className="flex items-center gap-3">
+                        <div className="min-w-0 flex-1 overflow-x-auto pb-1">
+                          <div className="flex w-max gap-2 pr-1">
                           {Array.from({ length: caseCount }, (_, index) => {
                             const caseResult = runResults?.[index];
                             const badgeState = getCaseBadgeState(
@@ -1182,8 +1251,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                               </button>
                             );
                           })}
+                          </div>
                         </div>
-                        <p className="text-xs font-medium text-zinc-500">
+                        <p className="shrink-0 text-xs font-medium text-zinc-500">
                           ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
                         </p>
                       </div>
@@ -1335,6 +1405,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   </div>
                 </div>
                 <DefinitionGrid
+                  compact
                   items={[
                     { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
                     { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
@@ -1430,8 +1501,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           <div className="space-y-4">
             {caseCount > 0 ? (
               <>
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex flex-wrap gap-2">
+                <div className="flex items-center gap-3">
+                  <div className="min-w-0 flex-1 overflow-x-auto pb-1">
+                    <div className="flex w-max gap-2 pr-1">
                     {Array.from({ length: caseCount }, (_, index) => {
                       const caseResult = runResults?.[index];
                       const badgeState = getCaseBadgeState(
@@ -1478,8 +1550,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                         </button>
                       );
                     })}
+                    </div>
                   </div>
-                  <p className="text-xs font-medium text-zinc-500">
+                  <p className="shrink-0 text-xs font-medium text-zinc-500">
                     ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
                   </p>
                 </div>

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -36,13 +36,13 @@ const BattleCodeEditor = dynamic(() => import("./code-editor"), {
   ),
 });
 
-const MIN_LEFT_RATIO = 22;
+const MIN_LEFT_RATIO = 0;
 const MAX_LEFT_RATIO = 78;
 const MIN_TOP_RATIO = 24;
-const MAX_TOP_RATIO = 76;
-const LEFT_RATIO_SNAP_POINTS = [22, 32, 50, 68, 78];
-const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76];
-const SPLIT_SNAP_GAP = 2;
+const MAX_TOP_RATIO = 100;
+const LEFT_RATIO_SNAP_POINTS = [0, 22, 32, 50, 68, 78];
+const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76, 92, 100];
+const SPLIT_SNAP_GAP = 4;
 const fallbackLanguages = ["python3", "java", "javascript"];
 const defaultCodeByLanguage: Record<string, string> = {
   javascript: `function solve(input) {\n  // TODO: implement\n}\n`,
@@ -863,9 +863,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     !isPlayable || runTargetCaseIndex === null || runningCaseIndex !== null;
   const runActionLabel = runningCaseIndex !== null ? "Running..." : "Run";
   const submitActionLabel = isSubmitting ? "Submitting..." : "Submit";
+  const isLeftPaneCollapsed = leftPaneRatio <= 8;
+  const isTestcaseCollapsed = rightTopPaneRatio >= 96;
 
   return (
-    <div className="space-y-6">
+    <div className="h-full space-y-6 lg:space-y-0">
       {error && (
         <div
           className="rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900"
@@ -874,35 +876,88 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         </div>
       )}
 
-      <div className="hidden h-[calc(100dvh-10.5rem)] min-h-0 lg:flex lg:flex-col lg:gap-4">
+      <div className="hidden h-full min-h-0 lg:flex lg:flex-col lg:gap-4">
         <div ref={splitContainerRef} className="flex min-h-0 flex-1">
-          <div className="h-full min-w-0" style={{ width: `${leftPaneRatio}%` }}>
-            <Panel title="문제 상세" className="flex h-full min-h-0 flex-col">
-              <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setLeftPanelTab("description")}
-                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                      leftPanelTab === "description"
-                        ? "border-zinc-900 bg-zinc-900 text-white"
-                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                    }`}
-                  >
-                    Description
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setLeftPanelTab("submission")}
-                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                      leftPanelTab === "submission"
-                        ? "border-zinc-900 bg-zinc-900 text-white"
-                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                    }`}
-                  >
-                    Submission
-                  </button>
+          <div
+            className={`h-full ${isLeftPaneCollapsed ? "" : "min-w-0"}`}
+            style={isLeftPaneCollapsed ? { width: "44px" } : { width: `${leftPaneRatio}%` }}
+          >
+            {isLeftPaneCollapsed ? (
+              <div
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-300 bg-white px-1 py-3"
+                onClick={(event) => {
+                  if (event.target === event.currentTarget) {
+                    setLeftPaneRatio(32);
+                  }
+                }}
+              >
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  onMouseDown={startVerticalResize}
+                  onDoubleClick={() => setLeftPaneRatio(50)}
+                  className="absolute inset-y-0 right-0 z-10 flex w-2 cursor-col-resize items-center justify-center"
+                >
+                  <div className="h-14 w-0.5 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
                 </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLeftPanelTab("description");
+                    setLeftPaneRatio(32);
+                  }}
+                  className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
+                    leftPanelTab === "description"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  }`}
+                  style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
+                >
+                  Description
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLeftPanelTab("submission");
+                    setLeftPaneRatio(32);
+                  }}
+                  className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
+                    leftPanelTab === "submission"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  }`}
+                  style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
+                >
+                  Submission
+                </button>
+              </div>
+            ) : (
+              <Panel title="문제 상세" className="flex h-full min-h-0 flex-col">
+                <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("description")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "description"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Description
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("submission")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "submission"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Submission
+                    </button>
+                  </div>
 
                 {leftPanelTab === "description" ? (
                   <>
@@ -993,8 +1048,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     </div>
                   </div>
                 )}
-              </div>
-            </Panel>
+                </div>
+              </Panel>
+            )}
           </div>
 
           <div
@@ -1009,10 +1065,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
           <div
             ref={rightColumnRef}
-            className="flex h-full min-w-0 flex-col"
-            style={{ width: `${100 - leftPaneRatio}%` }}
+            className={`relative flex h-full min-w-0 flex-col overflow-hidden ${isLeftPaneCollapsed ? "flex-1" : ""}`}
+            style={isLeftPaneCollapsed ? undefined : { width: `${100 - leftPaneRatio}%` }}
           >
-            <div className="min-h-0" style={{ height: `${rightTopPaneRatio}%` }}>
+            <div
+              className={`min-h-0 ${isTestcaseCollapsed ? "pb-[3.25rem]" : ""}`}
+              style={isTestcaseCollapsed ? { height: "100%" } : { height: `${rightTopPaneRatio}%` }}
+            >
               <BattleCodeEditor
                 languages={languages}
                 language={language}
@@ -1039,16 +1098,42 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               aria-orientation="horizontal"
               onMouseDown={startHorizontalResize}
               onDoubleClick={() => setRightTopPaneRatio(50)}
-              className="group my-1 flex h-3 cursor-row-resize items-center justify-center"
+              className={`group flex cursor-row-resize items-center justify-center transition-all ${
+                isTestcaseCollapsed
+                  ? "pointer-events-none my-0 h-0 opacity-0"
+                  : "my-1 h-3 opacity-100"
+              }`}
             >
               <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
             </div>
 
-            <div className="min-h-0" style={{ height: `${100 - rightTopPaneRatio}%` }}>
-              <Panel title="TestCase" className="flex h-full min-h-0 flex-col">
-                <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
-                  {caseCount > 0 ? (
-                    <>
+            <div
+              className={isTestcaseCollapsed ? "absolute inset-x-0 bottom-0 z-10 h-10" : "min-h-0"}
+              style={isTestcaseCollapsed ? undefined : { height: `${100 - rightTopPaneRatio}%` }}
+            >
+              {isTestcaseCollapsed ? (
+                <div
+                  role="separator"
+                  aria-orientation="horizontal"
+                  onMouseDown={startHorizontalResize}
+                  onDoubleClick={() => setRightTopPaneRatio(50)}
+                  onClick={() => {
+                    if (isTestcaseCollapsed) {
+                      setRightTopPaneRatio(76);
+                    }
+                  }}
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-300 bg-white px-4"
+                >
+                  <div className="pointer-events-none absolute inset-x-0 top-0 flex h-2 items-start justify-center">
+                    <div className="mt-1 h-0.5 w-14 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  </div>
+                  <p className="text-base font-semibold text-zinc-900">TestCase</p>
+                </div>
+              ) : (
+                <Panel title="TestCase" className="flex h-full min-h-0 flex-col">
+                  <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+                    {caseCount > 0 ? (
+                      <>
                       <div className="flex flex-wrap items-center justify-between gap-3">
                         <div className="flex flex-wrap gap-2">
                           {Array.from({ length: caseCount }, (_, index) => {
@@ -1193,14 +1278,15 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           </div>
                         </div>
                       ) : null}
-                    </>
-                  ) : (
-                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
-                      실행 가능한 샘플 케이스가 없습니다.
-                    </div>
-                  )}
-                </div>
-              </Panel>
+                      </>
+                    ) : (
+                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                        실행 가능한 샘플 케이스가 없습니다.
+                      </div>
+                    )}
+                  </div>
+                </Panel>
+              )}
             </div>
           </div>
         </div>

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -33,7 +33,7 @@ import {
 const BattleCodeEditor = dynamic(() => import("./code-editor"), {
   ssr: false,
   loading: () => (
-    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-700 bg-[#171c26] text-sm text-zinc-300">
+    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-app-border bg-app-surface text-sm text-app-secondary">
       에디터를 준비하는 중입니다.
     </div>
   ),
@@ -943,7 +943,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!sessionLoaded && !room) {
     return (
       <Panel variant="dark" title="세션 확인" description="인증 상태를 확인하는 중입니다.">
-        <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
+        <p className="text-sm text-app-muted">잠시만 기다려주세요.</p>
       </Panel>
     );
   }
@@ -951,8 +951,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!session.authenticated && !room) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-zinc-700 bg-[#171c26] px-4 py-3">
-          <p className="text-sm font-medium text-zinc-300">
+        <div className="flex items-center justify-between rounded-2xl border border-app-border bg-app-surface px-4 py-3">
+          <p className="text-sm font-medium text-app-secondary">
             배틀룸은 로그인 후 이용할 수 있습니다.
           </p>
           <StatusPill tone="warn" variant="dark">로그인 필요</StatusPill>
@@ -961,13 +961,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/battle/rooms/${roomId}`)}`}
-              className="rounded-2xl border border-violet-400/40 bg-gradient-to-r from-violet-600 to-violet-500 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl border border-app-accent/40 bg-gradient-to-r from-app-accent to-app-accent-hover px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/"
-              className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm font-medium text-zinc-200"
+              className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm font-medium text-app-primary"
             >
               메인으로 돌아가기
             </Link>
@@ -980,14 +980,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!room) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
-          <p className="text-sm font-medium text-rose-200">
+        <div className="flex items-center justify-between rounded-2xl border border-app-danger/35 bg-app-danger/10 px-4 py-3">
+          <p className="text-sm font-medium text-app-danger">
             배틀룸 정보를 가져오지 못했습니다.
           </p>
           <StatusPill tone="danger" variant="dark">Load failed</StatusPill>
         </div>
         <Panel variant="dark" title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-300">
+          <p className="text-sm leading-7 text-app-secondary">
             {error ?? message}
           </p>
         </Panel>
@@ -1016,24 +1016,24 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const submitIsWaiting = isSubmitting || latestResultCode === "JUDGING";
   const submitHasResult = Boolean(isSubmitting || latestSubmission?.result);
   const submitCardClass = submitIsAccepted
-    ? "border-emerald-500/30 bg-emerald-500/10"
+    ? "border-app-success/30 bg-app-success/10"
     : submitIsWaiting
-      ? "border-amber-500/30 bg-amber-500/10"
+      ? "border-app-warn/30 bg-app-warn/10"
       : submitHasResult
-        ? "border-rose-500/30 bg-rose-500/10"
-        : "border-zinc-700 bg-[#1b2130]";
+        ? "border-app-danger/35 bg-app-danger/10"
+        : "border-app-border bg-app-elevated";
   const submitHeadlineClass = submitIsAccepted
-    ? "text-emerald-300"
+    ? "text-app-success"
     : submitIsWaiting
-      ? "text-amber-300"
+      ? "text-app-warn"
       : submitHasResult
-        ? "text-rose-300"
-        : "text-zinc-200";
+        ? "text-app-danger"
+        : "text-app-primary";
   const submitBadgeClass = submitIsAccepted
-    ? "bg-emerald-500/15 text-emerald-300"
+    ? "bg-app-success/15 text-app-success"
     : submitIsWaiting
-      ? "bg-amber-500/15 text-amber-300"
-      : "bg-rose-500/15 text-rose-300";
+      ? "bg-app-warn/15 text-app-warn"
+      : "bg-app-danger/15 text-app-danger";
   const submitProgressText =
     latestSubmission &&
     latestSubmission.passedCount !== null &&
@@ -1052,7 +1052,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     <div className="h-full space-y-6 lg:space-y-0">
       {error && (
         <div
-          className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"
+          className="rounded-2xl border border-app-danger/35 bg-app-danger/10 px-4 py-3 text-sm text-app-danger"
         >
           {error}
         </div>
@@ -1066,7 +1066,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           >
             {isLeftPaneCollapsed ? (
               <div
-                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-700 bg-[#171c26] px-1 py-3"
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-app-border bg-app-surface px-1 py-3"
                 onClick={(event) => {
                   if (event.target === event.currentTarget) {
                     setLeftPaneRatio(32);
@@ -1081,9 +1081,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   className="absolute inset-y-0 -right-1 z-10 flex w-4 cursor-col-resize items-center justify-center"
                 >
                   <div className="relative flex h-full w-full items-center justify-center">
-                    <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
-                      <div className="h-8 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+                    <div className="h-full w-px rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-app-border-strong bg-app-surface shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-app-accent/60 group-hover:bg-app-accent/15">
+                      <div className="h-8 w-0.5 rounded-full bg-app-border-strong transition group-hover:bg-app-accent-soft" />
                     </div>
                   </div>
                 </div>
@@ -1095,8 +1095,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "description"
-                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                      ? "border-app-border-strong bg-app-elevated text-app-primary"
+                      : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1110,8 +1110,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "submission"
-                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                      ? "border-app-border-strong bg-app-elevated text-app-primary"
+                      : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1127,8 +1127,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       onClick={() => setLeftPanelTab("description")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "description"
-                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                          ? "border-app-border-strong bg-app-elevated text-app-primary"
+                          : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                       }`}
                     >
                       Description
@@ -1138,8 +1138,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       onClick={() => setLeftPanelTab("submission")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "submission"
-                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                          ? "border-app-border-strong bg-app-elevated text-app-primary"
+                          : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                       }`}
                     >
                       Submission
@@ -1148,11 +1148,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                 {leftPanelTab === "description" ? (
                   <>
-                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Battle
                       </p>
-                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
+                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-app-primary">
                         {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
                       </h1>
                       <div className="mt-3 flex flex-wrap gap-2">
@@ -1171,34 +1171,34 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     />
 
                     {problem ? (
-                      <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                      <div className="space-y-4 rounded-2xl border border-app-border bg-app-elevated p-4">
                         <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                             Content
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                          <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                             {problem.content}
                           </MathText>
                         </div>
                         <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                             Input
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                          <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                             {problem.inputFormat}
                           </MathText>
                         </div>
                         <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                             Output
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                          <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                             {problem.outputFormat}
                           </MathText>
                         </div>
                       </div>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                      <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                         문제 상세를 불러오는 중입니다.
                       </div>
                     )}
@@ -1206,7 +1206,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 ) : (
                   submitHasResult ? (
                     <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Submit Result
                       </p>
                       <div className="flex flex-wrap items-start gap-3">
@@ -1214,7 +1214,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           {submitHeadline}
                         </p>
                         {submitProgressText ? (
-                          <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
+                          <p className="pt-1 text-sm text-app-muted">{submitProgressText}</p>
                         ) : null}
                         <div className="ml-auto flex flex-col items-end gap-1 text-right">
                           {latestResultCode ? (
@@ -1224,21 +1224,21 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                               {latestResultCode}
                             </span>
                           ) : null}
-                          <p className="text-xs text-zinc-400">language: {language}</p>
+                          <p className="text-xs text-app-muted">language: {language}</p>
                         </div>
                       </div>
 
-                      <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <div className="rounded-xl border border-app-border bg-app-base/80 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Current Submission
                         </p>
-                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                           {code}
                         </pre>
                       </div>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                    <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                       아직 제출 결과가 없습니다.
                     </div>
                   )
@@ -1258,9 +1258,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
             }`}
           >
             <div className="relative flex h-full w-full items-center justify-center">
-              <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
-                <div className="h-10 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+              <div className="h-full w-px rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-app-border-strong bg-app-surface shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-app-accent/60 group-hover:bg-app-accent/15">
+                <div className="h-10 w-0.5 rounded-full bg-app-border-strong transition group-hover:bg-app-accent-soft" />
               </div>
             </div>
           </div>
@@ -1307,9 +1307,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               }`}
             >
               <div className="relative flex h-full w-full items-center justify-center">
-                <div className="h-px w-full rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
-                  <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                <div className="h-px w-full rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-app-border bg-app-surface/90 transition group-hover:border-app-accent/50 group-hover:bg-app-accent/10">
+                  <div className="h-0.5 w-6 rounded-full bg-app-elevated transition group-hover:bg-app-accent-soft" />
                 </div>
               </div>
             </div>
@@ -1329,20 +1329,20 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       setRightTopPaneRatio(76);
                     }
                   }}
-                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-700 bg-[#171c26] px-4"
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-app-border bg-app-surface px-4"
                 >
                   <div className="pointer-events-none absolute inset-x-0 top-1.5 flex h-2.5 items-center justify-center">
-                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
-                      <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-app-border bg-app-surface/90 transition group-hover:border-app-accent/50 group-hover:bg-app-accent/10">
+                      <div className="h-0.5 w-6 rounded-full bg-app-elevated transition group-hover:bg-app-accent-soft" />
                     </div>
                   </div>
-                  <p className="text-base font-semibold text-zinc-100">TestCase</p>
+                  <p className="text-base font-semibold text-app-primary">TestCase</p>
                 </div>
               ) : (
-                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
                   <div className="mb-4 flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
-                    <p className="shrink-0 text-xs font-medium text-zinc-500">
+                    <h2 className="text-lg font-semibold text-app-primary">TestCase</h2>
+                    <p className="shrink-0 text-xs font-medium text-app-dim">
                       {TESTCASE_SHORTCUT_HINT}
                     </p>
                   </div>
@@ -1356,13 +1356,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             const caseResult = runResults?.[index];
                             const badgeState = getCaseBadgeState(caseResult);
                             const isSelected = selectedRunCaseIndex === index;
-                            const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
-                            const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
-                            const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
-                            const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
+                            const idleClass = "border-app-border bg-app-elevated text-app-secondary hover:bg-app-elevated";
+                            const passClass = "border-app-success/30 bg-app-success/10 text-app-success hover:bg-app-success/15";
+                            const failClass = "border-app-danger/35 bg-app-danger/10 text-app-danger hover:bg-app-danger/15";
+                            const pendingClass = "border-app-warn/30 bg-app-warn/10 text-app-warn hover:bg-app-warn/15";
 
                             const colorClass = isSelected
-                              ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                              ? "border-app-border-strong bg-app-elevated text-app-primary"
                               : badgeState?.tone === "pass"
                                 ? passClass
                                 : badgeState?.tone === "fail"
@@ -1383,10 +1383,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   <span
                                     className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                       badgeState.tone === "pass"
-                                        ? "bg-emerald-500/15 text-emerald-200"
+                                        ? "bg-app-success/15 text-app-success"
                                         : badgeState.tone === "fail"
-                                          ? "bg-rose-500/15 text-rose-200"
-                                          : "bg-amber-500/15 text-amber-200"
+                                          ? "bg-app-danger/15 text-app-danger"
+                                          : "bg-app-warn/15 text-app-warn"
                                     }`}
                                   >
                                     {badgeState.label}
@@ -1401,47 +1401,47 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                       {selectedRunCaseIndex !== null ? (
                         <div className="grid gap-3 lg:grid-cols-[1fr_0.95fr]">
-                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                          <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
                             <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                                 Input
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                              <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                                 {activeCaseInput}
                               </MathText>
                             </div>
                             <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                                 Output
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                              <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                                 {activeCaseExpected}
                               </MathText>
                             </div>
                           </div>
 
-                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                               Run Result
                             </p>
                             <div
                               className={`rounded-xl border p-3 text-sm ${
                                 !activeRunCase
-                                  ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
+                                  ? "border-app-border bg-app-base text-app-secondary"
                                   : activeRunCasePass
-                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-                                    : "border-rose-500/30 bg-rose-500/10 text-rose-200"
+                                    ? "border-app-success/30 bg-app-success/10 text-app-success"
+                                    : "border-app-danger/35 bg-app-danger/10 text-app-danger"
                               }`}
                             >
                               {runningCaseIndex === selectedRunCaseIndex ? (
-                                <p className="text-amber-300">실행 요청 중입니다...</p>
+                                <p className="text-app-warn">실행 요청 중입니다...</p>
                               ) : activeRunCase ? (
                                 <div className="space-y-2">
                                   <p
                                     className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                       activeRunCasePass
-                                        ? "bg-emerald-500/15 text-emerald-200"
-                                        : "bg-rose-500/15 text-rose-200"
+                                        ? "bg-app-success/15 text-app-success"
+                                        : "bg-app-danger/15 text-app-danger"
                                     }`}
                                   >
                                     {activeRunCasePass
@@ -1451,29 +1451,29 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                         : normalizeVerdict(activeRunCase.status)}
                                   </p>
                                   {activeRunCase.stderr ? (
-                                    <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
-                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
+                                    <div className="rounded-lg border border-app-danger/35 bg-app-base/80 p-2">
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-danger">
                                         Error
                                       </p>
-                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
+                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-danger">
                                         {activeRunCase.stderr}
                                       </pre>
                                     </div>
                                   ) : (
                                     <div className="grid gap-2">
-                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                      <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                           Output
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                           {activeRunCase.actualOutput ?? "(empty)"}
                                         </pre>
                                       </div>
-                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                      <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                           Expected
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                           {activeRunCase.expectedOutput ?? "(empty)"}
                                         </pre>
                                       </div>
@@ -1481,7 +1481,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   )}
                                 </div>
                               ) : (
-                                <p className="text-zinc-400">
+                                <p className="text-app-muted">
                                   아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                                 </p>
                               )}
@@ -1491,7 +1491,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       ) : null}
                       </>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                      <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                         실행 가능한 샘플 케이스가 없습니다.
                       </div>
                     )}
@@ -1512,8 +1512,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 onClick={() => setLeftPanelTab("description")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "description"
-                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                    ? "border-app-border-strong bg-app-elevated text-app-primary"
+                    : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                 }`}
               >
                 Description
@@ -1523,8 +1523,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 onClick={() => setLeftPanelTab("submission")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "submission"
-                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                    ? "border-app-border-strong bg-app-elevated text-app-primary"
+                    : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                 }`}
               >
                 Submission
@@ -1533,11 +1533,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
             {leftPanelTab === "description" ? (
               <>
-                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                     Battle
                   </p>
-                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
+                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-app-primary">
                     {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
                   </h1>
                   <div className="mt-3 flex flex-wrap gap-2">
@@ -1554,34 +1554,34 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   ]}
                 />
                 {problem ? (
-                  <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                  <div className="space-y-4 rounded-2xl border border-app-border bg-app-elevated p-4">
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Content
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                      <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                         {problem.content}
                       </MathText>
                     </div>
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Input
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                      <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                         {problem.inputFormat}
                       </MathText>
                     </div>
                     <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Output
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                      <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                         {problem.outputFormat}
                       </MathText>
                     </div>
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                  <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                     문제 상세를 불러오는 중입니다.
                   </div>
                 )}
@@ -1589,7 +1589,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
             ) : (
               submitHasResult ? (
                 <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                     Submit Result
                   </p>
                   <div className="flex flex-wrap items-start gap-3">
@@ -1597,7 +1597,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       {submitHeadline}
                     </p>
                     {submitProgressText ? (
-                      <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
+                      <p className="pt-1 text-sm text-app-muted">{submitProgressText}</p>
                     ) : null}
                     <div className="ml-auto flex flex-col items-end gap-1 text-right">
                       {latestResultCode ? (
@@ -1605,21 +1605,21 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           {latestResultCode}
                         </span>
                       ) : null}
-                      <p className="text-xs text-zinc-400">language: {language}</p>
+                      <p className="text-xs text-app-muted">language: {language}</p>
                     </div>
                   </div>
 
-                  <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  <div className="rounded-xl border border-app-border bg-app-base/80 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                       Current Submission
                     </p>
-                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                       {code}
                     </pre>
                   </div>
                 </div>
               ) : (
-                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                   아직 제출 결과가 없습니다.
                 </div>
               )
@@ -1645,10 +1645,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           submitLabel={submitActionLabel}
         />
 
-        <section className="rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+        <section className="rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
-            <p className="shrink-0 text-xs font-medium text-zinc-500">
+            <h2 className="text-lg font-semibold text-app-primary">TestCase</h2>
+            <p className="shrink-0 text-xs font-medium text-app-dim">
               {TESTCASE_SHORTCUT_HINT}
             </p>
           </div>
@@ -1662,13 +1662,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       const caseResult = runResults?.[index];
                       const badgeState = getCaseBadgeState(caseResult);
                       const isSelected = selectedRunCaseIndex === index;
-                      const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
-                      const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
-                      const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
-                      const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
+                      const idleClass = "border-app-border bg-app-elevated text-app-secondary hover:bg-app-elevated";
+                      const passClass = "border-app-success/30 bg-app-success/10 text-app-success hover:bg-app-success/15";
+                      const failClass = "border-app-danger/35 bg-app-danger/10 text-app-danger hover:bg-app-danger/15";
+                      const pendingClass = "border-app-warn/30 bg-app-warn/10 text-app-warn hover:bg-app-warn/15";
 
                       const colorClass = isSelected
-                        ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                        ? "border-app-border-strong bg-app-elevated text-app-primary"
                         : badgeState?.tone === "pass"
                           ? passClass
                           : badgeState?.tone === "fail"
@@ -1689,10 +1689,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             <span
                               className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                 badgeState.tone === "pass"
-                                  ? "bg-emerald-500/15 text-emerald-200"
+                                  ? "bg-app-success/15 text-app-success"
                                   : badgeState.tone === "fail"
-                                    ? "bg-rose-500/15 text-rose-200"
-                                    : "bg-amber-500/15 text-amber-200"
+                                    ? "bg-app-danger/15 text-app-danger"
+                                    : "bg-app-warn/15 text-app-warn"
                               }`}
                             >
                               {badgeState.label}
@@ -1707,47 +1707,47 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                 {selectedRunCaseIndex !== null ? (
                   <div className="grid gap-3">
-                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                    <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {activeCaseInput}
                         </MathText>
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {activeCaseExpected}
                         </MathText>
                       </div>
                     </div>
 
-                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Run Result
                       </p>
                       <div
                         className={`rounded-xl border p-3 text-sm ${
                           !activeRunCase
-                            ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
+                            ? "border-app-border bg-app-base text-app-secondary"
                             : activeRunCasePass
-                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-                              : "border-rose-500/30 bg-rose-500/10 text-rose-200"
+                              ? "border-app-success/30 bg-app-success/10 text-app-success"
+                              : "border-app-danger/35 bg-app-danger/10 text-app-danger"
                         }`}
                       >
                         {runningCaseIndex === selectedRunCaseIndex ? (
-                          <p className="text-amber-300">실행 요청 중입니다...</p>
+                          <p className="text-app-warn">실행 요청 중입니다...</p>
                         ) : activeRunCase ? (
                           <div className="space-y-2">
                             <p
                               className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                 activeRunCasePass
-                                  ? "bg-emerald-500/15 text-emerald-200"
-                                  : "bg-rose-500/15 text-rose-200"
+                                  ? "bg-app-success/15 text-app-success"
+                                  : "bg-app-danger/15 text-app-danger"
                               }`}
                             >
                               {activeRunCasePass
@@ -1757,29 +1757,29 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   : normalizeVerdict(activeRunCase.status)}
                             </p>
                             {activeRunCase.stderr ? (
-                              <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
+                              <div className="rounded-lg border border-app-danger/35 bg-app-base/80 p-2">
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-danger">
                                   Error
                                 </p>
-                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
+                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-danger">
                                   {activeRunCase.stderr}
                                 </pre>
                               </div>
                             ) : (
                               <div className="grid gap-2">
-                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                     Output
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                     {activeRunCase.actualOutput ?? "(empty)"}
                                   </pre>
                                 </div>
-                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                     Expected
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                     {activeRunCase.expectedOutput ?? "(empty)"}
                                   </pre>
                                 </div>
@@ -1787,7 +1787,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             )}
                           </div>
                         ) : (
-                          <p className="text-zinc-400">
+                          <p className="text-app-muted">
                             아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                           </p>
                         )}
@@ -1797,7 +1797,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 ) : null}
               </>
             ) : (
-              <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+              <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                 실행 가능한 샘플 케이스가 없습니다.
               </div>
             )}
@@ -1807,13 +1807,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         <div className="flex flex-wrap gap-3">
           <Link
             href={`/battle/results/${room.roomId}`}
-            className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+            className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
           >
             결과 화면 보기
           </Link>
           <Link
             href="/"
-            className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+            className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
           >
             메인으로 돌아가기
           </Link>

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -36,10 +36,13 @@ const BattleCodeEditor = dynamic(() => import("./code-editor"), {
   ),
 });
 
-const MIN_LEFT_RATIO = 32;
-const MAX_LEFT_RATIO = 68;
-const MIN_TOP_RATIO = 28;
-const MAX_TOP_RATIO = 72;
+const MIN_LEFT_RATIO = 22;
+const MAX_LEFT_RATIO = 78;
+const MIN_TOP_RATIO = 24;
+const MAX_TOP_RATIO = 76;
+const LEFT_RATIO_SNAP_POINTS = [22, 32, 50, 68, 78];
+const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76];
+const SPLIT_SNAP_GAP = 2;
 const fallbackLanguages = ["python3", "java", "javascript"];
 const defaultCodeByLanguage: Record<string, string> = {
   javascript: `function solve(input) {\n  // TODO: implement\n}\n`,
@@ -57,6 +60,11 @@ interface CaseBadgeState {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function snapRatio(value: number, points: number[], gap: number) {
+  const nearest = points.find((point) => Math.abs(value - point) <= gap);
+  return nearest ?? value;
 }
 
 function normalizeVerdict(verdict: string | undefined) {
@@ -184,6 +192,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const stompClientRef = useRef<Client | null>(null);
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
+  const leftPaneRatioRef = useRef(leftPaneRatio);
+  const rightTopPaneRatioRef = useRef(rightTopPaneRatio);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
@@ -231,6 +241,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       return 0;
     });
   }, [problem, runResults]);
+
+  useEffect(() => {
+    leftPaneRatioRef.current = leftPaneRatio;
+  }, [leftPaneRatio]);
+
+  useEffect(() => {
+    rightTopPaneRatioRef.current = rightTopPaneRatio;
+  }, [rightTopPaneRatio]);
 
   useEffect(() => {
     if (!sessionLoaded) {
@@ -622,7 +640,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     const onMove = (moveEvent: MouseEvent) => {
       const rect = container.getBoundingClientRect();
       const nextRatio = ((moveEvent.clientX - rect.left) / rect.width) * 100;
-      setLeftPaneRatio(clamp(nextRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO));
+      const clamped = clamp(nextRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO);
+      leftPaneRatioRef.current = clamped;
+      setLeftPaneRatio(clamped);
     };
 
     const onUp = () => {
@@ -630,6 +650,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       window.removeEventListener("mouseup", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
+      const snapped = snapRatio(leftPaneRatioRef.current, LEFT_RATIO_SNAP_POINTS, SPLIT_SNAP_GAP);
+      leftPaneRatioRef.current = snapped;
+      setLeftPaneRatio(snapped);
     };
 
     document.body.style.userSelect = "none";
@@ -653,7 +676,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       }
 
       const nextRatio = ((moveEvent.clientY - rect.top) / rect.height) * 100;
-      setRightTopPaneRatio(clamp(nextRatio, MIN_TOP_RATIO, MAX_TOP_RATIO));
+      const clamped = clamp(nextRatio, MIN_TOP_RATIO, MAX_TOP_RATIO);
+      rightTopPaneRatioRef.current = clamped;
+      setRightTopPaneRatio(clamped);
     };
 
     const onUp = () => {
@@ -661,6 +686,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       window.removeEventListener("mouseup", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
+      const snapped = snapRatio(rightTopPaneRatioRef.current, TOP_RATIO_SNAP_POINTS, SPLIT_SNAP_GAP);
+      rightTopPaneRatioRef.current = snapped;
+      setRightTopPaneRatio(snapped);
     };
 
     document.body.style.userSelect = "none";
@@ -973,6 +1001,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
             role="separator"
             aria-orientation="vertical"
             onMouseDown={startVerticalResize}
+            onDoubleClick={() => setLeftPaneRatio(50)}
             className="group mx-1 flex w-3 cursor-col-resize items-center justify-center"
           >
             <div className="h-full w-px rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
@@ -1009,6 +1038,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               role="separator"
               aria-orientation="horizontal"
               onMouseDown={startHorizontalResize}
+              onDoubleClick={() => setRightTopPaneRatio(50)}
               className="group my-1 flex h-3 cursor-row-resize items-center justify-center"
             >
               <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -33,7 +33,7 @@ import {
 const BattleCodeEditor = dynamic(() => import("./code-editor"), {
   ssr: false,
   loading: () => (
-    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-300 bg-zinc-950 text-sm text-zinc-300">
+    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-700 bg-[#171c26] text-sm text-zinc-300">
       에디터를 준비하는 중입니다.
     </div>
   ),
@@ -942,8 +942,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
   if (!sessionLoaded && !room) {
     return (
-      <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
-        <p className="text-sm text-zinc-600">잠시만 기다려주세요.</p>
+      <Panel variant="dark" title="세션 확인" description="인증 상태를 확인하는 중입니다.">
+        <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
       </Panel>
     );
   }
@@ -951,23 +951,23 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!session.authenticated && !room) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-white px-4 py-3">
-          <p className="text-sm font-medium text-zinc-700">
+        <div className="flex items-center justify-between rounded-2xl border border-zinc-700 bg-[#171c26] px-4 py-3">
+          <p className="text-sm font-medium text-zinc-300">
             배틀룸은 로그인 후 이용할 수 있습니다.
           </p>
-          <StatusPill tone="warn">로그인 필요</StatusPill>
+          <StatusPill tone="warn" variant="dark">로그인 필요</StatusPill>
         </div>
-        <Panel title="이동" description="로그인 후 다시 배틀룸으로 돌아올 수 있습니다.">
+        <Panel variant="dark" title="이동" description="로그인 후 다시 배틀룸으로 돌아올 수 있습니다.">
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/battle/rooms/${roomId}`)}`}
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl border border-violet-400/40 bg-gradient-to-r from-violet-600 to-violet-500 px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+              className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm font-medium text-zinc-200"
             >
               메인으로 돌아가기
             </Link>
@@ -980,14 +980,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   if (!room) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3">
-          <p className="text-sm font-medium text-rose-900">
+        <div className="flex items-center justify-between rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-rose-200">
             배틀룸 정보를 가져오지 못했습니다.
           </p>
-          <StatusPill tone="danger">Load failed</StatusPill>
+          <StatusPill tone="danger" variant="dark">Load failed</StatusPill>
         </div>
-        <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-700">
+        <Panel variant="dark" title="오류" description="응답 메시지">
+          <p className="text-sm leading-7 text-zinc-300">
             {error ?? message}
           </p>
         </Panel>
@@ -1016,24 +1016,24 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const submitIsWaiting = isSubmitting || latestResultCode === "JUDGING";
   const submitHasResult = Boolean(isSubmitting || latestSubmission?.result);
   const submitCardClass = submitIsAccepted
-    ? "border-emerald-300 bg-emerald-50"
+    ? "border-emerald-500/30 bg-emerald-500/10"
     : submitIsWaiting
-      ? "border-amber-300 bg-amber-50"
+      ? "border-amber-500/30 bg-amber-500/10"
       : submitHasResult
-        ? "border-rose-300 bg-rose-50"
-        : "border-zinc-300 bg-zinc-50";
+        ? "border-rose-500/30 bg-rose-500/10"
+        : "border-zinc-700 bg-[#1b2130]";
   const submitHeadlineClass = submitIsAccepted
-    ? "text-emerald-700"
+    ? "text-emerald-300"
     : submitIsWaiting
-      ? "text-amber-700"
+      ? "text-amber-300"
       : submitHasResult
-        ? "text-rose-700"
-        : "text-zinc-700";
+        ? "text-rose-300"
+        : "text-zinc-200";
   const submitBadgeClass = submitIsAccepted
-    ? "bg-emerald-700/15 text-emerald-700"
+    ? "bg-emerald-500/15 text-emerald-300"
     : submitIsWaiting
-      ? "bg-amber-700/15 text-amber-700"
-      : "bg-rose-700/15 text-rose-700";
+      ? "bg-amber-500/15 text-amber-300"
+      : "bg-rose-500/15 text-rose-300";
   const submitProgressText =
     latestSubmission &&
     latestSubmission.passedCount !== null &&
@@ -1052,7 +1052,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     <div className="h-full space-y-6 lg:space-y-0">
       {error && (
         <div
-          className="rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+          className="rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"
         >
           {error}
         </div>
@@ -1066,7 +1066,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           >
             {isLeftPaneCollapsed ? (
               <div
-                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-300 bg-white px-1 py-3"
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-700 bg-[#171c26] px-1 py-3"
                 onClick={(event) => {
                   if (event.target === event.currentTarget) {
                     setLeftPaneRatio(32);
@@ -1078,9 +1078,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   aria-orientation="vertical"
                   onMouseDown={startVerticalResize}
                   onDoubleClick={() => setLeftPaneRatio(50)}
-                  className="absolute inset-y-0 right-0 z-10 flex w-2 cursor-col-resize items-center justify-center"
+                  className="absolute inset-y-0 -right-1 z-10 flex w-4 cursor-col-resize items-center justify-center"
                 >
-                  <div className="h-14 w-0.5 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  <div className="relative flex h-full w-full items-center justify-center">
+                    <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
+                      <div className="h-8 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+                    </div>
+                  </div>
                 </div>
                 <button
                   type="button"
@@ -1090,8 +1095,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "description"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1105,8 +1110,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "submission"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1114,7 +1119,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 </button>
               </div>
             ) : (
-              <Panel title="문제 상세" className="flex h-full min-h-0 flex-col">
+              <Panel variant="dark" title="문제 상세" className="flex h-full min-h-0 flex-col">
                 <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
                   <div className="flex flex-wrap gap-2">
                     <button
@@ -1122,8 +1127,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       onClick={() => setLeftPanelTab("description")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "description"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                       }`}
                     >
                       Description
@@ -1133,8 +1138,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       onClick={() => setLeftPanelTab("submission")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "submission"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                       }`}
                     >
                       Submission
@@ -1143,21 +1148,22 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                 {leftPanelTab === "description" ? (
                   <>
-                    <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Battle
                       </p>
-                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
                         {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
                       </h1>
                       <div className="mt-3 flex flex-wrap gap-2">
-                        <StatusPill>{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
-                        <StatusPill>멀티 배틀</StatusPill>
+                        <StatusPill variant="dark">{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
+                        <StatusPill variant="dark">멀티 배틀</StatusPill>
                       </div>
                     </div>
 
                     <DefinitionGrid
                       compact
+                      variant="dark"
                       items={[
                         { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
                         { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
@@ -1165,12 +1171,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     />
 
                     {problem ? (
-                      <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                      <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                         <div>
                           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                             Content
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                             {problem.content}
                           </MathText>
                         </div>
@@ -1178,7 +1184,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                             Input
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                             {problem.inputFormat}
                           </MathText>
                         </div>
@@ -1186,13 +1192,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                             Output
                           </p>
-                          <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                          <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                             {problem.outputFormat}
                           </MathText>
                         </div>
                       </div>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                         문제 상세를 불러오는 중입니다.
                       </div>
                     )}
@@ -1208,7 +1214,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           {submitHeadline}
                         </p>
                         {submitProgressText ? (
-                          <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                          <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
                         ) : null}
                         <div className="ml-auto flex flex-col items-end gap-1 text-right">
                           {latestResultCode ? (
@@ -1218,21 +1224,21 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                               {latestResultCode}
                             </span>
                           ) : null}
-                          <p className="text-xs text-zinc-600">language: {language}</p>
+                          <p className="text-xs text-zinc-400">language: {language}</p>
                         </div>
                       </div>
 
-                      <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                      <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Current Submission
                         </p>
-                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                           {code}
                         </pre>
                       </div>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                       아직 제출 결과가 없습니다.
                     </div>
                   )
@@ -1247,9 +1253,16 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
             aria-orientation="vertical"
             onMouseDown={startVerticalResize}
             onDoubleClick={() => setLeftPaneRatio(50)}
-            className="group mx-1 flex w-3 cursor-col-resize items-center justify-center"
+            className={`group mx-1 items-center justify-center ${
+              isLeftPaneCollapsed ? "pointer-events-none hidden opacity-0" : "flex w-3 cursor-col-resize opacity-100"
+            }`}
           >
-            <div className="h-full w-px rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+            <div className="relative flex h-full w-full items-center justify-center">
+              <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
+                <div className="h-10 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+              </div>
+            </div>
           </div>
 
           <div
@@ -1293,7 +1306,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   : "my-1 h-3 opacity-100"
               }`}
             >
-              <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+              <div className="relative flex h-full w-full items-center justify-center">
+                <div className="h-px w-full rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
+                  <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                </div>
+              </div>
             </div>
 
             <div
@@ -1311,17 +1329,19 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       setRightTopPaneRatio(76);
                     }
                   }}
-                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-300 bg-white px-4"
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-700 bg-[#171c26] px-4"
                 >
-                  <div className="pointer-events-none absolute inset-x-0 top-0 flex h-2 items-start justify-center">
-                    <div className="mt-1 h-0.5 w-14 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  <div className="pointer-events-none absolute inset-x-0 top-1.5 flex h-2.5 items-center justify-center">
+                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
+                      <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                    </div>
                   </div>
-                  <p className="text-base font-semibold text-zinc-900">TestCase</p>
+                  <p className="text-base font-semibold text-zinc-100">TestCase</p>
                 </div>
               ) : (
-                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
                   <div className="mb-4 flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+                    <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
                     <p className="shrink-0 text-xs font-medium text-zinc-500">
                       {TESTCASE_SHORTCUT_HINT}
                     </p>
@@ -1336,13 +1356,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             const caseResult = runResults?.[index];
                             const badgeState = getCaseBadgeState(caseResult);
                             const isSelected = selectedRunCaseIndex === index;
-                            const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
-                            const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
-                            const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
-                            const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+                            const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
+                            const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
+                            const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
+                            const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
 
                             const colorClass = isSelected
-                              ? "border-zinc-900 bg-zinc-900 text-white"
+                              ? "border-zinc-100 bg-zinc-100 text-zinc-950"
                               : badgeState?.tone === "pass"
                                 ? passClass
                                 : badgeState?.tone === "fail"
@@ -1363,10 +1383,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   <span
                                     className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                       badgeState.tone === "pass"
-                                        ? "bg-emerald-700/15 text-emerald-700"
+                                        ? "bg-emerald-500/15 text-emerald-200"
                                         : badgeState.tone === "fail"
-                                          ? "bg-rose-700/15 text-rose-700"
-                                          : "bg-amber-700/15 text-amber-700"
+                                          ? "bg-rose-500/15 text-rose-200"
+                                          : "bg-amber-500/15 text-amber-200"
                                     }`}
                                   >
                                     {badgeState.label}
@@ -1381,12 +1401,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                       {selectedRunCaseIndex !== null ? (
                         <div className="grid gap-3 lg:grid-cols-[1fr_0.95fr]">
-                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                             <div>
                               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                                 Input
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                                 {activeCaseInput}
                               </MathText>
                             </div>
@@ -1394,34 +1414,34 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                                 Output
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                                 {activeCaseExpected}
                               </MathText>
                             </div>
                           </div>
 
-                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                               Run Result
                             </p>
                             <div
                               className={`rounded-xl border p-3 text-sm ${
                                 !activeRunCase
-                                  ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                                  ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
                                   : activeRunCasePass
-                                    ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-                                    : "border-rose-200 bg-rose-50 text-rose-900"
+                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+                                    : "border-rose-500/30 bg-rose-500/10 text-rose-200"
                               }`}
                             >
                               {runningCaseIndex === selectedRunCaseIndex ? (
-                                <p className="text-amber-700">실행 요청 중입니다...</p>
+                                <p className="text-amber-300">실행 요청 중입니다...</p>
                               ) : activeRunCase ? (
                                 <div className="space-y-2">
                                   <p
                                     className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                       activeRunCasePass
-                                        ? "bg-emerald-700/15 text-emerald-700"
-                                        : "bg-rose-700/15 text-rose-700"
+                                        ? "bg-emerald-500/15 text-emerald-200"
+                                        : "bg-rose-500/15 text-rose-200"
                                     }`}
                                   >
                                     {activeRunCasePass
@@ -1431,29 +1451,29 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                         : normalizeVerdict(activeRunCase.status)}
                                   </p>
                                   {activeRunCase.stderr ? (
-                                    <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
-                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                                    <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
                                         Error
                                       </p>
-                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
                                         {activeRunCase.stderr}
                                       </pre>
                                     </div>
                                   ) : (
                                     <div className="grid gap-2">
-                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                           Output
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                           {activeRunCase.actualOutput ?? "(empty)"}
                                         </pre>
                                       </div>
-                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                           Expected
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                           {activeRunCase.expectedOutput ?? "(empty)"}
                                         </pre>
                                       </div>
@@ -1461,7 +1481,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   )}
                                 </div>
                               ) : (
-                                <p className="text-zinc-600">
+                                <p className="text-zinc-400">
                                   아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                                 </p>
                               )}
@@ -1471,7 +1491,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       ) : null}
                       </>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                         실행 가능한 샘플 케이스가 없습니다.
                       </div>
                     )}
@@ -1484,7 +1504,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       </div>
 
       <div className="space-y-6 lg:hidden">
-        <Panel title="문제 상세">
+        <Panel variant="dark" title="문제 상세">
           <div className="space-y-4">
             <div className="flex flex-wrap gap-2">
               <button
@@ -1492,8 +1512,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 onClick={() => setLeftPanelTab("description")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "description"
-                    ? "border-zinc-900 bg-zinc-900 text-white"
-                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                 }`}
               >
                 Description
@@ -1503,8 +1523,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 onClick={() => setLeftPanelTab("submission")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "submission"
-                    ? "border-zinc-900 bg-zinc-900 text-white"
-                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                 }`}
               >
                 Submission
@@ -1513,32 +1533,33 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
             {leftPanelTab === "description" ? (
               <>
-                <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                     Battle
                   </p>
-                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
                     {problem ? `${problem.problemId}. ${problem.title}` : `Problem ${room.problemId}`}
                   </h1>
                   <div className="mt-3 flex flex-wrap gap-2">
-                    <StatusPill>{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
-                    <StatusPill>멀티 배틀</StatusPill>
+                    <StatusPill variant="dark">{problem?.difficulty ?? "UNKNOWN"}</StatusPill>
+                    <StatusPill variant="dark">멀티 배틀</StatusPill>
                   </div>
                 </div>
                 <DefinitionGrid
                   compact
+                  variant="dark"
                   items={[
                     { label: "timeLimitMs", value: problem?.timeLimitMs ?? "-" },
                     { label: "memoryLimitMb", value: problem?.memoryLimitMb ?? "-" },
                   ]}
                 />
                 {problem ? (
-                  <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                  <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Content
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                         {problem.content}
                       </MathText>
                     </div>
@@ -1546,7 +1567,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Input
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                         {problem.inputFormat}
                       </MathText>
                     </div>
@@ -1554,13 +1575,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Output
                       </p>
-                      <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                      <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                         {problem.outputFormat}
                       </MathText>
                     </div>
                   </div>
                 ) : (
-                  <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                  <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                     문제 상세를 불러오는 중입니다.
                   </div>
                 )}
@@ -1576,7 +1597,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       {submitHeadline}
                     </p>
                     {submitProgressText ? (
-                      <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                      <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
                     ) : null}
                     <div className="ml-auto flex flex-col items-end gap-1 text-right">
                       {latestResultCode ? (
@@ -1584,21 +1605,21 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           {latestResultCode}
                         </span>
                       ) : null}
-                      <p className="text-xs text-zinc-600">language: {language}</p>
+                      <p className="text-xs text-zinc-400">language: {language}</p>
                     </div>
                   </div>
 
-                  <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                  <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                       Current Submission
                     </p>
-                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                       {code}
                     </pre>
                   </div>
                 </div>
               ) : (
-                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                   아직 제출 결과가 없습니다.
                 </div>
               )
@@ -1624,9 +1645,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           submitLabel={submitActionLabel}
         />
 
-        <section className="rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+        <section className="rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+            <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
             <p className="shrink-0 text-xs font-medium text-zinc-500">
               {TESTCASE_SHORTCUT_HINT}
             </p>
@@ -1641,13 +1662,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       const caseResult = runResults?.[index];
                       const badgeState = getCaseBadgeState(caseResult);
                       const isSelected = selectedRunCaseIndex === index;
-                      const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
-                      const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
-                      const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
-                      const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+                      const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
+                      const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
+                      const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
+                      const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
 
                       const colorClass = isSelected
-                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        ? "border-zinc-100 bg-zinc-100 text-zinc-950"
                         : badgeState?.tone === "pass"
                           ? passClass
                           : badgeState?.tone === "fail"
@@ -1668,10 +1689,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             <span
                               className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                 badgeState.tone === "pass"
-                                  ? "bg-emerald-700/15 text-emerald-700"
+                                  ? "bg-emerald-500/15 text-emerald-200"
                                   : badgeState.tone === "fail"
-                                    ? "bg-rose-700/15 text-rose-700"
-                                    : "bg-amber-700/15 text-amber-700"
+                                    ? "bg-rose-500/15 text-rose-200"
+                                    : "bg-amber-500/15 text-amber-200"
                               }`}
                             >
                               {badgeState.label}
@@ -1686,12 +1707,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
                 {selectedRunCaseIndex !== null ? (
                   <div className="grid gap-3">
-                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <div>
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {activeCaseInput}
                         </MathText>
                       </div>
@@ -1699,34 +1720,34 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {activeCaseExpected}
                         </MathText>
                       </div>
                     </div>
 
-                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Run Result
                       </p>
                       <div
                         className={`rounded-xl border p-3 text-sm ${
                           !activeRunCase
-                            ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                            ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
                             : activeRunCasePass
-                              ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-                              : "border-rose-200 bg-rose-50 text-rose-900"
+                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+                              : "border-rose-500/30 bg-rose-500/10 text-rose-200"
                         }`}
                       >
                         {runningCaseIndex === selectedRunCaseIndex ? (
-                          <p className="text-amber-700">실행 요청 중입니다...</p>
+                          <p className="text-amber-300">실행 요청 중입니다...</p>
                         ) : activeRunCase ? (
                           <div className="space-y-2">
                             <p
                               className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                 activeRunCasePass
-                                  ? "bg-emerald-700/15 text-emerald-700"
-                                  : "bg-rose-700/15 text-rose-700"
+                                  ? "bg-emerald-500/15 text-emerald-200"
+                                  : "bg-rose-500/15 text-rose-200"
                               }`}
                             >
                               {activeRunCasePass
@@ -1736,29 +1757,29 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                                   : normalizeVerdict(activeRunCase.status)}
                             </p>
                             {activeRunCase.stderr ? (
-                              <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                              <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
                                   Error
                                 </p>
-                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
                                   {activeRunCase.stderr}
                                 </pre>
                               </div>
                             ) : (
                               <div className="grid gap-2">
-                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                     Output
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                     {activeRunCase.actualOutput ?? "(empty)"}
                                   </pre>
                                 </div>
-                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                     Expected
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                     {activeRunCase.expectedOutput ?? "(empty)"}
                                   </pre>
                                 </div>
@@ -1766,7 +1787,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             )}
                           </div>
                         ) : (
-                          <p className="text-zinc-600">
+                          <p className="text-zinc-400">
                             아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                           </p>
                         )}
@@ -1776,7 +1797,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 ) : null}
               </>
             ) : (
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+              <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                 실행 가능한 샘플 케이스가 없습니다.
               </div>
             )}

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -8,6 +8,7 @@ import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
+  BattleRoomStateResponse,
   JoinRoomResponse,
   ProblemDetailResponse,
   RoomResponse,
@@ -151,11 +152,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   }, [refreshSession, roomId, session.authenticated, sessionLoaded]);
 
   useEffect(() => {
+    hasAttemptedJoinRef.current = false;
+  }, [roomId]);
+
+  useEffect(() => {
     if (
       hasAttemptedJoinRef.current ||
       !room ||
       !session.authenticated ||
-      room.status !== "WAITING" ||
       !session.member
     ) {
       return;
@@ -165,7 +169,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       (item) => item.userId === session.member?.memberId,
     );
 
-    if (participant?.status !== "READY") {
+    const shouldJoin =
+      (room.status === "WAITING" && participant?.status === "READY") ||
+      (room.status === "PLAYING" && participant?.status === "ABANDONED");
+
+    if (!shouldJoin) {
       return;
     }
 
@@ -180,6 +188,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         if (!response.ok) {
           const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
           setError(payload?.message ?? "배틀룸 입장에 실패했습니다.");
+          hasAttemptedJoinRef.current = false;
           return;
         }
 
@@ -192,6 +201,17 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
         if (refreshed.ok) {
           setRoom((await refreshed.json()) as RoomResponse);
+        }
+
+        const stateResponse = await fetch(`/api/battle/rooms/${roomId}/state`, {
+          cache: "no-store",
+        });
+
+        if (stateResponse.ok) {
+          const stateData = (await stateResponse.json()) as BattleRoomStateResponse;
+          if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
+            setCode(stateData.myCode);
+          }
         }
       })();
     });

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -27,7 +27,6 @@ import {
 import {
   getBattleRoom,
   getProblemDetail,
-  latestSubmission as fallbackSubmission,
   submitTemplate,
 } from "./data";
 
@@ -50,6 +49,7 @@ const SPLIT_SNAP_GAP = 4;
 const DEFAULT_LEFT_PANE_RATIO = 50;
 const DEFAULT_RIGHT_TOP_PANE_RATIO = 100;
 const BATTLE_LAYOUT_STORAGE_KEY = "bracket:battle-editor-layout:v1";
+const TESTCASE_SHORTCUT_HINT = "⌘/Ctrl+Enter: Run · Shift+Enter: Submit";
 const fallbackLanguages = ["python3", "java", "javascript"];
 const defaultCodeByLanguage: Record<string, string> = {
   javascript: `function solve(input) {\n  // TODO: implement\n}\n`,
@@ -124,14 +124,13 @@ function isWrongAnswerVerdict(verdict: string | undefined) {
 
 function getCaseBadgeState(
   result: RunTestCaseResult | undefined,
-  isPending: boolean,
 ): CaseBadgeState | null {
-  if (isPending) {
-    return { label: "RUN", tone: "pending" };
-  }
-
   if (!result) {
     return null;
+  }
+
+  if (normalizeVerdict(result.status) === "RUNNING") {
+    return { label: "RUNNING", tone: "pending" };
   }
 
   if (isPassVerdict(result.status)) {
@@ -143,6 +142,45 @@ function getCaseBadgeState(
   }
 
   return { label: normalizeVerdict(result.status) || "FAIL", tone: "fail" };
+}
+
+function createFallbackCaseResult(
+  status: string,
+  input: string,
+  expectedOutput: string,
+  stderr: string | null = null,
+): RunTestCaseResult {
+  return {
+    input,
+    expectedOutput,
+    actualOutput: null,
+    status,
+    stderr,
+  };
+}
+
+function mapRunResultsByCaseIndex(
+  incomingResults: RunTestCaseResult[],
+  sampleCases: ProblemDetailResponse["sampleCases"],
+): RunTestCaseResult[] {
+  const sampleCaseList = sampleCases ?? [];
+  const totalCaseCount = Math.max(sampleCaseList.length, incomingResults.length);
+
+  return Array.from({ length: totalCaseCount }, (_, index) => {
+    const result = incomingResults[index];
+
+    if (result) {
+      return result;
+    }
+
+    const sampleCase = sampleCaseList[index];
+    return createFallbackCaseResult(
+      "NO_RESULT",
+      sampleCase?.input ?? "(empty)",
+      sampleCase?.output ?? "(empty)",
+      "해당 케이스 실행 결과를 받지 못했습니다.",
+    );
+  });
 }
 
 function resolveLanguages(problem: ProblemDetailResponse | null, currentLanguage: string) {
@@ -217,7 +255,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [latestSubmission, setLatestSubmission] =
-    useState<SubmissionResponse | null>(fallbackSubmission);
+    useState<SubmissionResponse | null>(null);
   const [language, setLanguage] = useState(
     () => readPreferredEditorLanguage() ?? submitTemplate.language,
   );
@@ -241,11 +279,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const [message, setMessage] = useState("배틀룸 정보를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
   const hasAttemptedJoinRef = useRef(false);
+  const joinRequestInFlightRef = useRef(false);
+  const lastRejoinAttemptAtRef = useRef(0);
   const stompClientRef = useRef<Client | null>(null);
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
   const leftPaneRatioRef = useRef(leftPaneRatio);
   const rightTopPaneRatioRef = useRef(rightTopPaneRatio);
+  const sampleCasesRef = useRef(problem?.sampleCases ?? []);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
@@ -301,6 +342,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   useEffect(() => {
     rightTopPaneRatioRef.current = rightTopPaneRatio;
   }, [rightTopPaneRatio]);
+
+  useEffect(() => {
+    sampleCasesRef.current = problem?.sampleCases ?? [];
+  }, [problem]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -442,10 +487,15 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
   useEffect(() => {
     hasAttemptedJoinRef.current = false;
+    joinRequestInFlightRef.current = false;
+    lastRejoinAttemptAtRef.current = 0;
+    setLatestSubmission(null);
+    setIsSubmitting(false);
+    setLeftPanelTab("description");
   }, [roomId]);
 
   useEffect(() => {
-    if (hasAttemptedJoinRef.current || !room || !session.authenticated || !session.member) {
+    if (!room || !session.authenticated || !session.member || joinRequestInFlightRef.current) {
       return;
     }
 
@@ -453,49 +503,81 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       (item) => item.userId === session.member?.memberId,
     );
 
-    const shouldJoin =
-      (room.status === "WAITING" && participant?.status === "READY") ||
-      (room.status === "PLAYING" && participant?.status === "ABANDONED");
+    const shouldJoinFromWaiting =
+      room.status === "WAITING" &&
+      participant?.status === "READY" &&
+      !hasAttemptedJoinRef.current;
+    const shouldRejoinFromPlaying =
+      room.status === "PLAYING" &&
+      (participant?.status === "ABANDONED" || participant?.status === "EXIT");
 
-    if (!shouldJoin) {
+    if (!shouldJoinFromWaiting && !shouldRejoinFromPlaying) {
       return;
     }
 
-    hasAttemptedJoinRef.current = true;
-
-    void (async () => {
-      const response = await fetch(`/api/battle/rooms/${roomId}/join`, {
-        method: "POST",
-      });
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-        setError(payload?.message ?? "배틀룸 입장에 실패했습니다.");
-        hasAttemptedJoinRef.current = false;
+    if (shouldRejoinFromPlaying) {
+      const now = Date.now();
+      // 재연결 상태에서는 짧은 텀으로 재시도하되 과도한 join 요청 폭주를 막는다.
+      if (now - lastRejoinAttemptAtRef.current < 2000) {
         return;
       }
+      lastRejoinAttemptAtRef.current = now;
+    }
 
-      const payload = (await response.json()) as JoinRoomResponse;
-      setMessage(`배틀룸 입장 처리 완료: ${payload.status}`);
+    if (shouldJoinFromWaiting) {
+      hasAttemptedJoinRef.current = true;
+    }
 
-      const refreshed = await fetch(`/api/battle/rooms/${roomId}`, {
-        cache: "no-store",
-      });
+    joinRequestInFlightRef.current = true;
 
-      if (refreshed.ok) {
-        setRoom((await refreshed.json()) as RoomResponse);
-      }
+    const finalizeJoinAttempt = () => {
+      joinRequestInFlightRef.current = false;
+    };
 
-      const stateResponse = await fetch(`/api/battle/rooms/${roomId}/state`, {
-        cache: "no-store",
-      });
+    if (!participant) {
+      finalizeJoinAttempt();
+      return;
+    }
 
-      if (stateResponse.ok) {
-        const stateData = (await stateResponse.json()) as BattleRoomStateResponse;
+    void (async () => {
+      try {
+        const response = await fetch(`/api/battle/rooms/${roomId}/join`, {
+          method: "POST",
+        });
 
-        if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
-          setCode(stateData.myCode);
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+          if (shouldJoinFromWaiting) {
+            setError(payload?.message ?? "배틀룸 입장에 실패했습니다.");
+            hasAttemptedJoinRef.current = false;
+          }
+          return;
         }
+
+        const payload = (await response.json()) as JoinRoomResponse;
+        setMessage(`배틀룸 입장 처리 완료: ${payload.status}`);
+
+        const refreshed = await fetch(`/api/battle/rooms/${roomId}`, {
+          cache: "no-store",
+        });
+
+        if (refreshed.ok) {
+          setRoom((await refreshed.json()) as RoomResponse);
+        }
+
+        const stateResponse = await fetch(`/api/battle/rooms/${roomId}/state`, {
+          cache: "no-store",
+        });
+
+        if (stateResponse.ok) {
+          const stateData = (await stateResponse.json()) as BattleRoomStateResponse;
+
+          if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
+            setCode(stateData.myCode);
+          }
+        }
+      } finally {
+        finalizeJoinAttempt();
       }
     })();
   }, [room, roomId, session.authenticated, session.member?.memberId]);
@@ -591,7 +673,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           const msg = payload as RunWsMessage;
 
           if (msg.type === "RUN_RESULT" && msg.userId === session.member?.memberId) {
-            setRunResults(msg.results);
+            setRunResults(mapRunResultsByCaseIndex(msg.results, sampleCasesRef.current));
             setRunningCaseIndex(null);
           }
         });
@@ -630,9 +712,20 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       return;
     }
 
+    const sampleCaseList = problem?.sampleCases ?? [];
+    const totalCaseCount = Math.max(sampleCaseList.length, runResults?.length ?? 0);
+    const runningResults = Array.from({ length: totalCaseCount }, (_, index) =>
+      createFallbackCaseResult(
+        "RUNNING",
+        sampleCaseList[index]?.input ?? "(empty)",
+        sampleCaseList[index]?.output ?? "(empty)",
+      ),
+    );
+
     setError(null);
     setSelectedRunCaseIndex(caseIndex);
     setRunningCaseIndex(caseIndex);
+    setRunResults(runningResults);
 
     try {
       const response = await fetch("/api/run", {
@@ -643,11 +736,33 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
       if (!response.ok) {
         const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-        setError(payload?.message ?? "실행 요청에 실패했습니다.");
+        const failMessage = payload?.message ?? "실행 요청에 실패했습니다.";
+        setError(failMessage);
+        setRunResults(
+          Array.from({ length: totalCaseCount }, (_, index) =>
+            createFallbackCaseResult(
+              "REQUEST_FAILED",
+              sampleCaseList[index]?.input ?? "(empty)",
+              sampleCaseList[index]?.output ?? "(empty)",
+              failMessage,
+            ),
+          ),
+        );
         setRunningCaseIndex((current) => (current === caseIndex ? null : current));
       }
     } catch {
-      setError("실행 요청 중 네트워크 오류가 발생했습니다.");
+      const failMessage = "실행 요청 중 네트워크 오류가 발생했습니다.";
+      setError(failMessage);
+      setRunResults(
+        Array.from({ length: totalCaseCount }, (_, index) =>
+          createFallbackCaseResult(
+            "REQUEST_FAILED",
+            sampleCaseList[index]?.input ?? "(empty)",
+            sampleCaseList[index]?.output ?? "(empty)",
+            failMessage,
+          ),
+        ),
+      );
       setRunningCaseIndex((current) => (current === caseIndex ? null : current));
     }
   }
@@ -1083,38 +1198,44 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     )}
                   </>
                 ) : (
-                  <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Submit Result
-                    </p>
-                    <div className="flex flex-wrap items-start gap-3">
-                      <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
-                        {submitHeadline}
+                  submitHasResult ? (
+                    <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        Submit Result
                       </p>
-                      {submitProgressText ? (
-                        <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
-                      ) : null}
-                      <div className="ml-auto flex flex-col items-end gap-1 text-right">
-                        {submitHasResult && latestResultCode ? (
-                          <span
-                            className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}
-                          >
-                            {latestResultCode}
-                          </span>
+                      <div className="flex flex-wrap items-start gap-3">
+                        <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                          {submitHeadline}
+                        </p>
+                        {submitProgressText ? (
+                          <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
                         ) : null}
-                        <p className="text-xs text-zinc-600">language: {language}</p>
+                        <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                          {latestResultCode ? (
+                            <span
+                              className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}
+                            >
+                              {latestResultCode}
+                            </span>
+                          ) : null}
+                          <p className="text-xs text-zinc-600">language: {language}</p>
+                        </div>
+                      </div>
+
+                      <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Current Submission
+                        </p>
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                          {code}
+                        </pre>
                       </div>
                     </div>
-
-                    <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Current Submission
-                      </p>
-                      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
-                        {code}
-                      </pre>
+                  ) : (
+                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      아직 제출 결과가 없습니다.
                     </div>
-                  </div>
+                  )
                 )}
                 </div>
               </Panel>
@@ -1198,7 +1319,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   <p className="text-base font-semibold text-zinc-900">TestCase</p>
                 </div>
               ) : (
-                <Panel title="TestCase" className="flex h-full min-h-0 flex-col">
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+                    <p className="shrink-0 text-xs font-medium text-zinc-500">
+                      {TESTCASE_SHORTCUT_HINT}
+                    </p>
+                  </div>
                   <div className="min-h-0 flex-1 space-y-4 overflow-y-auto">
                     {caseCount > 0 ? (
                       <>
@@ -1207,10 +1334,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           <div className="flex w-max gap-2 pr-1">
                           {Array.from({ length: caseCount }, (_, index) => {
                             const caseResult = runResults?.[index];
-                            const badgeState = getCaseBadgeState(
-                              caseResult,
-                              runningCaseIndex === index,
-                            );
+                            const badgeState = getCaseBadgeState(caseResult);
                             const isSelected = selectedRunCaseIndex === index;
                             const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
                             const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
@@ -1253,9 +1377,6 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                           })}
                           </div>
                         </div>
-                        <p className="shrink-0 text-xs font-medium text-zinc-500">
-                          ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
-                        </p>
                       </div>
 
                       {selectedRunCaseIndex !== null ? (
@@ -1355,7 +1476,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       </div>
                     )}
                   </div>
-                </Panel>
+                </section>
               )}
             </div>
           </div>
@@ -1445,36 +1566,42 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 )}
               </>
             ) : (
-              <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                  Submit Result
-                </p>
-                <div className="flex flex-wrap items-start gap-3">
-                  <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
-                    {submitHeadline}
+              submitHasResult ? (
+                <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    Submit Result
                   </p>
-                  {submitProgressText ? (
-                    <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
-                  ) : null}
-                  <div className="ml-auto flex flex-col items-end gap-1 text-right">
-                    {submitHasResult && latestResultCode ? (
-                      <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
-                        {latestResultCode}
-                      </span>
+                  <div className="flex flex-wrap items-start gap-3">
+                    <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                      {submitHeadline}
+                    </p>
+                    {submitProgressText ? (
+                      <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
                     ) : null}
-                    <p className="text-xs text-zinc-600">language: {language}</p>
+                    <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                      {latestResultCode ? (
+                        <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
+                          {latestResultCode}
+                        </span>
+                      ) : null}
+                      <p className="text-xs text-zinc-600">language: {language}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Current Submission
+                    </p>
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                      {code}
+                    </pre>
                   </div>
                 </div>
-
-                <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Current Submission
-                  </p>
-                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
-                    {code}
-                  </pre>
+              ) : (
+                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                  아직 제출 결과가 없습니다.
                 </div>
-              </div>
+              )
             )}
           </div>
         </Panel>
@@ -1497,7 +1624,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           submitLabel={submitActionLabel}
         />
 
-        <Panel title="TestCase">
+        <section className="rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+            <p className="shrink-0 text-xs font-medium text-zinc-500">
+              {TESTCASE_SHORTCUT_HINT}
+            </p>
+          </div>
           <div className="space-y-4">
             {caseCount > 0 ? (
               <>
@@ -1506,10 +1639,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     <div className="flex w-max gap-2 pr-1">
                     {Array.from({ length: caseCount }, (_, index) => {
                       const caseResult = runResults?.[index];
-                      const badgeState = getCaseBadgeState(
-                        caseResult,
-                        runningCaseIndex === index,
-                      );
+                      const badgeState = getCaseBadgeState(caseResult);
                       const isSelected = selectedRunCaseIndex === index;
                       const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
                       const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
@@ -1552,9 +1682,6 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                     })}
                     </div>
                   </div>
-                  <p className="shrink-0 text-xs font-medium text-zinc-500">
-                    ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
-                  </p>
                 </div>
 
                 {selectedRunCaseIndex !== null ? (
@@ -1654,7 +1781,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               </div>
             )}
           </div>
-        </Panel>
+        </section>
 
         <div className="flex flex-wrap gap-3">
           <Link

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -186,7 +186,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(min-width: 1280px)");
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
     const body = document.body;
     const html = document.documentElement;
     const previousBodyOverflow = body.style.overflow;
@@ -669,6 +669,67 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     window.addEventListener("mouseup", onUp);
   }
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      const isRunShortcut =
+        event.key === "Enter" && (event.metaKey || event.ctrlKey) && !event.shiftKey;
+      const isSubmitShortcut = event.key === "Enter" && event.shiftKey;
+
+      if (!isRunShortcut && !isSubmitShortcut) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof HTMLInputElement || target instanceof HTMLSelectElement) {
+        return;
+      }
+
+      if (isSubmitShortcut) {
+        if (isSubmitting) {
+          return;
+        }
+
+        event.preventDefault();
+        void handleSubmit();
+        return;
+      }
+
+      if (!room || room.status !== "PLAYING" || runningCaseIndex !== null) {
+        return;
+      }
+
+      const sampleCaseCount = problem?.sampleCases?.length ?? 0;
+      const runCaseCount = runResults?.length ?? 0;
+      const totalCaseCount = Math.max(sampleCaseCount, runCaseCount);
+      const runCaseIndex = selectedRunCaseIndex ?? (totalCaseCount > 0 ? 0 : null);
+
+      if (runCaseIndex === null) {
+        return;
+      }
+
+      event.preventDefault();
+      void handleRunCase(runCaseIndex);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [
+    handleRunCase,
+    handleSubmit,
+    isSubmitting,
+    problem,
+    room,
+    runResults,
+    runningCaseIndex,
+    selectedRunCaseIndex,
+  ]);
+
   if (!sessionLoaded && !room) {
     return (
       <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
@@ -769,6 +830,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     latestSubmission.totalCount !== null
       ? `${latestSubmission.passedCount}/${latestSubmission.totalCount} testcases passed`
       : null;
+  const runTargetCaseIndex = selectedRunCaseIndex ?? (caseCount > 0 ? 0 : null);
+  const runActionDisabled =
+    !isPlayable || runTargetCaseIndex === null || runningCaseIndex !== null;
+  const runActionLabel = runningCaseIndex !== null ? "Running..." : "Run";
+  const submitActionLabel = isSubmitting ? "Submitting..." : "Submit";
 
   return (
     <div className="space-y-6">
@@ -785,38 +851,28 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           <div className="h-full min-w-0" style={{ width: `${leftPaneRatio}%` }}>
             <Panel title="문제 상세" className="flex h-full min-h-0 flex-col">
               <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setLeftPanelTab("description")}
-                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                        leftPanelTab === "description"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                      }`}
-                    >
-                      Description
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setLeftPanelTab("submission")}
-                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                        leftPanelTab === "submission"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                      }`}
-                    >
-                      Submission
-                    </button>
-                  </div>
+                <div className="flex flex-wrap gap-2">
                   <button
                     type="button"
-                    onClick={() => void handleSubmit()}
-                    disabled={!isPlayable || isSubmitting}
-                    className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                    onClick={() => setLeftPanelTab("description")}
+                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                      leftPanelTab === "description"
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    }`}
                   >
-                    {isSubmitting ? "Submitting..." : "Submit"}
+                    Description
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setLeftPanelTab("submission")}
+                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                      leftPanelTab === "submission"
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    }`}
+                  >
+                    Submission
                   </button>
                 </div>
 
@@ -877,6 +933,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   </>
                 ) : (
                   <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Submit Result
+                    </p>
                     <div className="flex flex-wrap items-start gap-3">
                       <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
                         {submitHeadline}
@@ -931,6 +990,16 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 onLanguageChange={handleLanguageChange}
                 value={code}
                 onChange={handleCodeChange}
+                onRun={() => {
+                  if (runTargetCaseIndex !== null) {
+                    void handleRunCase(runTargetCaseIndex);
+                  }
+                }}
+                onSubmit={() => void handleSubmit()}
+                runDisabled={runActionDisabled}
+                submitDisabled={!isPlayable || isSubmitting}
+                runLabel={runActionLabel}
+                submitLabel={submitActionLabel}
                 height="100%"
                 className="h-full"
               />
@@ -999,19 +1068,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                             );
                           })}
                         </div>
-
-                        <button
-                          type="button"
-                          onClick={() =>
-                            selectedRunCaseIndex !== null
-                              ? void handleRunCase(selectedRunCaseIndex)
-                              : null
-                          }
-                          disabled={!isPlayable || selectedRunCaseIndex === null || runningCaseIndex !== null}
-                          className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-                        >
-                          {runningCaseIndex !== null ? "실행 중..." : isPlayable ? "▶ Run" : "대기 중"}
-                        </button>
+                        <p className="text-xs font-medium text-zinc-500">
+                          ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
+                        </p>
                       </div>
 
                       {selectedRunCaseIndex !== null ? (
@@ -1120,38 +1179,28 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       <div className="space-y-6 lg:hidden">
         <Panel title="문제 상세">
           <div className="space-y-4">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={() => setLeftPanelTab("description")}
-                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                    leftPanelTab === "description"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                  }`}
-                >
-                  Description
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setLeftPanelTab("submission")}
-                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                    leftPanelTab === "submission"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                  }`}
-                >
-                  Submission
-                </button>
-              </div>
+            <div className="flex flex-wrap gap-2">
               <button
                 type="button"
-                onClick={() => void handleSubmit()}
-                disabled={!isPlayable || isSubmitting}
-                className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                onClick={() => setLeftPanelTab("description")}
+                className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                  leftPanelTab === "description"
+                    ? "border-zinc-900 bg-zinc-900 text-white"
+                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                }`}
               >
-                {isSubmitting ? "Submitting..." : "Submit"}
+                Description
+              </button>
+              <button
+                type="button"
+                onClick={() => setLeftPanelTab("submission")}
+                className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                  leftPanelTab === "submission"
+                    ? "border-zinc-900 bg-zinc-900 text-white"
+                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                }`}
+              >
+                Submission
               </button>
             </div>
 
@@ -1210,6 +1259,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               </>
             ) : (
               <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  Submit Result
+                </p>
                 <div className="flex flex-wrap items-start gap-3">
                   <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
                     {submitHeadline}
@@ -1246,6 +1298,16 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
           onLanguageChange={handleLanguageChange}
           value={code}
           onChange={handleCodeChange}
+          onRun={() => {
+            if (runTargetCaseIndex !== null) {
+              void handleRunCase(runTargetCaseIndex);
+            }
+          }}
+          onSubmit={() => void handleSubmit()}
+          runDisabled={runActionDisabled}
+          submitDisabled={!isPlayable || isSubmitting}
+          runLabel={runActionLabel}
+          submitLabel={submitActionLabel}
         />
 
         <Panel title="TestCase">
@@ -1301,18 +1363,9 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                       );
                     })}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      selectedRunCaseIndex !== null
-                        ? void handleRunCase(selectedRunCaseIndex)
-                        : null
-                    }
-                    disabled={!isPlayable || selectedRunCaseIndex === null || runningCaseIndex !== null}
-                    className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-                  >
-                    {runningCaseIndex !== null ? "실행 중..." : isPlayable ? "▶ Run" : "대기 중"}
-                  </button>
+                  <p className="text-xs font-medium text-zinc-500">
+                    ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
+                  </p>
                 </div>
 
                 {selectedRunCaseIndex !== null ? (

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -26,7 +26,7 @@ function renderDbRailIcon(name: string) {
       return (
         <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
           <path d="M8 3a3 3 0 0 0-3 3v2.2l-1 1.6h8l-1-1.6V6a3 3 0 0 0-3-3Z" stroke="currentColor" strokeWidth="1.2" />
-          <circle cx="12.2" cy="3.8" r="1.4" fill="#ff5f6d" />
+          <circle cx="12.2" cy="3.8" r="1.4" fill="var(--app-danger)" />
         </svg>
       );
     case "search":
@@ -155,16 +155,16 @@ export default function ProfilePane({
   };
 
   return (
-    <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
+    <aside className="min-h-0 bg-app-elevated md:col-span-2 lg:col-span-1">
       <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
         <div className={`min-h-0 ${isProfilePanelOpen ? "block" : "hidden"}`}>
-          <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
-            <p className="text-sm font-semibold text-zinc-200">프로필</p>
+          <div className="flex h-12 items-center justify-between border-b border-app-border-strong/80 px-4">
+            <p className="text-sm font-semibold text-app-primary">프로필</p>
           </div>
-          <div className="h-full overflow-y-auto p-3 text-xs text-zinc-300">
-            <div className="rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+          <div className="h-full overflow-y-auto p-3 text-xs text-app-secondary">
+            <div className="rounded-md border border-app-border-strong/80 bg-app-surface p-3">
               <div className="flex items-center justify-between">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-app-dim">
                   계정
                 </p>
                 <StatusPill tone={session.authenticated ? "success" : "warn"}>
@@ -172,10 +172,10 @@ export default function ProfilePane({
                 </StatusPill>
               </div>
               <div className="mt-3 space-y-1">
-                <p className="text-base font-semibold text-zinc-100">
+                <p className="text-base font-semibold text-app-primary">
                   {session.member?.nickname ?? "게스트"}
                 </p>
-                <p className="text-zinc-400">
+                <p className="text-app-muted">
                   {session.authenticated
                     ? formatRoleLabel(session.member?.role)
                     : "로그인이 필요합니다."}
@@ -184,9 +184,9 @@ export default function ProfilePane({
             </div>
 
             {battleSidebarState ? (
-              <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+              <div className="mt-3 rounded-md border border-app-border-strong/80 bg-app-surface p-3">
                 <div className="flex items-center justify-between">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-app-dim">
                     배틀 상태
                   </p>
                   <StatusPill tone={battleStatusTone}>
@@ -194,13 +194,13 @@ export default function ProfilePane({
                   </StatusPill>
                 </div>
                 <div className="mt-2 grid grid-cols-2 gap-2">
-                  <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                    <p className="text-[10px] text-zinc-500">남은 시간</p>
-                    <p className="text-sm font-semibold text-zinc-100">{battleSidebarState.remainingTime}</p>
+                  <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                    <p className="text-[10px] text-app-dim">남은 시간</p>
+                    <p className="text-sm font-semibold text-app-primary">{battleSidebarState.remainingTime}</p>
                   </div>
-                  <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                    <p className="text-[10px] text-zinc-500">내 상태</p>
-                    <p className="text-sm font-semibold text-zinc-100">
+                  <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                    <p className="text-[10px] text-app-dim">내 상태</p>
+                    <p className="text-sm font-semibold text-app-primary">
                       {battleSidebarState.myStatus ?? "-"}
                     </p>
                   </div>
@@ -213,14 +213,14 @@ export default function ProfilePane({
                         key={`profile-battle-participant-${participant.userId}`}
                         className={`flex items-center justify-between rounded border px-2 py-1.5 ${
                           isMe
-                            ? "border-violet-500/40 bg-violet-500/10"
-                            : "border-zinc-700 bg-[#171a22]"
+                            ? "border-app-accent/40 bg-app-accent/10"
+                            : "border-app-border bg-app-base"
                         }`}
                       >
                         <div className="flex items-center gap-2">
-                          <p className="text-xs font-medium text-zinc-100">{participant.nickname}</p>
+                          <p className="text-xs font-medium text-app-primary">{participant.nickname}</p>
                           {isMe ? (
-                            <span className="rounded bg-violet-600/20 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300">
+                            <span className="rounded bg-app-accent/20 px-1.5 py-0.5 text-[10px] font-semibold text-app-accent-soft">
                               나
                             </span>
                           ) : null}
@@ -235,40 +235,40 @@ export default function ProfilePane({
               </div>
             ) : null}
 
-            <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+            <div className="mt-3 rounded-md border border-app-border-strong/80 bg-app-surface p-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-app-dim">
                 전적 요약
               </p>
               {session.authenticated ? (
                 <>
                   <div className="mt-2 grid grid-cols-2 gap-2">
-                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                      <p className="text-[10px] text-zinc-500">최근 경기</p>
-                      <p className="text-sm font-semibold text-zinc-100">{previewPlayedCount}</p>
+                    <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                      <p className="text-[10px] text-app-dim">최근 경기</p>
+                      <p className="text-sm font-semibold text-app-primary">{previewPlayedCount}</p>
                     </div>
-                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                      <p className="text-[10px] text-zinc-500">클리어</p>
-                      <p className="text-sm font-semibold text-zinc-100">{previewSolvedCount}</p>
+                    <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                      <p className="text-[10px] text-app-dim">클리어</p>
+                      <p className="text-sm font-semibold text-app-primary">{previewSolvedCount}</p>
                     </div>
-                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                      <p className="text-[10px] text-zinc-500">승률</p>
-                      <p className="text-sm font-semibold text-zinc-100">{previewWinRate}%</p>
+                    <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                      <p className="text-[10px] text-app-dim">승률</p>
+                      <p className="text-sm font-semibold text-app-primary">{previewWinRate}%</p>
                     </div>
-                    <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
-                      <p className="text-[10px] text-zinc-500">점수 변화</p>
-                      <p className="text-sm font-semibold text-zinc-100">{previewScoreDeltaLabel}</p>
+                    <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
+                      <p className="text-[10px] text-app-dim">점수 변화</p>
+                      <p className="text-sm font-semibold text-app-primary">{previewScoreDeltaLabel}</p>
                     </div>
                   </div>
                   <p
                     className={`mt-2 text-[11px] ${
-                      resultsPreviewError ? "text-rose-300" : "text-zinc-500"
+                      resultsPreviewError ? "text-app-danger" : "text-app-dim"
                     }`}
                   >
                     {resultsPreviewError ?? resultsPreviewMessage}
                   </p>
                 </>
               ) : (
-                <p className="mt-2 text-[11px] text-zinc-500">
+                <p className="mt-2 text-[11px] text-app-dim">
                   로그인 후 전적 요약을 확인할 수 있습니다.
                 </p>
               )}
@@ -279,7 +279,7 @@ export default function ProfilePane({
                 <>
                   <Link
                     href="/mypage"
-                    className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                    className="block w-full rounded-md border border-app-border bg-app-base px-3 py-2 text-center text-sm font-medium text-app-primary transition hover:bg-app-elevated/90"
                   >
                     내 프로필
                   </Link>
@@ -287,7 +287,7 @@ export default function ProfilePane({
                     type="button"
                     onClick={onLogout}
                     disabled={isBusy}
-                    className="w-full rounded-md bg-[#9146ff] px-3 py-2 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                    className="w-full rounded-md bg-app-accent px-3 py-2 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:bg-app-elevated disabled:text-app-secondary"
                   >
                     로그아웃
                   </button>
@@ -296,13 +296,13 @@ export default function ProfilePane({
                 <>
                   <Link
                     href="/signup"
-                    className="block w-full rounded-md border border-zinc-700 bg-[#1e1f22] px-3 py-2 text-center text-sm font-medium text-zinc-100 transition hover:bg-zinc-700/30"
+                    className="block w-full rounded-md border border-app-border bg-app-base px-3 py-2 text-center text-sm font-medium text-app-primary transition hover:bg-app-elevated/90"
                   >
                     회원가입
                   </Link>
                   <Link
                     href="/login?next=/"
-                    className="block w-full rounded-md bg-[#9146ff] px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                    className="block w-full rounded-md bg-app-accent px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-app-accent-hover"
                   >
                     로그인
                   </Link>
@@ -312,7 +312,7 @@ export default function ProfilePane({
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-col items-center justify-between border-l border-zinc-800/90 bg-[#25272d] py-2">
+        <div className="flex min-h-0 flex-col items-center justify-between border-l border-app-border-strong/80 bg-app-rail py-2">
           <div className="flex flex-col items-center gap-2">
             {ideDbRailTopItems.map((item) => (
               <button
@@ -327,8 +327,8 @@ export default function ProfilePane({
                 aria-label={item.title}
                 className={`h-8 w-8 rounded-md border transition ${
                   item.icon === "database" && isProfilePanelOpen
-                    ? "border-[#2f77ff] bg-[#2f77ff] text-white shadow-[0_0_0_1px_rgba(80,130,255,0.35)]"
-                    : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-200"
+                    ? "border-app-accent/70 bg-app-accent text-white shadow-[0_0_0_1px_var(--app-accent-glow)]"
+                    : "border-transparent text-app-muted hover:bg-app-elevated/90 hover:text-app-primary"
                 }`}
               >
                 <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
@@ -342,7 +342,7 @@ export default function ProfilePane({
                 type="button"
                 title={item.title}
                 aria-label={item.title}
-                className="h-8 w-8 rounded-md border border-transparent text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-200"
+                className="h-8 w-8 rounded-md border border-transparent text-app-dim transition hover:bg-app-elevated/90 hover:text-app-primary"
               >
                 <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
               </button>

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -100,6 +100,17 @@ interface ProfilePaneProps {
   isProfilePanelOpen: boolean;
   onToggleProfilePanel: () => void;
   session: SessionResponse;
+  battleSidebarState?: {
+    status: "WAITING" | "PLAYING" | "FINISHED";
+    remainingTime: string;
+    participants: Array<{
+      userId: number;
+      nickname: string;
+      status: "READY" | "PLAYING" | "EXIT" | "ABANDONED";
+    }>;
+    myStatus: string | null;
+    myUserId: number | null;
+  } | null;
   previewPlayedCount: number;
   previewSolvedCount: number;
   previewWinRate: number;
@@ -114,6 +125,7 @@ export default function ProfilePane({
   isProfilePanelOpen,
   onToggleProfilePanel,
   session,
+  battleSidebarState,
   previewPlayedCount,
   previewSolvedCount,
   previewWinRate,
@@ -123,6 +135,25 @@ export default function ProfilePane({
   isBusy,
   onLogout,
 }: ProfilePaneProps) {
+  const battleStatusTone =
+    battleSidebarState?.status === "PLAYING"
+      ? "success"
+      : battleSidebarState?.status === "WAITING"
+        ? "warn"
+        : "default";
+
+  const participantTone = (status: string) => {
+    if (status === "PLAYING" || status === "READY") {
+      return "success" as const;
+    }
+
+    if (status === "ABANDONED") {
+      return "danger" as const;
+    }
+
+    return "default" as const;
+  };
+
   return (
     <aside className="min-h-0 bg-[#2b2d30] md:col-span-2 lg:col-span-1">
       <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
@@ -151,6 +182,58 @@ export default function ProfilePane({
                 </p>
               </div>
             </div>
+
+            {battleSidebarState ? (
+              <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    배틀 상태
+                  </p>
+                  <StatusPill tone={battleStatusTone}>
+                    {battleSidebarState.status}
+                  </StatusPill>
+                </div>
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                    <p className="text-[10px] text-zinc-500">남은 시간</p>
+                    <p className="text-sm font-semibold text-zinc-100">{battleSidebarState.remainingTime}</p>
+                  </div>
+                  <div className="rounded border border-zinc-700 bg-[#171a22] px-2 py-1.5">
+                    <p className="text-[10px] text-zinc-500">내 상태</p>
+                    <p className="text-sm font-semibold text-zinc-100">
+                      {battleSidebarState.myStatus ?? "-"}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-2 space-y-2">
+                  {battleSidebarState.participants.map((participant) => {
+                    const isMe = participant.userId === battleSidebarState.myUserId;
+                    return (
+                      <div
+                        key={`profile-battle-participant-${participant.userId}`}
+                        className={`flex items-center justify-between rounded border px-2 py-1.5 ${
+                          isMe
+                            ? "border-violet-500/40 bg-violet-500/10"
+                            : "border-zinc-700 bg-[#171a22]"
+                        }`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <p className="text-xs font-medium text-zinc-100">{participant.nickname}</p>
+                          {isMe ? (
+                            <span className="rounded bg-violet-600/20 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300">
+                              나
+                            </span>
+                          ) : null}
+                        </div>
+                        <StatusPill tone={participantTone(participant.status)}>
+                          {participant.status}
+                        </StatusPill>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
 
             <div className="mt-3 rounded-md border border-zinc-800/90 bg-[#1f222b] p-3">
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
@@ -270,4 +353,3 @@ export default function ProfilePane({
     </aside>
   );
 }
-

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -50,12 +50,12 @@ export default function QueueEditorPane({
   terminalMessage,
 }: QueueEditorPaneProps) {
   return (
-    <main className="h-full overflow-hidden border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
+    <main className="h-full overflow-hidden border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
       <div className="flex h-full min-h-0 flex-col">
-        <div className="flex h-12 items-center justify-between border-b border-zinc-700/80 bg-[#1e1f22] px-3">
+        <div className="flex h-12 items-center justify-between border-b border-app-border/80 bg-app-base px-3">
           <div className="flex h-full items-end gap-0.5 pt-1">
-            <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-              <span className="inline-flex h-4 w-4 items-center justify-center text-[#7da2f7]">
+            <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+              <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
                 <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
                   <path
                     d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
@@ -67,18 +67,18 @@ export default function QueueEditorPane({
                 </svg>
               </span>
               <span>.env.queue.match</span>
-              <span className="text-zinc-500">×</span>
-              <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+              <span className="text-app-dim">×</span>
+              <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
             </div>
           </div>
           <button
             type="button"
             onClick={onStartMatch}
             disabled={!canStartMatch}
-            className="inline-flex h-10 items-center gap-2 rounded-md border border-[#b08cff]/45 bg-[#9146ff] px-3 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-600 disabled:text-zinc-300"
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-app-accent/45 bg-app-accent px-3 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary"
             aria-label="매칭 시작"
           >
-            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#7dd48c]">
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-app-syntax-icon">
               <path
                 d="M8 2.3v3M5 3.4A4.9 4.9 0 1 0 11 3.4"
                 stroke="currentColor"
@@ -87,44 +87,44 @@ export default function QueueEditorPane({
               />
             </svg>
             <span>매칭 시작</span>
-            <span className="mx-0.5 h-4 w-px bg-white/35" />
-            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-[#74cc84]">
+            <span className="mx-0.5 h-4 w-px bg-app-surface/35" />
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-app-success">
               <path d="m6 4 5 4-5 4V4Z" fill="currentColor" />
             </svg>
           </button>
         </div>
 
-        <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-[#1e1f22]">
+        <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-app-base">
           <div
-            className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-[#1e1f22] font-mono"
+            className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-app-base font-mono"
             style={editorContentStyle}
           >
-            <div className="border-r border-zinc-700/70 bg-[#1e1f22] px-3 py-4 text-right text-[#606366]">
+            <div className="border-r border-app-border/70 bg-app-base px-3 py-4 text-right text-app-syntax-line-number">
               {editorLineNumbers.map((line) => (
                 <div key={line} style={editorLineStyle}>
                   {line}
                 </div>
               ))}
             </div>
-            <div className="px-4 py-4 text-[#a9b7c6]">
-              <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
+            <div className="px-4 py-4 text-app-syntax-default">
+              <div className="whitespace-nowrap text-app-syntax-comment" style={editorLineStyle}>
                 # queue config
               </div>
-              <div className="whitespace-nowrap text-[#6a717d]" style={editorLineStyle}>
-                <span className="font-semibold text-[#ffcc66]"># TODO:</span>
-                <span className="text-[#ffcc66]">
+              <div className="whitespace-nowrap text-app-syntax-comment" style={editorLineStyle}>
+                <span className="font-semibold text-app-syntax-keyword"># TODO:</span>
+                <span className="text-app-syntax-keyword">
                   {" "}
                   카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
                 </span>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-[#9cdcfe]">QUEUE_CATEGORY</span>
-                <span className="text-[#80889a]">=</span>
+                <span className="w-40 text-app-syntax-name">QUEUE_CATEGORY</span>
+                <span className="text-app-syntax-operator">=</span>
                 <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
                   <select
                     value={category}
                     onChange={(event) => onCategoryChange(event.target.value as QueueCategoryValue)}
-                    className="h-7 w-full appearance-none rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 pr-6 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
+                    className="h-7 w-full appearance-none rounded-sm border border-app-border bg-app-elevated px-2 pr-6 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
                   >
                     {categoryOptions.map((item) => (
                       <option
@@ -136,22 +136,22 @@ export default function QueueEditorPane({
                       </option>
                     ))}
                   </select>
-                  <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-zinc-500">
+                  <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-app-dim">
                     ▾
                   </span>
                 </div>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-[#9cdcfe]">QUEUE_LEVEL</span>
-                <span className="text-[#80889a]">=</span>
+                <span className="w-40 text-app-syntax-name">QUEUE_LEVEL</span>
+                <span className="text-app-syntax-operator">=</span>
                 <div className="flex flex-wrap gap-1 leading-none">
                   {difficultyOptions.map((option) => (
                     <label
                       key={option.value}
                       className={`rounded-sm border px-2 py-1 text-xs transition ${
                         difficulty === option.value
-                          ? "border-[#4e89ff]/60 bg-[#2b3a52] text-[#dcdcaa]"
-                          : "border-zinc-700 bg-[#2b2d30] text-[#9aa5b1] hover:bg-zinc-700/40"
+                          ? "border-app-syntax-selected-border/60 bg-app-syntax-selected-bg text-app-syntax-selected-text"
+                          : "border-app-border bg-app-elevated text-app-syntax-value hover:bg-app-elevated/90"
                       }`}
                     >
                       <input
@@ -168,30 +168,30 @@ export default function QueueEditorPane({
                 </div>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-[#9cdcfe]">QUEUE_PARTY_SIZE</span>
-                <span className="text-[#80889a]">=</span>
-                <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#b5cea8]">
+                <span className="w-40 text-app-syntax-name">QUEUE_PARTY_SIZE</span>
+                <span className="text-app-syntax-operator">=</span>
+                <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-constant">
                   4
                 </span>
               </div>
               <div className="flex items-start gap-2" style={editorRowStyle}>
-                <span className="w-40 text-[#9cdcfe]">QUEUE_MEMO</span>
-                <span className="pt-1 text-[#80889a]">=</span>
+                <span className="w-40 text-app-syntax-name">QUEUE_MEMO</span>
+                <span className="pt-1 text-app-syntax-operator">=</span>
                 <input
                   type="text"
                   value={queueMemo}
                   onChange={(event) => onQueueMemoChange(event.target.value)}
-                  className="mt-0.5 h-7 w-full rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 text-xs text-[#ce9178] outline-none transition focus:border-[#4e89ff]/70"
+                  className="mt-0.5 h-7 w-full rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
                 />
               </div>
 
-              <div className="mt-2 text-[#6a717d]" style={editorLineStyle}>
+              <div className="mt-2 text-app-syntax-comment" style={editorLineStyle}>
                 {showStopQueueButton ? (
                   <button
                     type="button"
                     onClick={onCancelQueue}
                     disabled={isBusy}
-                    className="rounded-sm border border-zinc-700 bg-[#2b2d30] px-2 py-0.5 text-xs text-zinc-100 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
+                    className="rounded-sm border border-app-border bg-app-elevated px-2 py-0.5 text-xs text-app-primary transition hover:bg-app-elevated/90 disabled:cursor-not-allowed disabled:text-app-dim"
                   >
                     stopQueue();
                   </button>
@@ -201,8 +201,8 @@ export default function QueueEditorPane({
                 <div
                   className={`mt-1 rounded-sm border px-3 py-2 text-xs ${
                     error
-                      ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                      : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                      ? "border-app-danger/60 bg-app-danger/20 text-app-danger"
+                      : "border-app-border bg-app-elevated text-app-secondary"
                   }`}
                 >
                   {error ?? terminalMessage}

--- a/src/features/home/components/quick-menu-pane.tsx
+++ b/src/features/home/components/quick-menu-pane.tsx
@@ -62,8 +62,8 @@ function renderRailIcon(name: string) {
             strokeWidth="1.2"
             strokeLinecap="round"
           />
-          <circle cx="6" cy="5.2" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
-          <circle cx="10" cy="10.8" r="1.6" fill="#25272d" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="6" cy="5.2" r="1.6" fill="var(--app-bg-surface)" stroke="currentColor" strokeWidth="1.2" />
+          <circle cx="10" cy="10.8" r="1.6" fill="var(--app-bg-surface)" stroke="currentColor" strokeWidth="1.2" />
         </svg>
       );
     case "branch":
@@ -149,32 +149,32 @@ function renderProjectTreeIcon(icon: QuickMenuTreeIcon) {
   switch (icon) {
     case "class":
       return (
-        <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#3b78e7] text-[8px] font-semibold leading-none text-[#62a5ff]">
+        <span className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-app-accent/60 text-[8px] font-semibold leading-none text-app-accent-soft">
           C
         </span>
       );
     case "package":
       return (
-        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-app-accent-soft">
           <path d="M2.2 5h3.2l.9.9h7.5v6.1a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V5Z" stroke="currentColor" strokeWidth="1.2" />
         </svg>
       );
     case "folderAccent":
       return (
-        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#cf8f4e]">
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-app-warn">
           <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
         </svg>
       );
     case "root":
     case "folder":
       return (
-        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-app-secondary">
           <path d="M2.2 4.8h3.4l1 1h7.2v6.2a1.3 1.3 0 0 1-1.3 1.3H3.5A1.3 1.3 0 0 1 2.2 12V4.8Z" stroke="currentColor" strokeWidth="1.2" />
         </svg>
       );
     case "fileAccent":
       return (
-        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-[#6ea5ff]">
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-app-accent-soft">
           <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
           <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
         </svg>
@@ -182,7 +182,7 @@ function renderProjectTreeIcon(icon: QuickMenuTreeIcon) {
     case "file":
     default:
       return (
-        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-zinc-300">
+        <svg viewBox="0 0 16 16" fill="none" className="h-3.5 w-3.5 text-app-secondary">
           <path d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z" stroke="currentColor" strokeWidth="1.2" />
           <path d="M9 2.5V6h3" stroke="currentColor" strokeWidth="1.2" />
         </svg>
@@ -204,9 +204,9 @@ export default function QuickMenuPane({
   projectTreeItems,
 }: QuickMenuPaneProps) {
   return (
-    <aside className="min-h-0 border-b border-zinc-800/90 bg-[#2b2d30] md:border-b-0 md:border-r">
+    <aside className="min-h-0 border-b border-app-border-strong/80 bg-app-elevated md:border-b-0 md:border-r">
       <div className={`grid h-full ${isQuickMenuOpen ? "grid-cols-[48px_minmax(0,1fr)]" : "grid-cols-[48px]"}`}>
-        <div className="flex min-h-0 flex-col items-center justify-between border-r border-zinc-800/90 bg-[#25272d] py-2">
+        <div className="flex min-h-0 flex-col items-center justify-between border-r border-app-border-strong/80 bg-app-rail py-2">
           <div className="flex flex-col items-center gap-2">
             {ideRailTopItems.map((item) => (
               <button
@@ -221,8 +221,8 @@ export default function QuickMenuPane({
                 aria-label={item.title}
                 className={`h-8 w-8 rounded-md border text-[10px] font-semibold tracking-wide transition ${
                   item.icon === "project" && isQuickMenuOpen
-                    ? "border-zinc-500 bg-zinc-700/70 text-zinc-100"
-                    : "border-transparent text-zinc-400 hover:bg-zinc-700/30 hover:text-zinc-300"
+                    ? "border-app-border-strong bg-app-elevated/95 text-app-primary"
+                    : "border-transparent text-app-muted hover:bg-app-elevated/90 hover:text-app-secondary"
                 }`}
               >
                 <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
@@ -236,7 +236,7 @@ export default function QuickMenuPane({
                 type="button"
                 title={item.title}
                 aria-label={item.title}
-                className="h-8 w-8 rounded-md border border-transparent text-[10px] font-semibold tracking-wide text-zinc-500 transition hover:bg-zinc-700/30 hover:text-zinc-300"
+                className="h-8 w-8 rounded-md border border-transparent text-[10px] font-semibold tracking-wide text-app-dim transition hover:bg-app-elevated/90 hover:text-app-secondary"
               >
                 <span className="flex items-center justify-center">{renderRailIcon(item.icon)}</span>
               </button>
@@ -245,37 +245,37 @@ export default function QuickMenuPane({
         </div>
 
         <div className={`min-h-0 flex-col ${isQuickMenuOpen ? "flex" : "hidden"}`}>
-          <div className="flex h-12 items-center justify-between border-b border-zinc-800/90 px-4">
-            <p className="text-sm font-semibold text-zinc-200">퀵 메뉴</p>
-            <span className="text-xs text-zinc-500">▼</span>
+          <div className="flex h-12 items-center justify-between border-b border-app-border-strong/80 px-4">
+            <p className="text-sm font-semibold text-app-primary">퀵 메뉴</p>
+            <span className="text-xs text-app-dim">▼</span>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-sm text-zinc-300">
+          <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-sm text-app-secondary">
             {projectTreeItems.map((item) => {
               const rowToneClass =
                 item.rowTone === "amber"
-                  ? "bg-[#4a3924]/50"
+                  ? "bg-app-warn/15"
                   : item.rowTone === "green"
-                    ? "bg-[#1f3a2a]/55"
+                    ? "bg-app-success/15"
                     : item.rowTone === "selected"
-                      ? "bg-zinc-600/70"
-                      : "hover:bg-zinc-700/30";
+                      ? "bg-app-elevated/70"
+                      : "hover:bg-app-elevated/90";
 
               const content = (
                 <div
                   className={`flex h-7 items-center gap-1.5 rounded-sm px-1.5 ${rowToneClass}`}
                   style={{ paddingLeft: `${item.depth * 8 + 4}px` }}
                 >
-                  <span className="inline-flex w-3 items-center justify-center text-[10px] text-zinc-500">
+                  <span className="inline-flex w-3 items-center justify-center text-[10px] text-app-dim">
                     {item.hasChildren ? (item.expanded ? "▾" : "▸") : ""}
                   </span>
                   <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
                     {renderProjectTreeIcon(item.icon)}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-[13px] text-zinc-200">
+                  <span className="min-w-0 flex-1 truncate text-[13px] text-app-primary">
                     {item.label}
                   </span>
                   {item.subtitle ? (
-                    <span className="truncate pl-1 text-[12px] text-zinc-500">{item.subtitle}</span>
+                    <span className="truncate pl-1 text-[12px] text-app-dim">{item.subtitle}</span>
                   ) : null}
                 </div>
               );

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -45,12 +45,12 @@ interface ConsoleLogLine {
 const CONSOLE_MAX_LINES = 90;
 const SPRING_BOOT_VERSION = "v3.5.11";
 
-const SPRING_BOOT_BANNER = String.raw`  .   ____          _            __ _ _
- /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
-( ( )\___ | '_ | '_| | '_ \/ _\` | \ \ \ \
- \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
-  ' |____| .__|_| |_|_| |_\__, | / / / /
- =========|_|==============|___/=/_/_/_/`;
+const SPRING_BOOT_BANNER = String.raw`  .   ____                 _        _   __ _ _
+ /\\ | __ ) _ __ __ _  ___| | _____| |_ \ \ \ \
+( ( )|  _ \| '__/ _\` |/ __| |/ / _ \ __| \ \ \ \
+ \\/ | |_) | | | (_| | (__|   <  __/ |_   ) ) ) )
+  '  |____/|_|  \__,_|\___|_|\_\___|\__| / / / /
+ =======================================/_/_/_/_/`;
 
 function getModeHeadline(mode: Exclude<QueueModalMode, null>) {
   if (mode === "SEARCHING") {
@@ -716,7 +716,7 @@ export default function QueueModal({
                   {SPRING_BOOT_BANNER}
                 </pre>
                 <p className="mt-2 font-mono text-sm text-emerald-400">
-                  :: Spring Boot ::({SPRING_BOOT_VERSION})
+                  :: Bracket Boot ::                      ({SPRING_BOOT_VERSION})
                 </p>
               </div>
 

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ReadyCheckState } from "@/shared/api/contracts";
-import { StatusPill } from "@/shared/ui";
+import { ConfirmDialog } from "@/shared/ui";
 
 import {
   formatClock,
@@ -39,9 +39,11 @@ interface ConsoleLogLine {
   time: string;
   level: "INFO" | "DEBUG" | "WARN" | "ERROR";
   message: string;
+  count: number;
 }
 
 const CONSOLE_MAX_LINES = 90;
+const SPRING_BOOT_VERSION = "v3.5.11";
 
 const SPRING_BOOT_BANNER = String.raw`  .   ____          _            __ _ _
  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
@@ -189,38 +191,6 @@ function buildDynamicEventMessages({
   return [{ level: "WARN", message: "terminal flow reached" }];
 }
 
-function getModeStatusLine({
-  mode,
-  waitingCount,
-  requiredCount,
-  queueElapsedSeconds,
-  countdownSeconds,
-  readyCheck,
-  roomId,
-}: {
-  mode: Exclude<QueueModalMode, null>;
-  waitingCount: number;
-  requiredCount: number;
-  queueElapsedSeconds: number;
-  countdownSeconds: number;
-  readyCheck: ReadyCheckState | null;
-  roomId: number | null;
-}) {
-  if (mode === "SEARCHING") {
-    return `상태: 상대를 찾는 중 (${waitingCount}/${requiredCount}명) · 경과 ${formatClock(queueElapsedSeconds)}`;
-  }
-
-  if (mode === "READY_CHECK") {
-    return `상태: 수락 확인 중 (${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}명 수락) · 남은 시간 ${formatClock(countdownSeconds)} · 경과 ${formatClock(queueElapsedSeconds)}`;
-  }
-
-  if (mode === "ROOM_READY") {
-    return `상태: 입장 준비 완료 · 방 번호 ${roomId ?? "확인 중"} · 수락 ${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}명`;
-  }
-
-  return "상태: 매칭 종료";
-}
-
 export default function QueueModal({
   mode,
   categoryLabel,
@@ -243,6 +213,7 @@ export default function QueueModal({
   onCloseTerminal,
 }: QueueModalProps) {
   const [consoleLogs, setConsoleLogs] = useState<ConsoleLogLine[]>([]);
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
   const logViewportRef = useRef<HTMLDivElement | null>(null);
   const logIdRef = useRef(0);
   const pidRef = useRef(24000 + Math.floor(Math.random() * 6000));
@@ -275,6 +246,7 @@ export default function QueueModal({
         time: timestamp,
         level,
         message,
+        count: 1,
       };
     },
     [],
@@ -283,7 +255,22 @@ export default function QueueModal({
   const appendLog = useCallback(
     (level: ConsoleLogLine["level"], message: string) => {
       setConsoleLogs((prev) => {
-        const next = [...prev, makeLogLine(level, message)];
+        const nextLine = makeLogLine(level, message);
+
+        if (prev.length > 0) {
+          const lastLine = prev[prev.length - 1];
+          if (lastLine && lastLine.level === level && lastLine.message === message) {
+            const mergedLine: ConsoleLogLine = {
+              ...lastLine,
+              time: nextLine.time,
+              count: (lastLine.count ?? 1) + 1,
+            };
+            const merged = [...prev.slice(0, -1), mergedLine];
+            return merged;
+          }
+        }
+
+        const next = [...prev, nextLine];
         if (next.length > CONSOLE_MAX_LINES) {
           return next.slice(next.length - CONSOLE_MAX_LINES);
         }
@@ -296,6 +283,7 @@ export default function QueueModal({
   useEffect(() => {
     if (!mode) {
       setConsoleLogs([]);
+      setIsCancelConfirmOpen(false);
       snapshotRef.current = {
         mode: null,
         waitingCount: 0,
@@ -340,6 +328,12 @@ export default function QueueModal({
     terminalMessage,
     waitingCount,
   ]);
+
+  useEffect(() => {
+    if (mode !== "SEARCHING") {
+      setIsCancelConfirmOpen(false);
+    }
+  }, [mode]);
 
   useEffect(() => {
     if (!mode) {
@@ -501,18 +495,6 @@ export default function QueueModal({
     logViewportRef.current.scrollTop = logViewportRef.current.scrollHeight;
   }, [consoleLogs.length]);
 
-  const modalTone = useMemo(() => {
-    if (mode === "TERMINAL") {
-      return "danger";
-    }
-
-    if (mode === "ROOM_READY") {
-      return "success";
-    }
-
-    return "warn";
-  }, [mode]);
-
   const modeStatus = useMemo(() => {
     if (mode === "SEARCHING") {
       return "매칭 대기 중";
@@ -528,35 +510,183 @@ export default function QueueModal({
 
     return "매칭 종료";
   }, [mode]);
-
-  const modeStatusLine = useMemo(
-    () => {
-      if (!mode) {
-        return "";
-      }
-
-      return getModeStatusLine({
-        mode,
-        waitingCount,
-        requiredCount,
-        queueElapsedSeconds,
-        countdownSeconds,
-        readyCheck,
-        roomId,
-      });
-    },
-    [
-      countdownSeconds,
-      mode,
-      queueElapsedSeconds,
-      readyCheck,
-      requiredCount,
-      roomId,
-      waitingCount,
-    ],
-  );
-
   const actionButtonClass = "rounded-md border border-zinc-600 bg-[#171f2c] px-3 py-1.5 text-xs font-semibold text-zinc-100 transition hover:border-violet-400/55 hover:bg-violet-500/10 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-[#141a24] disabled:text-zinc-500";
+  const actionPrimaryButtonClass = "rounded-md border border-violet-400/45 bg-gradient-to-r from-violet-600 to-violet-500 px-3 py-1.5 text-xs font-semibold text-white shadow-[0_0_0_1px_rgba(168,85,247,0.25)] transition hover:from-violet-500 hover:to-violet-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-700 disabled:text-zinc-300";
+  const headerStatusChipClass = "inline-flex items-center rounded-full border border-amber-400/45 bg-amber-500/10 px-2.5 py-0.5 text-[11px] font-semibold text-amber-200";
+  const headerMetaChipClass = "inline-flex items-center rounded-full border border-zinc-700 bg-zinc-900/55 px-2.5 py-0.5 text-[11px] font-medium text-zinc-400";
+  const headerMetaText = useMemo(() => {
+    if (!mode) {
+      return "";
+    }
+
+    if (mode === "SEARCHING") {
+      return `대기 인원 ${waitingCount}/${requiredCount}명 · 경과 ${formatClock(queueElapsedSeconds)}`;
+    }
+
+    if (mode === "READY_CHECK") {
+      return `수락 ${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}명 · 남은 시간 ${formatClock(countdownSeconds)}`;
+    }
+
+    if (mode === "ROOM_READY") {
+      return `방 입장 준비 완료 · 방 번호 ${roomId ?? "확인 중"}`;
+    }
+
+    return "매칭 종료";
+  }, [
+    countdownSeconds,
+    mode,
+    queueElapsedSeconds,
+    readyCheck?.acceptedCount,
+    readyCheck?.requiredCount,
+    requiredCount,
+    roomId,
+    waitingCount,
+  ]);
+
+  const footerMessage = useMemo(() => {
+    if (!mode) {
+      return "";
+    }
+
+    if (error) {
+      return error;
+    }
+
+    if (terminalMessage) {
+      return terminalMessage;
+    }
+
+    if (feedback.trim().length > 0) {
+      return feedback;
+    }
+
+    return getModeDescription(mode);
+  }, [error, feedback, mode, terminalMessage]);
+
+  const summaryCountText = useMemo(() => {
+    if (!mode) {
+      return "";
+    }
+
+    if (mode === "SEARCHING") {
+      return `${waitingCount}/${requiredCount}`;
+    }
+
+    if (mode === "READY_CHECK" || mode === "ROOM_READY") {
+      return `${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}`;
+    }
+
+    return "0/0";
+  }, [
+    mode,
+    readyCheck?.acceptedCount,
+    readyCheck?.requiredCount,
+    requiredCount,
+    waitingCount,
+  ]);
+
+  const summaryModeText = useMemo(() => {
+    if (!mode) {
+      return "";
+    }
+
+    if (mode === "SEARCHING") {
+      return "매칭 대기중";
+    }
+
+    if (mode === "READY_CHECK") {
+      return "수락 확인중";
+    }
+
+    if (mode === "ROOM_READY") {
+      return "입장 준비중";
+    }
+
+    return "매칭 종료";
+  }, [mode]);
+
+  const handleCancelClick = useCallback(() => {
+    if (isPending) {
+      return;
+    }
+
+    setIsCancelConfirmOpen(true);
+  }, [isPending]);
+
+  const handleCancelConfirm = useCallback(() => {
+    if (isPending) {
+      return;
+    }
+
+    setIsCancelConfirmOpen(false);
+    onCancel();
+  }, [isPending, onCancel]);
+
+  const handleCancelDialogClose = useCallback(() => {
+    if (isPending) {
+      return;
+    }
+
+    setIsCancelConfirmOpen(false);
+  }, [isPending]);
+
+  const actionButtons = (
+    <>
+      {mode === "SEARCHING" ? (
+        <button
+          type="button"
+          onClick={handleCancelClick}
+          disabled={isPending}
+          className={actionPrimaryButtonClass}
+        >
+          매칭 취소
+        </button>
+      ) : null}
+
+      {mode === "READY_CHECK" ? (
+        <>
+          <button
+            type="button"
+            onClick={onDecline}
+            disabled={isPending || !readyCheck}
+            className={actionButtonClass}
+          >
+            거절
+          </button>
+          <button
+            type="button"
+            onClick={onAccept}
+            disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
+            className={actionButtonClass}
+          >
+            {readyCheck?.acceptedByMe ? "수락 완료" : "수락"}
+          </button>
+        </>
+      ) : null}
+
+      {mode === "ROOM_READY" ? (
+        <button
+          type="button"
+          onClick={onRetryRoomEntry}
+          disabled={isPending}
+          className={actionButtonClass}
+        >
+          방 입장 재시도
+        </button>
+      ) : null}
+
+      {mode === "TERMINAL" ? (
+        <button
+          type="button"
+          onClick={onCloseTerminal}
+          disabled={isPending}
+          className={actionButtonClass}
+        >
+          닫기
+        </button>
+      ) : null}
+    </>
+  );
 
   if (!mode) {
     return null;
@@ -565,113 +695,44 @@ export default function QueueModal({
   return (
     <div className="absolute inset-0 z-40 flex items-end bg-zinc-950/30">
       <div className="queue-sheet w-full overflow-hidden border-t border-zinc-700 bg-[#12161f] text-zinc-200 shadow-[0_-20px_48px_rgba(0,0,0,0.55)]">
-        <div className="px-4 pb-4 pt-2">
-          <div className="mx-auto mb-2 h-1.5 w-16 rounded-full bg-zinc-600/80" />
-          <div className="flex flex-wrap items-center gap-2 border-b border-zinc-700 pb-2">
-            <StatusPill tone={modalTone}>{modeStatus}</StatusPill>
-            <StatusPill>{categoryLabel}</StatusPill>
-            <StatusPill>{difficultyLabel}</StatusPill>
+        <div className="px-4 pb-4 pt-3">
+          <div className="flex flex-wrap items-center gap-2 pb-2">
+            <span className={headerStatusChipClass}>{modeStatus}</span>
+            <span className={headerMetaChipClass}>{categoryLabel}</span>
+            <span className={headerMetaChipClass}>{difficultyLabel}</span>
             <p className="ml-auto text-xs font-medium text-zinc-400">
-              {getModeHeadline(mode)} · pid {pidRef.current}
+              {headerMetaText}
             </p>
+            <div className="flex flex-wrap items-center gap-2">{actionButtons}</div>
           </div>
-          <section className="mt-3 overflow-hidden rounded-lg border border-zinc-700 bg-[#0b1018]">
-            <div className="border-b border-zinc-700 bg-[#1a202c] px-3 py-1.5 font-mono text-[11px] text-zinc-400">
+          <section className="mt-3 overflow-hidden rounded-lg border border-zinc-700/70 bg-[#0b1018] shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
+            <div className="bg-[#1a202c] px-3 py-1.5 font-mono text-[11px] text-zinc-400">
               /Users/chan/Library/Java/JavaVirtualMachines/graalvm-ce-21.0.2/Contents/Home/bin/java ...
             </div>
 
-            <div className="grid max-h-[65vh] grid-cols-1 overflow-hidden lg:grid-cols-[360px_minmax(0,1fr)]">
+            <div className="grid max-h-[65vh] grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_220px]">
               <div className="min-w-0 px-3 py-3">
-                <pre className="overflow-x-auto font-mono text-[10px] leading-4 text-zinc-500">
+                <pre className="overflow-x-auto font-mono text-[16px] leading-[1.2] text-zinc-300">
                   {SPRING_BOOT_BANNER}
                 </pre>
+                <p className="mt-2 font-mono text-sm text-emerald-400">
+                  :: Spring Boot ::({SPRING_BOOT_VERSION})
+                </p>
               </div>
 
-              <div className="min-w-0 px-3 py-3">
-                <div className="space-y-1 font-mono text-xs leading-6">
-                  <p className="text-zinc-300">
-                    <span className="text-zinc-500">$</span>{" "}
-                    <span className="text-cyan-300">{modeStatusLine}</span>
+              <div className="flex min-w-0 items-center justify-center px-3 py-3">
+                <div className="w-full rounded-lg border border-zinc-700 bg-[#111827]/70 px-3 py-5 text-center">
+                  <p className="font-mono text-4xl font-bold leading-none text-cyan-300">
+                    {summaryCountText}
                   </p>
-                  <p className="text-zinc-300">
-                    <span className="text-zinc-500">$</span>{" "}
-                    <span>{getModeDescription(mode)}</span>
-                  </p>
-                  <p className="text-zinc-400">
-                    <span className="text-zinc-500">$</span>{" "}
-                    선택 설정: 카테고리 {categoryLabel}, 난이도 {difficultyLabel}, 세션 ID {pidRef.current}
-                  </p>
-                  {readyCheck?.participants?.length ? (
-                    <p className="text-zinc-400">
-                      <span className="text-zinc-500">$</span>{" "}
-                      {readyCheck.participants
-                        .map((participant) => `${participant.nickname}${participant.userId === currentUserId ? "(ME)" : ""}:${getReadyDecisionLabel(participant.decision)}`)
-                        .join(" | ")}
-                    </p>
-                  ) : null}
-                </div>
-
-                <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1">
-                  {mode === "SEARCHING" ? (
-                    <button
-                      type="button"
-                      onClick={onCancel}
-                      disabled={isPending}
-                      className={actionButtonClass}
-                    >
-                      매칭 취소
-                    </button>
-                  ) : null}
-
-                  {mode === "READY_CHECK" ? (
-                    <>
-                      <button
-                        type="button"
-                        onClick={onDecline}
-                        disabled={isPending || !readyCheck}
-                        className={actionButtonClass}
-                      >
-                        거절
-                      </button>
-                      <button
-                        type="button"
-                        onClick={onAccept}
-                        disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
-                        className={actionButtonClass}
-                      >
-                        {readyCheck?.acceptedByMe ? "수락 완료" : "수락"}
-                      </button>
-                    </>
-                  ) : null}
-
-                  {mode === "ROOM_READY" ? (
-                    <button
-                      type="button"
-                      onClick={onRetryRoomEntry}
-                      disabled={isPending}
-                      className={actionButtonClass}
-                    >
-                      방 입장 재시도
-                    </button>
-                  ) : null}
-
-                  {mode === "TERMINAL" ? (
-                    <button
-                      type="button"
-                      onClick={onCloseTerminal}
-                      disabled={isPending}
-                      className={actionButtonClass}
-                    >
-                      닫기
-                    </button>
-                  ) : null}
+                  <p className="mt-2 text-sm font-semibold text-zinc-300">{summaryModeText}</p>
                 </div>
               </div>
             </div>
 
             <div
               ref={logViewportRef}
-              className="h-[30vh] min-h-[150px] overflow-y-auto px-3 py-2"
+              className="mt-2 h-[30vh] min-h-[150px] overflow-y-auto px-3 py-2"
             >
               <div className="font-mono text-xs">
                 {consoleLogs.map((line) => (
@@ -684,6 +745,9 @@ export default function QueueModal({
                       {line.level}
                     </span>{" "}
                     <span>{line.message}</span>
+                    {line.count > 1 ? (
+                      <span className="ml-1 text-zinc-500">(x{line.count})</span>
+                    ) : null}
                   </p>
                 ))}
               </div>
@@ -696,11 +760,23 @@ export default function QueueModal({
                   : "bg-[#151d2a] text-zinc-400"
               }`}
             >
-              {error ?? terminalMessage ?? feedback}
+              {footerMessage}
             </div>
           </section>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={isCancelConfirmOpen}
+        title="매칭을 취소할까요?"
+        description="현재 대기열에서 즉시 이탈합니다. 다시 시작하려면 매칭 시작을 다시 눌러야 합니다."
+        confirmLabel="매칭 취소"
+        cancelLabel="계속 대기"
+        confirmTone="default"
+        disabled={isPending}
+        onConfirm={handleCancelConfirm}
+        onCancel={handleCancelDialogClose}
+      />
 
       <style jsx>{`
         .queue-sheet {

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -86,18 +86,18 @@ function getModeDescription(mode: Exclude<QueueModalMode, null>) {
 
 function getLevelColor(level: ConsoleLogLine["level"]) {
   if (level === "INFO") {
-    return "text-emerald-400";
+    return "text-app-success";
   }
 
   if (level === "DEBUG") {
-    return "text-cyan-400";
+    return "text-app-accent-soft";
   }
 
   if (level === "WARN") {
-    return "text-amber-300";
+    return "text-app-warn";
   }
 
-  return "text-rose-300";
+  return "text-app-danger";
 }
 
 function getLoopInfoMessage(mode: Exclude<QueueModalMode, null>) {
@@ -510,10 +510,10 @@ export default function QueueModal({
 
     return "매칭 종료";
   }, [mode]);
-  const actionButtonClass = "rounded-md border border-zinc-600 bg-[#171f2c] px-3 py-1.5 text-xs font-semibold text-zinc-100 transition hover:border-violet-400/55 hover:bg-violet-500/10 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-[#141a24] disabled:text-zinc-500";
-  const actionPrimaryButtonClass = "rounded-md border border-violet-400/45 bg-gradient-to-r from-violet-600 to-violet-500 px-3 py-1.5 text-xs font-semibold text-white shadow-[0_0_0_1px_rgba(168,85,247,0.25)] transition hover:from-violet-500 hover:to-violet-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-700 disabled:text-zinc-300";
-  const headerStatusChipClass = "inline-flex items-center rounded-full border border-amber-400/45 bg-amber-500/10 px-2.5 py-0.5 text-[11px] font-semibold text-amber-200";
-  const headerMetaChipClass = "inline-flex items-center rounded-full border border-zinc-700 bg-zinc-900/55 px-2.5 py-0.5 text-[11px] font-medium text-zinc-400";
+  const actionButtonClass = "rounded-md border border-app-border-strong bg-app-elevated px-3 py-1.5 text-xs font-semibold text-app-primary transition hover:border-app-accent/55 hover:bg-app-accent/10 disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim";
+  const actionPrimaryButtonClass = "rounded-md border border-app-accent/45 bg-gradient-to-r from-app-accent to-app-accent-hover px-3 py-1.5 text-xs font-semibold text-white shadow-[0_0_0_1px_var(--app-accent-glow)] transition hover:from-app-accent-hover hover:to-app-accent disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary";
+  const headerStatusChipClass = "inline-flex items-center rounded-full border border-app-warn/45 bg-app-warn/10 px-2.5 py-0.5 text-[11px] font-semibold text-app-warn";
+  const headerMetaChipClass = "inline-flex items-center rounded-full border border-app-border bg-app-base/55 px-2.5 py-0.5 text-[11px] font-medium text-app-muted";
   const headerMetaText = useMemo(() => {
     if (!mode) {
       return "";
@@ -693,39 +693,39 @@ export default function QueueModal({
   }
 
   return (
-    <div className="absolute inset-0 z-40 flex items-end bg-zinc-950/30">
-      <div className="queue-sheet w-full overflow-hidden border-t border-zinc-700 bg-[#12161f] text-zinc-200 shadow-[0_-20px_48px_rgba(0,0,0,0.55)]">
+    <div className="absolute inset-0 z-40 flex items-end bg-app-base/30">
+      <div className="queue-sheet w-full overflow-hidden border-t border-app-border bg-app-surface text-app-primary shadow-[0_-20px_48px_rgba(0,0,0,0.55)]">
         <div className="px-4 pb-4 pt-3">
           <div className="flex flex-wrap items-center gap-2 pb-2">
             <span className={headerStatusChipClass}>{modeStatus}</span>
             <span className={headerMetaChipClass}>{categoryLabel}</span>
             <span className={headerMetaChipClass}>{difficultyLabel}</span>
-            <p className="ml-auto text-xs font-medium text-zinc-400">
+            <p className="ml-auto text-xs font-medium text-app-muted">
               {headerMetaText}
             </p>
             <div className="flex flex-wrap items-center gap-2">{actionButtons}</div>
           </div>
-          <section className="mt-3 overflow-hidden rounded-lg border border-zinc-700/70 bg-[#0b1018] shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
-            <div className="bg-[#1a202c] px-3 py-1.5 font-mono text-[11px] text-zinc-400">
+          <section className="mt-3 overflow-hidden rounded-lg border border-app-border/70 bg-app-base shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]">
+            <div className="bg-app-elevated px-3 py-1.5 font-mono text-[11px] text-app-muted">
               /Users/chan/Library/Java/JavaVirtualMachines/graalvm-ce-21.0.2/Contents/Home/bin/java ...
             </div>
 
             <div className="grid max-h-[65vh] grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_220px]">
               <div className="min-w-0 px-3 py-3">
-                <pre className="overflow-x-auto font-mono text-[16px] leading-[1.2] text-zinc-300">
+                <pre className="overflow-x-auto font-mono text-[16px] leading-[1.2] text-app-secondary">
                   {SPRING_BOOT_BANNER}
                 </pre>
-                <p className="mt-2 font-mono text-sm text-emerald-400">
+                <p className="mt-2 font-mono text-sm text-app-success">
                   :: Bracket Boot ::                      ({SPRING_BOOT_VERSION})
                 </p>
               </div>
 
               <div className="flex min-w-0 items-center justify-center px-3 py-3">
-                <div className="w-full rounded-lg border border-zinc-700 bg-[#111827]/70 px-3 py-5 text-center">
-                  <p className="font-mono text-4xl font-bold leading-none text-cyan-300">
+                <div className="w-full rounded-lg border border-app-border bg-app-surface/80 px-3 py-5 text-center">
+                  <p className="font-mono text-4xl font-bold leading-none text-app-accent-soft">
                     {summaryCountText}
                   </p>
-                  <p className="mt-2 text-sm font-semibold text-zinc-300">{summaryModeText}</p>
+                  <p className="mt-2 text-sm font-semibold text-app-secondary">{summaryModeText}</p>
                 </div>
               </div>
             </div>
@@ -738,15 +738,15 @@ export default function QueueModal({
                 {consoleLogs.map((line) => (
                   <p
                     key={line.id}
-                    className="mb-0.5 whitespace-pre-wrap break-words leading-6 text-zinc-300"
+                    className="mb-0.5 whitespace-pre-wrap break-words leading-6 text-app-secondary"
                   >
-                    <span className="text-zinc-500">{line.time}</span>{" "}
+                    <span className="text-app-dim">{line.time}</span>{" "}
                     <span className={`font-semibold ${getLevelColor(line.level)}`}>
                       {line.level}
                     </span>{" "}
                     <span>{line.message}</span>
                     {line.count > 1 ? (
-                      <span className="ml-1 text-zinc-500">(x{line.count})</span>
+                      <span className="ml-1 text-app-dim">(x{line.count})</span>
                     ) : null}
                   </p>
                 ))}
@@ -756,8 +756,8 @@ export default function QueueModal({
             <div
               className={`px-3 py-1.5 text-xs ${
                 error || mode === "TERMINAL"
-                  ? "bg-rose-500/10 text-rose-200"
-                  : "bg-[#151d2a] text-zinc-400"
+                  ? "bg-app-danger/10 text-app-danger"
+                  : "bg-app-elevated text-app-muted"
               }`}
             >
               {footerMessage}

--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
 import type { ReadyCheckState } from "@/shared/api/contracts";
 import { StatusPill } from "@/shared/ui";
 
 import {
   formatClock,
   getReadyDecisionLabel,
-  getReadyDecisionTone,
 } from "./data";
 
 type QueueModalMode = "SEARCHING" | "READY_CHECK" | "ROOM_READY" | "TERMINAL" | null;
@@ -33,21 +34,191 @@ interface QueueModalProps {
   onCloseTerminal: () => void;
 }
 
-function SectionTitle({
-  label,
-  value,
+interface ConsoleLogLine {
+  id: number;
+  time: string;
+  level: "INFO" | "DEBUG" | "WARN" | "ERROR";
+  message: string;
+}
+
+const CONSOLE_MAX_LINES = 90;
+
+const SPRING_BOOT_BANNER = String.raw`  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _\` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  ' |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/`;
+
+function getModeHeadline(mode: Exclude<QueueModalMode, null>) {
+  if (mode === "SEARCHING") {
+    return "큐 매칭 중";
+  }
+
+  if (mode === "READY_CHECK") {
+    return "Ready-check 진행 중";
+  }
+
+  if (mode === "ROOM_READY") {
+    return "입장 준비 완료";
+  }
+
+  return "매칭 종료";
+}
+
+function getModeDescription(mode: Exclude<QueueModalMode, null>) {
+  if (mode === "SEARCHING") {
+    return "플레이어를 찾는 중입니다. 인원이 채워지면 자동으로 ready-check로 전환됩니다.";
+  }
+
+  if (mode === "READY_CHECK") {
+    return "제한 시간 안에 수락 여부를 선택하세요. 전원 수락 시 즉시 배틀룸으로 연결됩니다.";
+  }
+
+  if (mode === "ROOM_READY") {
+    return "모든 준비가 끝났습니다. 방 입장 연결을 시도하고 있습니다.";
+  }
+
+  return "이번 매칭 세션이 종료되었습니다. 종료 메시지를 확인하고 다시 시작하세요.";
+}
+
+function getLevelColor(level: ConsoleLogLine["level"]) {
+  if (level === "INFO") {
+    return "text-emerald-400";
+  }
+
+  if (level === "DEBUG") {
+    return "text-cyan-400";
+  }
+
+  if (level === "WARN") {
+    return "text-amber-300";
+  }
+
+  return "text-rose-300";
+}
+
+function getLoopInfoMessage(mode: Exclude<QueueModalMode, null>) {
+  if (mode === "SEARCHING") {
+    return "대기열에서 상대를 찾고 있습니다.";
+  }
+
+  if (mode === "READY_CHECK") {
+    return "ready-check 응답을 기다리고 있습니다.";
+  }
+
+  if (mode === "ROOM_READY") {
+    return "방 입장 연결을 시도하고 있습니다.";
+  }
+
+  return "매칭 세션이 종료되었습니다.";
+}
+
+function pickRandom<T>(items: T[]): T | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const index = Math.floor(Math.random() * items.length);
+  return items[index] ?? null;
+}
+
+function buildBaseLoopMessages(
+  mode: Exclude<QueueModalMode, null>,
+  categoryLabel: string,
+  difficultyLabel: string,
+): Array<{ level: ConsoleLogLine["level"]; message: string }> {
+  return [
+    { level: "INFO", message: ":: Spring Queue :: (v1.0.0)" },
+    {
+      level: "DEBUG",
+      message: `profile=queue/${categoryLabel.toLowerCase()}/${difficultyLabel.toLowerCase()}`,
+    },
+    { level: "INFO", message: `mode=${mode} initialized` },
+    { level: "INFO", message: getLoopInfoMessage(mode) },
+  ];
+}
+
+function buildDynamicEventMessages({
+  mode,
+  waitingCount,
+  requiredCount,
+  queueElapsedSeconds,
+  countdownSeconds,
+  readyCheck,
+  roomId,
 }: {
-  label: string;
-  value: string;
+  mode: Exclude<QueueModalMode, null>;
+  waitingCount: number;
+  requiredCount: number;
+  queueElapsedSeconds: number;
+  countdownSeconds: number;
+  readyCheck: ReadyCheckState | null;
+  roomId: number | null;
+}): Array<{ level: ConsoleLogLine["level"]; message: string }> {
+  if (mode === "SEARCHING") {
+    return [
+      {
+        level: "DEBUG",
+        message: `queue waiting=${waitingCount}/${requiredCount} elapsed=${formatClock(queueElapsedSeconds)}`,
+      },
+      { level: "DEBUG", message: "socket heartbeat ok" },
+      { level: "INFO", message: "matching engine scanning candidates..." },
+    ];
+  }
+
+  if (mode === "READY_CHECK") {
+    return [
+      {
+        level: "INFO",
+        message: `ready-check accepted=${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}`,
+      },
+      { level: "WARN", message: `ready-check deadline T-${Math.max(countdownSeconds, 0)}s` },
+      { level: "DEBUG", message: "waiting for participant decisions..." },
+    ];
+  }
+
+  if (mode === "ROOM_READY") {
+    return [
+      { level: "INFO", message: `room join pending roomId=${roomId ?? "unknown"}` },
+      { level: "DEBUG", message: "join handshake in progress..." },
+      { level: "INFO", message: "room admission check passed" },
+    ];
+  }
+
+  return [{ level: "WARN", message: "terminal flow reached" }];
+}
+
+function getModeStatusLine({
+  mode,
+  waitingCount,
+  requiredCount,
+  queueElapsedSeconds,
+  countdownSeconds,
+  readyCheck,
+  roomId,
+}: {
+  mode: Exclude<QueueModalMode, null>;
+  waitingCount: number;
+  requiredCount: number;
+  queueElapsedSeconds: number;
+  countdownSeconds: number;
+  readyCheck: ReadyCheckState | null;
+  roomId: number | null;
 }) {
-  return (
-    <div>
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
-        {label}
-      </p>
-      <p className="mt-2 font-medium text-zinc-100">{value}</p>
-    </div>
-  );
+  if (mode === "SEARCHING") {
+    return `상태: 상대를 찾는 중 (${waitingCount}/${requiredCount}명) · 경과 ${formatClock(queueElapsedSeconds)}`;
+  }
+
+  if (mode === "READY_CHECK") {
+    return `상태: 수락 확인 중 (${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}명 수락) · 남은 시간 ${formatClock(countdownSeconds)} · 경과 ${formatClock(queueElapsedSeconds)}`;
+  }
+
+  if (mode === "ROOM_READY") {
+    return `상태: 입장 준비 완료 · 방 번호 ${roomId ?? "확인 중"} · 수락 ${readyCheck?.acceptedCount ?? 0}/${readyCheck?.requiredCount ?? requiredCount}명`;
+  }
+
+  return "상태: 매칭 종료";
 }
 
 export default function QueueModal({
@@ -71,299 +242,482 @@ export default function QueueModal({
   onRetryRoomEntry,
   onCloseTerminal,
 }: QueueModalProps) {
+  const [consoleLogs, setConsoleLogs] = useState<ConsoleLogLine[]>([]);
+  const logViewportRef = useRef<HTMLDivElement | null>(null);
+  const logIdRef = useRef(0);
+  const pidRef = useRef(24000 + Math.floor(Math.random() * 6000));
+  const snapshotRef = useRef<{
+    mode: QueueModalMode;
+    waitingCount: number;
+    acceptedCount: number;
+    countdownSeconds: number;
+    roomId: number | null;
+    error: string | null;
+    feedback: string;
+    terminalMessage: string | null;
+  }>({
+    mode: null,
+    waitingCount: 0,
+    acceptedCount: 0,
+    countdownSeconds: 0,
+    roomId: null,
+    error: null,
+    feedback: "",
+    terminalMessage: null,
+  });
+
+  const makeLogLine = useCallback(
+    (level: ConsoleLogLine["level"], message: string): ConsoleLogLine => {
+      logIdRef.current += 1;
+      const timestamp = new Date().toISOString().replace("T", " ").slice(0, 19);
+      return {
+        id: logIdRef.current,
+        time: timestamp,
+        level,
+        message,
+      };
+    },
+    [],
+  );
+
+  const appendLog = useCallback(
+    (level: ConsoleLogLine["level"], message: string) => {
+      setConsoleLogs((prev) => {
+        const next = [...prev, makeLogLine(level, message)];
+        if (next.length > CONSOLE_MAX_LINES) {
+          return next.slice(next.length - CONSOLE_MAX_LINES);
+        }
+        return next;
+      });
+    },
+    [makeLogLine],
+  );
+
+  useEffect(() => {
+    if (!mode) {
+      setConsoleLogs([]);
+      snapshotRef.current = {
+        mode: null,
+        waitingCount: 0,
+        acceptedCount: 0,
+        countdownSeconds: 0,
+        roomId: null,
+        error: null,
+        feedback: "",
+        terminalMessage: null,
+      };
+      return;
+    }
+
+    const initialLogs: ConsoleLogLine[] = [
+      makeLogLine("INFO", ":: Spring Queue :: (v1.0.0)"),
+      makeLogLine("DEBUG", `profile=queue/${categoryLabel.toLowerCase()}/${difficultyLabel.toLowerCase()}`),
+      makeLogLine("INFO", `mode=${mode} initialized`),
+      makeLogLine("INFO", getLoopInfoMessage(mode)),
+    ];
+
+    setConsoleLogs(initialLogs);
+    snapshotRef.current = {
+      mode,
+      waitingCount,
+      acceptedCount: readyCheck?.acceptedCount ?? 0,
+      countdownSeconds,
+      roomId,
+      error,
+      feedback,
+      terminalMessage,
+    };
+  }, [
+    mode,
+    categoryLabel,
+    countdownSeconds,
+    difficultyLabel,
+    error,
+    feedback,
+    makeLogLine,
+    readyCheck?.acceptedCount,
+    roomId,
+    terminalMessage,
+    waitingCount,
+  ]);
+
+  useEffect(() => {
+    if (!mode) {
+      return;
+    }
+
+    const prev = snapshotRef.current;
+
+    if (mode === "SEARCHING" && waitingCount !== prev.waitingCount) {
+      appendLog("DEBUG", `queue waiting=${waitingCount}/${requiredCount}`);
+    }
+
+    const nextAcceptedCount = readyCheck?.acceptedCount ?? 0;
+    if (mode === "READY_CHECK" && nextAcceptedCount !== prev.acceptedCount) {
+      appendLog("INFO", `ready-check accepted=${nextAcceptedCount}/${readyCheck?.requiredCount ?? requiredCount}`);
+    }
+
+    if (
+      mode === "READY_CHECK" &&
+      countdownSeconds !== prev.countdownSeconds &&
+      countdownSeconds <= 10 &&
+      countdownSeconds >= 0
+    ) {
+      appendLog("WARN", `ready-check deadline T-${countdownSeconds}s`);
+    }
+
+    if (roomId !== null && roomId !== prev.roomId) {
+      appendLog("INFO", `room allocated roomId=${roomId}`);
+    }
+
+    if (error && error !== prev.error) {
+      appendLog("ERROR", error);
+    }
+
+    if (feedback && feedback !== prev.feedback) {
+      appendLog("INFO", feedback);
+    }
+
+    if (terminalMessage && terminalMessage !== prev.terminalMessage) {
+      appendLog("WARN", terminalMessage);
+    }
+
+    if (mode === "TERMINAL" && prev.mode !== "TERMINAL") {
+      appendLog("ERROR", "queue flow terminated by system state");
+    }
+
+    snapshotRef.current = {
+      mode,
+      waitingCount,
+      acceptedCount: nextAcceptedCount,
+      countdownSeconds,
+      roomId,
+      error,
+      feedback,
+      terminalMessage,
+    };
+  }, [
+    appendLog,
+    countdownSeconds,
+    error,
+    feedback,
+    mode,
+    readyCheck?.acceptedCount,
+    readyCheck?.requiredCount,
+    requiredCount,
+    roomId,
+    terminalMessage,
+    waitingCount,
+  ]);
+
+  useEffect(() => {
+    if (!mode) {
+      return;
+    }
+
+    let cancelled = false;
+    let timerId: number | null = null;
+    let loopCursor = 0;
+
+    const runLoop = () => {
+      if (cancelled) {
+        return;
+      }
+
+      const baseMessages = buildBaseLoopMessages(mode, categoryLabel, difficultyLabel);
+      const nextBaseLine = baseMessages[loopCursor % baseMessages.length];
+      loopCursor += 1;
+      appendLog(nextBaseLine.level, nextBaseLine.message);
+
+      if (mode !== "TERMINAL" && loopCursor % baseMessages.length === 0) {
+        const dynamicLine = pickRandom(
+          buildDynamicEventMessages({
+            mode,
+            waitingCount,
+            requiredCount,
+            queueElapsedSeconds,
+            countdownSeconds,
+            readyCheck,
+            roomId,
+          }),
+        );
+
+        if (dynamicLine) {
+          appendLog(dynamicLine.level, dynamicLine.message);
+        }
+      }
+
+      if (mode !== "TERMINAL" && Math.random() < 0.28) {
+        const burstLine = pickRandom(
+          buildDynamicEventMessages({
+            mode,
+            waitingCount,
+            requiredCount,
+            queueElapsedSeconds,
+            countdownSeconds,
+            readyCheck,
+            roomId,
+          }),
+        );
+
+        if (burstLine) {
+          appendLog(burstLine.level, burstLine.message);
+        }
+      }
+
+      const nextDelay = mode === "TERMINAL"
+        ? 1200
+        : 400 + Math.floor(Math.random() * 800);
+      timerId = window.setTimeout(runLoop, nextDelay);
+    };
+
+    const firstDelay = mode === "TERMINAL" ? 900 : 450;
+    timerId = window.setTimeout(runLoop, firstDelay);
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+      }
+    };
+  }, [
+    appendLog,
+    categoryLabel,
+    countdownSeconds,
+    difficultyLabel,
+    mode,
+    queueElapsedSeconds,
+    readyCheck,
+    requiredCount,
+    roomId,
+    waitingCount,
+  ]);
+
+  useEffect(() => {
+    if (!logViewportRef.current) {
+      return;
+    }
+
+    logViewportRef.current.scrollTop = logViewportRef.current.scrollHeight;
+  }, [consoleLogs.length]);
+
+  const modalTone = useMemo(() => {
+    if (mode === "TERMINAL") {
+      return "danger";
+    }
+
+    if (mode === "ROOM_READY") {
+      return "success";
+    }
+
+    return "warn";
+  }, [mode]);
+
+  const modeStatus = useMemo(() => {
+    if (mode === "SEARCHING") {
+      return "매칭 대기 중";
+    }
+
+    if (mode === "READY_CHECK") {
+      return "수락 확인 중";
+    }
+
+    if (mode === "ROOM_READY") {
+      return "방 입장 준비 완료";
+    }
+
+    return "매칭 종료";
+  }, [mode]);
+
+  const modeStatusLine = useMemo(
+    () => {
+      if (!mode) {
+        return "";
+      }
+
+      return getModeStatusLine({
+        mode,
+        waitingCount,
+        requiredCount,
+        queueElapsedSeconds,
+        countdownSeconds,
+        readyCheck,
+        roomId,
+      });
+    },
+    [
+      countdownSeconds,
+      mode,
+      queueElapsedSeconds,
+      readyCheck,
+      requiredCount,
+      roomId,
+      waitingCount,
+    ],
+  );
+
+  const actionButtonClass = "rounded-md border border-zinc-600 bg-[#171f2c] px-3 py-1.5 text-xs font-semibold text-zinc-100 transition hover:border-violet-400/55 hover:bg-violet-500/10 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-[#141a24] disabled:text-zinc-500";
+
   if (!mode) {
     return null;
   }
 
-  const modalTone =
-    mode === "TERMINAL"
-      ? "danger"
-      : mode === "ROOM_READY"
-        ? "success"
-        : "warn";
-  const modalStatus =
-    mode === "SEARCHING"
-      ? "매칭 대기 중"
-      : mode === "READY_CHECK"
-        ? "수락 확인 중"
-        : mode === "ROOM_READY"
-          ? "방 입장 준비 완료"
-          : "매칭 종료";
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/60 p-4">
-      <div className="w-full max-w-2xl rounded-2xl border border-zinc-700 bg-[#1f222a] p-6 text-zinc-200 shadow-2xl">
-        <div className="flex flex-wrap items-center gap-2">
-          <StatusPill tone={modalTone}>{modalStatus}</StatusPill>
-          <StatusPill>{categoryLabel}</StatusPill>
-          <StatusPill>{difficultyLabel}</StatusPill>
-          {mode === "SEARCHING" ? (
-            <StatusPill>{waitingCount} / {requiredCount}</StatusPill>
-          ) : null}
-          {readyCheck ? (
-            <StatusPill>
-              {readyCheck.acceptedCount} / {readyCheck.requiredCount}
-            </StatusPill>
-          ) : null}
-        </div>
+    <div className="absolute inset-0 z-40 flex items-end bg-zinc-950/30">
+      <div className="queue-sheet w-full overflow-hidden border-t border-zinc-700 bg-[#12161f] text-zinc-200 shadow-[0_-20px_48px_rgba(0,0,0,0.55)]">
+        <div className="px-4 pb-4 pt-2">
+          <div className="mx-auto mb-2 h-1.5 w-16 rounded-full bg-zinc-600/80" />
+          <div className="flex flex-wrap items-center gap-2 border-b border-zinc-700 pb-2">
+            <StatusPill tone={modalTone}>{modeStatus}</StatusPill>
+            <StatusPill>{categoryLabel}</StatusPill>
+            <StatusPill>{difficultyLabel}</StatusPill>
+            <p className="ml-auto text-xs font-medium text-zinc-400">
+              {getModeHeadline(mode)} · pid {pidRef.current}
+            </p>
+          </div>
+          <section className="mt-3 overflow-hidden rounded-lg border border-zinc-700 bg-[#0b1018]">
+            <div className="border-b border-zinc-700 bg-[#1a202c] px-3 py-1.5 font-mono text-[11px] text-zinc-400">
+              /Users/chan/Library/Java/JavaVirtualMachines/graalvm-ce-21.0.2/Contents/Home/bin/java ...
+            </div>
 
-        {mode === "SEARCHING" ? (
-          <>
-            <div className="mt-6 flex items-center gap-4">
-              <div className="flex size-16 shrink-0 animate-spin items-center justify-center rounded-full border-4 border-zinc-700 border-t-sky-400 bg-[#1a1d24] text-transparent">
-                .
+            <div className="grid max-h-[65vh] grid-cols-1 overflow-hidden lg:grid-cols-[360px_minmax(0,1fr)]">
+              <div className="min-w-0 px-3 py-3">
+                <pre className="overflow-x-auto font-mono text-[10px] leading-4 text-zinc-500">
+                  {SPRING_BOOT_BANNER}
+                </pre>
               </div>
 
-              <div>
-                <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
-                  상대를 찾고 있습니다
-                </h2>
-                <p className="mt-2 text-sm leading-7 text-zinc-400">
-                  ready-check 전까지는 대기열 인원만 표시합니다.
-                  네 명이 채워져서 큐에서 빠지면 자동으로 수락 화면으로 전환됩니다.
-                </p>
-              </div>
-            </div>
+              <div className="min-w-0 px-3 py-3">
+                <div className="space-y-1 font-mono text-xs leading-6">
+                  <p className="text-zinc-300">
+                    <span className="text-zinc-500">$</span>{" "}
+                    <span className="text-cyan-300">{modeStatusLine}</span>
+                  </p>
+                  <p className="text-zinc-300">
+                    <span className="text-zinc-500">$</span>{" "}
+                    <span>{getModeDescription(mode)}</span>
+                  </p>
+                  <p className="text-zinc-400">
+                    <span className="text-zinc-500">$</span>{" "}
+                    선택 설정: 카테고리 {categoryLabel}, 난이도 {difficultyLabel}, 세션 ID {pidRef.current}
+                  </p>
+                  {readyCheck?.participants?.length ? (
+                    <p className="text-zinc-400">
+                      <span className="text-zinc-500">$</span>{" "}
+                      {readyCheck.participants
+                        .map((participant) => `${participant.nickname}${participant.userId === currentUserId ? "(ME)" : ""}:${getReadyDecisionLabel(participant.decision)}`)
+                        .join(" | ")}
+                    </p>
+                  ) : null}
+                </div>
 
-            <div
-              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
-                error
-                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
-              }`}
-            >
-              {error ?? feedback}
-            </div>
-
-            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
-              <SectionTitle label="경과 시간" value={formatClock(queueElapsedSeconds)} />
-              <SectionTitle
-                label="현재 인원"
-                value={`${waitingCount} / ${requiredCount}`}
-              />
-              <SectionTitle label="현재 상태" value="큐 대기 중" />
-            </div>
-
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={onCancel}
-                disabled={isPending}
-                className="rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
-              >
-                매칭 취소
-              </button>
-              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
-                cancel 버튼은 SEARCHING 단계에서만 노출됩니다.
-              </div>
-            </div>
-          </>
-        ) : null}
-
-        {mode === "READY_CHECK" ? (
-          <>
-            <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
-                매칭이 성사되었습니다
-              </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-400">
-                수락 여부를 확인하는 단계입니다. 마지막 수락이 완료되면 방이 만들어지고
-                자동으로 입장 절차를 시작합니다.
-              </p>
-            </div>
-
-            <div
-              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
-                error
-                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
-              }`}
-            >
-              {error ?? feedback}
-            </div>
-
-            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
-              <SectionTitle
-                label="수락 현황"
-                value={
-                  readyCheck
-                    ? `${readyCheck.acceptedCount} / ${readyCheck.requiredCount}`
-                    : "확인 중"
-                }
-              />
-              <SectionTitle label="남은 시간" value={formatClock(countdownSeconds)} />
-              <SectionTitle
-                label="내 상태"
-                value={readyCheck?.acceptedByMe ? "수락 완료" : "응답 대기"}
-              />
-            </div>
-
-            <div className="mt-6 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4">
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-sm font-medium text-zinc-100">참가자 상태</p>
-                {readyCheck ? (
-                  <p className="text-xs text-zinc-500">matchId {readyCheck.matchId}</p>
-                ) : null}
-              </div>
-
-              <div className="mt-4 space-y-3">
-                {readyCheck?.participants?.length ? (
-                  readyCheck.participants.map((participant) => (
-                    <div
-                      key={`${participant.userId}-${participant.nickname}`}
-                      className="flex items-center justify-between rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3"
+                <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1">
+                  {mode === "SEARCHING" ? (
+                    <button
+                      type="button"
+                      onClick={onCancel}
+                      disabled={isPending}
+                      className={actionButtonClass}
                     >
-                      <div>
-                        <p className="font-medium text-zinc-100">
-                          {participant.nickname}
-                          {participant.userId === currentUserId ? " (나)" : ""}
-                        </p>
-                        <p className="mt-1 text-xs text-zinc-500">
-                          userId {participant.userId}
-                        </p>
-                      </div>
-                      <StatusPill tone={getReadyDecisionTone(participant.decision)}>
-                        {getReadyDecisionLabel(participant.decision)}
-                      </StatusPill>
-                    </div>
-                  ))
-                ) : (
-                  <div className="rounded-2xl border border-dashed border-zinc-700 px-4 py-6 text-center text-sm text-zinc-500">
-                    참가자 상태를 불러오는 중입니다.
-                  </div>
-                )}
-              </div>
-            </div>
+                      매칭 취소
+                    </button>
+                  ) : null}
 
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={onDecline}
-                disabled={isPending || !readyCheck}
-                className="rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3 text-sm font-medium text-zinc-100 transition hover:border-sky-400/45 hover:bg-sky-500/10 disabled:cursor-not-allowed disabled:text-zinc-500"
-              >
-                매칭 거절
-              </button>
-              <button
-                type="button"
-                onClick={onAccept}
-                disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
-                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
-              >
-                {readyCheck?.acceptedByMe ? "이미 수락했습니다" : "매칭 수락"}
-              </button>
-            </div>
-          </>
-        ) : null}
+                  {mode === "READY_CHECK" ? (
+                    <>
+                      <button
+                        type="button"
+                        onClick={onDecline}
+                        disabled={isPending || !readyCheck}
+                        className={actionButtonClass}
+                      >
+                        거절
+                      </button>
+                      <button
+                        type="button"
+                        onClick={onAccept}
+                        disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
+                        className={actionButtonClass}
+                      >
+                        {readyCheck?.acceptedByMe ? "수락 완료" : "수락"}
+                      </button>
+                    </>
+                  ) : null}
 
-        {mode === "ROOM_READY" ? (
-          <>
-            <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
-                방이 준비되었습니다
-              </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-400">
-                전원이 수락해서 방 입장 준비가 끝났습니다. 기존 battle room join API로
-                연결하는 중입니다.
-              </p>
-            </div>
-
-            <div
-              className={`mt-6 rounded-2xl border px-4 py-3 text-sm ${
-                error
-                  ? "border-rose-400/60 bg-rose-900/20 text-rose-200"
-                  : "border-zinc-700 bg-[#1a1d24] text-zinc-300"
-              }`}
-            >
-              {error ?? feedback}
-            </div>
-
-            <div className="mt-6 grid gap-4 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4 text-sm text-zinc-300 md:grid-cols-3">
-              <SectionTitle
-                label="roomId"
-                value={roomId !== null ? String(roomId) : "확인 중"}
-              />
-              <SectionTitle
-                label="수락 현황"
-                value={
-                  readyCheck
-                    ? `${readyCheck.acceptedCount} / ${readyCheck.requiredCount}`
-                    : "확인 중"
-                }
-              />
-              <SectionTitle label="현재 상태" value="방 입장 시도 중" />
-            </div>
-
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={onRetryRoomEntry}
-                disabled={isPending}
-                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
-              >
-                방 입장 다시 시도
-              </button>
-              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
-                join 성공 시 battle room 화면으로 이동합니다.
-              </div>
-            </div>
-          </>
-        ) : null}
-
-        {mode === "TERMINAL" ? (
-          <>
-            <div className="mt-6">
-              <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">
-                매칭이 종료되었습니다
-              </h2>
-              <p className="mt-2 text-sm leading-7 text-zinc-400">
-                서버 상태는 종료 상태를 유지할 수 있으므로, 현재 화면에서는 한 번 안내한 뒤
-                로컬 UI를 초기화합니다.
-              </p>
-            </div>
-
-            <div className="mt-6 rounded-2xl border border-rose-400/60 bg-rose-900/20 px-4 py-3 text-sm text-rose-200">
-              {terminalMessage ?? error ?? feedback}
-            </div>
-
-            {readyCheck?.participants?.length ? (
-              <div className="mt-6 rounded-xl border border-zinc-700 bg-[#1a1d24] p-4">
-                <p className="text-sm font-medium text-zinc-100">종료 시점 참가자 상태</p>
-                <div className="mt-4 space-y-3">
-                  {readyCheck.participants.map((participant) => (
-                    <div
-                      key={`${participant.userId}-${participant.nickname}`}
-                      className="flex items-center justify-between rounded-lg border border-zinc-700 bg-[#22262e] px-4 py-3"
+                  {mode === "ROOM_READY" ? (
+                    <button
+                      type="button"
+                      onClick={onRetryRoomEntry}
+                      disabled={isPending}
+                      className={actionButtonClass}
                     >
-                      <p className="font-medium text-zinc-100">
-                        {participant.nickname}
-                        {participant.userId === currentUserId ? " (나)" : ""}
-                      </p>
-                      <StatusPill tone={getReadyDecisionTone(participant.decision)}>
-                        {getReadyDecisionLabel(participant.decision)}
-                      </StatusPill>
-                    </div>
-                  ))}
+                      방 입장 재시도
+                    </button>
+                  ) : null}
+
+                  {mode === "TERMINAL" ? (
+                    <button
+                      type="button"
+                      onClick={onCloseTerminal}
+                      disabled={isPending}
+                      className={actionButtonClass}
+                    >
+                      닫기
+                    </button>
+                  ) : null}
                 </div>
               </div>
-            ) : null}
+            </div>
 
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                onClick={onCloseTerminal}
-                disabled={isPending}
-                className="rounded-lg bg-sky-500 px-4 py-3 text-sm font-semibold text-zinc-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
-              >
-                확인하고 닫기
-              </button>
-              <div className="rounded-lg border border-zinc-700 bg-[#1a1d24] px-4 py-3 text-sm leading-6 text-zinc-400">
-                닫은 뒤에는 메인에서 다시 매칭을 시작할 수 있습니다.
+            <div
+              ref={logViewportRef}
+              className="h-[30vh] min-h-[150px] overflow-y-auto px-3 py-2"
+            >
+              <div className="font-mono text-xs">
+                {consoleLogs.map((line) => (
+                  <p
+                    key={line.id}
+                    className="mb-0.5 whitespace-pre-wrap break-words leading-6 text-zinc-300"
+                  >
+                    <span className="text-zinc-500">{line.time}</span>{" "}
+                    <span className={`font-semibold ${getLevelColor(line.level)}`}>
+                      {line.level}
+                    </span>{" "}
+                    <span>{line.message}</span>
+                  </p>
+                ))}
               </div>
             </div>
-          </>
-        ) : null}
+
+            <div
+              className={`px-3 py-1.5 text-xs ${
+                error || mode === "TERMINAL"
+                  ? "bg-rose-500/10 text-rose-200"
+                  : "bg-[#151d2a] text-zinc-400"
+              }`}
+            >
+              {error ?? terminalMessage ?? feedback}
+            </div>
+          </section>
+        </div>
       </div>
+
+      <style jsx>{`
+        .queue-sheet {
+          animation: queue-sheet-slide-up 180ms ease-out;
+        }
+
+        @keyframes queue-sheet-slide-up {
+          from {
+            transform: translateY(30px);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -705,8 +705,8 @@ export default function HomeScreen() {
       }
 
       if (nextMatchState.status === "IDLE") {
-        setMatchState(defaultMatchState);
-        setFeedback("ready-check 세션을 확인하는 중입니다.");
+        logMatchingDebug("poll matches/me status=IDLE -> reset flow");
+        resetFlow("매칭이 취소되었거나 종료되었습니다. 다시 시작할 수 있습니다.");
         return;
       }
 
@@ -725,7 +725,13 @@ export default function HomeScreen() {
       active = false;
       window.clearInterval(intervalId);
     };
-  }, [applyMatchSnapshot, clearQueueTopicSubscription, pollStage, session.authenticated]);
+  }, [
+    applyMatchSnapshot,
+    clearQueueTopicSubscription,
+    pollStage,
+    resetFlow,
+    session.authenticated,
+  ]);
 
   useEffect(() => {
     if (!session.authenticated || pollStage !== "MATCH") {
@@ -742,10 +748,8 @@ export default function HomeScreen() {
       }
 
       if (nextMatchState.status === "IDLE") {
-        setMatchState(defaultMatchState);
-        setModalMode("READY_CHECK");
-        setError(null);
-        setFeedback("ready-check 세션을 확인하는 중입니다.");
+        logMatchingDebug("poll match stage status=IDLE -> reset flow");
+        resetFlow("ready-check 세션이 종료되었습니다. 다시 매칭을 시작하세요.");
         return;
       }
 
@@ -762,7 +766,7 @@ export default function HomeScreen() {
       active = false;
       window.clearInterval(intervalId);
     };
-  }, [applyMatchSnapshot, pollStage, session.authenticated]);
+  }, [applyMatchSnapshot, pollStage, resetFlow, session.authenticated]);
 
   useEffect(() => {
     const roomId = matchState.room?.roomId ?? null;

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -948,7 +948,7 @@ export default function HomeScreen() {
   };
 
   return (
-    <div className="h-full min-h-0">
+    <div className="relative h-full min-h-0">
       <QueueEditorPane
         editorPaneRef={editorPaneRef}
         editorContentStyle={editorContentStyle}

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -367,7 +367,7 @@ export default function IdeShell({
 
   return (
     <SessionContext.Provider value={{ session, sessionLoaded, refreshSession, applySession }}>
-      <div className="flex h-full min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
+      <div className="flex h-full min-h-0 flex-1 overflow-hidden bg-app-base">
         <div className={`grid h-full w-full ${layoutColumnsClass}`}>
           <QuickMenuPane
             isQuickMenuOpen={isQuickMenuOpen}
@@ -376,7 +376,7 @@ export default function IdeShell({
             projectTreeItems={projectTreeItems}
           />
 
-          <section className="h-full min-h-0 overflow-hidden bg-[#1e1f22]">
+          <section className="h-full min-h-0 overflow-hidden bg-app-base">
             {isFullBleedCenter ? (
               <div className="h-full min-h-0">{children}</div>
             ) : (

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -85,7 +85,7 @@ export default function IdeShell({
   const pathname = usePathname();
   const router = useRouter();
   const refreshInFlightRef = useRef<Promise<SessionResponse> | null>(null);
-  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(true);
+  const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(false);
   const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
   const [session, setSession] = useState<SessionResponse>(initialSession);
   const [sessionLoaded, setSessionLoaded] = useState(true);
@@ -205,6 +205,15 @@ export default function IdeShell({
       window.clearInterval(intervalId);
     };
   }, [pathname, session.authenticated, session.member]);
+
+  useEffect(() => {
+    const isSoloProblemRoute = /^\/problems\/\d+$/.test(pathname);
+    const isBattleRoomRoute = /^\/battle\/rooms\/\d+$/.test(pathname);
+
+    if (isSoloProblemRoute || isBattleRoomRoute) {
+      setIsQuickMenuOpen(false);
+    }
+  }, [pathname]);
 
   useEffect(() => {
     let active = true;

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -352,12 +352,13 @@ export default function IdeShell({
     pathname === "/signup" ||
     pathname === "/login" ||
     pathname === "/problems" ||
+    pathname.startsWith("/problems/") ||
     pathname === "/mypage" ||
     pathname.startsWith("/battle/rooms/");
 
   return (
     <SessionContext.Provider value={{ session, sessionLoaded, refreshSession, applySession }}>
-      <div className="flex min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
+      <div className="flex h-full min-h-0 flex-1 overflow-hidden bg-[#1e1f22]">
         <div className={`grid h-full w-full ${layoutColumnsClass}`}>
           <QuickMenuPane
             isQuickMenuOpen={isQuickMenuOpen}
@@ -366,7 +367,7 @@ export default function IdeShell({
             projectTreeItems={projectTreeItems}
           />
 
-          <section className="min-h-0 overflow-hidden bg-[#1e1f22]">
+          <section className="h-full min-h-0 overflow-hidden bg-[#1e1f22]">
             {isFullBleedCenter ? (
               <div className="h-full min-h-0">{children}</div>
             ) : (

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   MyBattleResultItem,
   MyBattleResultsResponse,
+  RoomResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
 
@@ -16,6 +17,32 @@ import QuickMenuPane, {
 import SessionContext from "@/features/layout/session-context";
 
 const PREVIEW_RESULTS_SIZE = 5;
+
+interface BattleSidebarState {
+  status: RoomResponse["status"];
+  remainingTime: string;
+  participants: RoomResponse["participants"];
+  myStatus: string | null;
+  myUserId: number | null;
+}
+
+function formatRemainingTime(timerEnd: string | null) {
+  if (!timerEnd) {
+    return "--:--";
+  }
+
+  const end = new Date(timerEnd).getTime();
+
+  if (!Number.isFinite(end)) {
+    return "--:--";
+  }
+
+  const remainingMs = Math.max(0, end - Date.now());
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
 
 async function readSession() {
   const response = await fetch("/api/auth/session", {
@@ -67,6 +94,7 @@ export default function IdeShell({
     "로그인 후 최근 전적을 확인할 수 있습니다.",
   );
   const [resultsPreviewError, setResultsPreviewError] = useState<string | null>(null);
+  const [battleSidebarState, setBattleSidebarState] = useState<BattleSidebarState | null>(null);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const applySession = useCallback((nextSession: SessionResponse) => {
     setSession(nextSession);
@@ -120,6 +148,63 @@ export default function IdeShell({
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [refreshSession]);
+
+  useEffect(() => {
+    const battleRoomMatch = pathname.match(/^\/battle\/rooms\/(\d+)$/);
+
+    if (!battleRoomMatch) {
+      setBattleSidebarState(null);
+      return;
+    }
+
+    const targetRoomId = Number(battleRoomMatch[1]);
+    const memberId = session.member?.memberId ?? null;
+
+    if (!session.authenticated || memberId === null) {
+      setBattleSidebarState(null);
+      return;
+    }
+
+    let active = true;
+
+    const poll = async () => {
+      const response = await fetch(`/api/battle/rooms/${targetRoomId}`, {
+        cache: "no-store",
+        credentials: "include",
+      });
+
+      if (!active) {
+        return;
+      }
+
+      if (!response.ok) {
+        setBattleSidebarState(null);
+        return;
+      }
+
+      const payload = (await response.json()) as RoomResponse;
+      const me = payload.participants.find((item) => item.userId === memberId) ?? null;
+
+      setBattleSidebarState({
+        status: payload.status,
+        remainingTime: formatRemainingTime(payload.timerEnd),
+        participants: payload.participants,
+        myStatus: me?.status ?? null,
+        myUserId: memberId,
+      });
+    };
+
+    void poll();
+
+    const intervalId = window.setInterval(() => {
+      void poll();
+    }, 1000);
+
+    return () => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
+  }, [pathname, session.authenticated, session.member]);
 
   useEffect(() => {
     let active = true;
@@ -267,7 +352,8 @@ export default function IdeShell({
     pathname === "/signup" ||
     pathname === "/login" ||
     pathname === "/problems" ||
-    pathname === "/mypage";
+    pathname === "/mypage" ||
+    pathname.startsWith("/battle/rooms/");
 
   return (
     <SessionContext.Provider value={{ session, sessionLoaded, refreshSession, applySession }}>
@@ -294,6 +380,7 @@ export default function IdeShell({
             isProfilePanelOpen={isProfilePanelOpen}
             onToggleProfilePanel={() => setIsProfilePanelOpen((current) => !current)}
             session={session}
+            battleSidebarState={battleSidebarState}
             previewPlayedCount={previewPlayedCount}
             previewSolvedCount={previewSolvedCount}
             previewWinRate={previewWinRate}

--- a/src/features/login/screen.tsx
+++ b/src/features/login/screen.tsx
@@ -60,10 +60,10 @@ export default function LoginScreen() {
 
   return (
     <form onSubmit={handleSubmit} className="h-full min-h-0">
-      <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
-        <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
-          <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-            <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+      <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
               <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
                 <rect
                   x="3.4"
@@ -84,23 +84,23 @@ export default function LoginScreen() {
               </svg>
             </span>
             <span>login-request.json</span>
-            <span className="text-zinc-500">×</span>
-            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+            <span className="text-app-dim">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
           </div>
         </div>
 
-        <div className="flex-1 overflow-auto bg-[#1e1f22]">
+        <div className="flex-1 overflow-auto bg-app-base">
           <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
             <div className="mb-6">
-              <h1 className="text-xl font-semibold text-zinc-100">로그인</h1>
-              <p className="mt-1 text-sm text-zinc-400">
+              <h1 className="text-xl font-semibold text-app-primary">로그인</h1>
+              <p className="mt-1 text-sm text-app-muted">
                 이메일과 비밀번호를 입력해 계정에 로그인합니다.
               </p>
             </div>
 
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="space-y-2 sm:col-span-2">
-                <span className="text-sm font-medium text-zinc-200">이메일</span>
+                <span className="text-sm font-medium text-app-primary">이메일</span>
                 <input
                   type="email"
                   value={form.email}
@@ -108,13 +108,13 @@ export default function LoginScreen() {
                     setForm((current) => ({ ...current, email: event.target.value }))
                   }
                   placeholder="duel@example.com"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
               </label>
 
               <label className="space-y-2 sm:col-span-2">
-                <span className="text-sm font-medium text-zinc-200">비밀번호</span>
+                <span className="text-sm font-medium text-app-primary">비밀번호</span>
                 <input
                   type="password"
                   value={form.password}
@@ -122,7 +122,7 @@ export default function LoginScreen() {
                     setForm((current) => ({ ...current, password: event.target.value }))
                   }
                   placeholder="비밀번호를 입력하세요"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
               </label>
@@ -131,8 +131,8 @@ export default function LoginScreen() {
             <div
               className={`mt-5 rounded-md border px-3 py-2 text-sm ${
                 error
-                  ? "border-rose-400/60 bg-rose-900/25 text-rose-200"
-                  : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                  ? "border-app-danger/60 bg-app-danger/20 text-app-danger"
+                  : "border-app-border bg-app-elevated text-app-secondary"
               }`}
             >
               {error ?? message}
@@ -141,16 +141,16 @@ export default function LoginScreen() {
             <button
               type="submit"
               disabled={isPending}
-              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:bg-app-elevated disabled:text-app-secondary"
             >
               {isPending ? "로그인 중..." : "로그인"}
             </button>
 
-            <div className="mt-3 text-sm text-zinc-400">
+            <div className="mt-3 text-sm text-app-muted">
               아직 계정이 없다면{" "}
               <Link
                 href="/signup"
-                className="font-medium text-violet-300 transition hover:text-violet-200"
+                className="font-medium text-app-accent-soft transition hover:text-app-primary"
               >
                 회원가입
               </Link>

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -48,60 +48,60 @@ function formatScoreDelta(scoreDelta: number) {
 
 function toneForScore(scoreDelta: number) {
   if (scoreDelta > 0) {
-    return "text-emerald-300";
+    return "text-app-success";
   }
 
   if (scoreDelta < 0) {
-    return "text-rose-300";
+    return "text-app-danger";
   }
 
-  return "text-zinc-300";
+  return "text-app-secondary";
 }
 
 function ResultCard({ item }: { item: MyBattleResultItem }) {
   return (
     <Link
       href={`/battle/results/${item.roomId}`}
-      className="block rounded-md border border-zinc-700 bg-[#2b2d30] p-4 transition hover:bg-zinc-700/35"
+      className="block rounded-md border border-app-border bg-app-elevated p-4 transition hover:bg-app-elevated/90"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-app-dim">
             roomId {item.roomId} · problemId {item.problemId}
           </p>
-          <h3 className="mt-1 text-base font-semibold text-zinc-100">{item.problemTitle}</h3>
-          <p className="mt-1 text-xs text-zinc-400">{formatDateTime(item.playedAt)} 플레이</p>
+          <h3 className="mt-1 text-base font-semibold text-app-primary">{item.problemTitle}</h3>
+          <p className="mt-1 text-xs text-app-muted">{formatDateTime(item.playedAt)} 플레이</p>
         </div>
         <div className="flex items-center gap-2 text-xs">
           <span
             className={`inline-flex h-6 items-center rounded-full border px-2 font-semibold ${
               item.solved
-                ? "border-emerald-400/60 bg-emerald-900/30 text-emerald-200"
-                : "border-amber-400/60 bg-amber-900/30 text-amber-200"
+                ? "border-app-success/60 bg-app-success/20 text-app-success"
+                : "border-app-warn/60 bg-app-warn/20 text-app-warn"
             }`}
           >
             {item.solved ? "성공" : "미해결"}
           </span>
-          <span className="inline-flex h-6 items-center rounded-full border border-zinc-600 bg-[#1f2128] px-2 font-semibold text-zinc-200">
+          <span className="inline-flex h-6 items-center rounded-full border border-app-border-strong bg-app-base px-2 font-semibold text-app-primary">
             {formatRank(item.finalRank)}
           </span>
         </div>
       </div>
 
       <div className="mt-4 grid gap-2 text-sm sm:grid-cols-3">
-        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
-          <p className="text-xs text-zinc-500">최종 순위</p>
-          <p className="mt-1 font-semibold text-zinc-100">{formatRank(item.finalRank)}</p>
+        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+          <p className="text-xs text-app-dim">최종 순위</p>
+          <p className="mt-1 font-semibold text-app-primary">{formatRank(item.finalRank)}</p>
         </div>
-        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
-          <p className="text-xs text-zinc-500">점수 변화</p>
+        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+          <p className="text-xs text-app-dim">점수 변화</p>
           <p className={`mt-1 font-semibold ${toneForScore(item.scoreDelta)}`}>
             {formatScoreDelta(item.scoreDelta)}
           </p>
         </div>
-        <div className="rounded-md border border-zinc-700 bg-[#1f2128] px-3 py-2">
-          <p className="text-xs text-zinc-500">정답 처리 시각</p>
-          <p className="mt-1 font-medium text-zinc-100">
+        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+          <p className="text-xs text-app-dim">정답 처리 시각</p>
+          <p className="mt-1 font-medium text-app-primary">
             {item.finishTime ? formatDateTime(item.finishTime) : "기록 없음"}
           </p>
         </div>
@@ -116,15 +116,15 @@ function LoadingRows() {
       {Array.from({ length: 3 }).map((_, index) => (
         <div
           key={index}
-          className="animate-pulse rounded-md border border-zinc-700 bg-[#2b2d30] p-4"
+          className="animate-pulse rounded-md border border-app-border bg-app-elevated p-4"
         >
-          <div className="h-3 w-36 rounded bg-zinc-600" />
-          <div className="mt-3 h-4 w-2/3 rounded bg-zinc-600" />
-          <div className="mt-1 h-3 w-40 rounded bg-zinc-700" />
+          <div className="h-3 w-36 rounded bg-app-elevated" />
+          <div className="mt-3 h-4 w-2/3 rounded bg-app-elevated" />
+          <div className="mt-1 h-3 w-40 rounded bg-app-elevated" />
           <div className="mt-4 grid gap-2 sm:grid-cols-3">
-            <div className="h-14 rounded-md bg-zinc-700" />
-            <div className="h-14 rounded-md bg-zinc-700" />
-            <div className="h-14 rounded-md bg-zinc-700" />
+            <div className="h-14 rounded-md bg-app-elevated" />
+            <div className="h-14 rounded-md bg-app-elevated" />
+            <div className="h-14 rounded-md bg-app-elevated" />
           </div>
         </div>
       ))}
@@ -230,10 +230,10 @@ export default function MyPageScreen() {
   const currentPage = pageInfo.totalPages > 0 ? pageInfo.page + 1 : 0;
 
   return (
-    <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
-      <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
-        <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-          <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+    <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+        <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+          <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
             <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
               <path
                 d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
@@ -245,22 +245,22 @@ export default function MyPageScreen() {
             </svg>
           </span>
           <span>my-page.json</span>
-          <span className="text-zinc-500">×</span>
-          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+          <span className="text-app-dim">×</span>
+          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto bg-[#1e1f22]">
+      <div className="flex-1 overflow-auto bg-app-base">
         <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
-          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-zinc-700/70 pb-3">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-app-border/70 pb-3">
             <div>
-              <h1 className="text-xl font-semibold text-zinc-100">마이페이지</h1>
-              <p className="mt-1 text-sm text-zinc-400">
+              <h1 className="text-xl font-semibold text-app-primary">마이페이지</h1>
+              <p className="mt-1 text-sm text-app-muted">
                 내 계정 정보와 최근 배틀 전적을 확인합니다.
               </p>
             </div>
             {session.authenticated ? (
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-app-dim">
                 {pageInfo.totalElements > 0
                   ? `총 ${pageInfo.totalElements}개 · ${currentPage}/${pageInfo.totalPages} 페이지`
                   : "전적 데이터 준비 중"}
@@ -269,18 +269,18 @@ export default function MyPageScreen() {
           </div>
 
           {!session.authenticated ? (
-            <div className="space-y-4 rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4">
-              <p className="text-sm text-zinc-300">{message}</p>
+            <div className="space-y-4 rounded-md border border-app-border bg-app-elevated px-4 py-4">
+              <p className="text-sm text-app-secondary">{message}</p>
               <div className="flex flex-wrap gap-2">
                 <Link
                   href="/login?next=/mypage"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover"
                 >
                   로그인
                 </Link>
                 <Link
                   href="/signup"
-                  className="inline-flex h-10 items-center justify-center rounded-md border border-zinc-700 bg-[#1e1f22] px-4 text-sm font-medium text-zinc-200 transition hover:bg-zinc-700/30"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-app-border bg-app-base px-4 text-sm font-medium text-app-primary transition hover:bg-app-elevated/90"
                 >
                   회원가입
                 </Link>
@@ -289,38 +289,38 @@ export default function MyPageScreen() {
           ) : (
             <div className="space-y-5">
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
-                  <p className="text-xs text-zinc-500">닉네임</p>
-                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">닉네임</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
                     {session.member?.nickname ?? "-"}
                   </p>
                 </div>
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
-                  <p className="text-xs text-zinc-500">이메일</p>
-                  <p className="mt-1 truncate text-base font-semibold text-zinc-100">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">이메일</p>
+                  <p className="mt-1 truncate text-base font-semibold text-app-primary">
                     {session.member?.email ?? "-"}
                   </p>
                 </div>
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
-                  <p className="text-xs text-zinc-500">역할</p>
-                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">역할</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
                     {formatRoleLabel(session.member?.role)}
                   </p>
                 </div>
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2">
-                  <p className="text-xs text-zinc-500">해결 / 전체</p>
-                  <p className="mt-1 text-base font-semibold text-zinc-100">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">해결 / 전체</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
                     {solvedCount} / {loadedCount}
                   </p>
                 </div>
               </div>
 
               {error ? (
-                <div className="rounded-md border border-rose-400/60 bg-rose-900/25 px-3 py-2 text-sm text-rose-200">
+                <div className="rounded-md border border-app-danger/60 bg-app-danger/20 px-3 py-2 text-sm text-app-danger">
                   {error}
                 </div>
               ) : (
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-3 py-2 text-sm text-zinc-300">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2 text-sm text-app-secondary">
                   {message}
                 </div>
               )}
@@ -328,7 +328,7 @@ export default function MyPageScreen() {
               {isLoading ? (
                 <LoadingRows />
               ) : battleResults.length === 0 ? (
-                <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-6 text-center text-sm text-zinc-400">
+                <div className="rounded-md border border-app-border bg-app-elevated px-4 py-6 text-center text-sm text-app-muted">
                   아직 전적이 없습니다. 배틀을 완료하면 이곳에서 확인할 수 있습니다.
                 </div>
               ) : (
@@ -341,7 +341,7 @@ export default function MyPageScreen() {
 
               {!isLoading && battleResults.length > 0 ? (
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <p className="text-sm text-zinc-400">
+                  <p className="text-sm text-app-muted">
                     {loadedCount}개 로드됨 / 전체 {pageInfo.totalElements}개
                   </p>
                   {pageInfo.hasNext ? (
@@ -349,12 +349,12 @@ export default function MyPageScreen() {
                       type="button"
                       onClick={handleLoadMore}
                       disabled={isLoadingMore}
-                      className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+                      className="inline-flex h-10 items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:bg-app-elevated disabled:text-app-secondary"
                     >
                       {isLoadingMore ? "불러오는 중..." : "다음 전적 더 보기"}
                     </button>
                   ) : (
-                    <div className="inline-flex h-10 items-center rounded-md border border-zinc-700 bg-[#2b2d30] px-4 text-sm text-zinc-400">
+                    <div className="inline-flex h-10 items-center rounded-md border border-app-border bg-app-elevated px-4 text-sm text-app-muted">
                       마지막 페이지입니다.
                     </div>
                   )}

--- a/src/features/problem-solo/code-editor.tsx
+++ b/src/features/problem-solo/code-editor.tsx
@@ -8,6 +8,12 @@ interface SoloCodeEditorProps {
   onLanguageChange: (nextLanguage: string) => void;
   value: string;
   onChange: (nextValue: string) => void;
+  onRun?: () => void;
+  onSubmit?: () => void;
+  runDisabled?: boolean;
+  submitDisabled?: boolean;
+  runLabel?: string;
+  submitLabel?: string;
   height?: string;
   className?: string;
 }
@@ -44,6 +50,12 @@ export default function SoloCodeEditor({
   onLanguageChange,
   value,
   onChange,
+  onRun,
+  onSubmit,
+  runDisabled = false,
+  submitDisabled = false,
+  runLabel = "Run",
+  submitLabel = "Submit",
   height = "26rem",
   className = "",
 }: SoloCodeEditorProps) {
@@ -69,6 +81,24 @@ export default function SoloCodeEditor({
           <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-zinc-400">
             ▼
           </span>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={runDisabled || !onRun}
+            className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs font-semibold text-zinc-100 transition hover:border-zinc-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:text-zinc-500"
+          >
+            {runLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={submitDisabled || !onSubmit}
+            className="rounded-md border border-zinc-200 bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-900 transition hover:bg-white disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-800 disabled:text-zinc-500"
+          >
+            {submitLabel}
+          </button>
         </div>
       </div>
       <div className="min-h-0 flex-1">

--- a/src/features/problem-solo/code-editor.tsx
+++ b/src/features/problem-solo/code-editor.tsx
@@ -61,16 +61,16 @@ export default function SoloCodeEditor({
 }: SoloCodeEditorProps) {
   return (
     <div
-      className={`flex min-h-0 flex-col overflow-hidden rounded-2xl border border-zinc-700 bg-zinc-950 ${className}`.trim()}
+      className={`flex min-h-0 flex-col overflow-hidden rounded-2xl border border-app-border bg-app-base ${className}`.trim()}
     >
-      <div className="flex h-12 items-center gap-3 border-b border-zinc-700 bg-zinc-900 px-4">
-        <span className="font-mono text-lg font-semibold text-emerald-400">&lt;/&gt;</span>
-        <span className="ml-2 text-sm font-semibold text-zinc-100">Code</span>
+      <div className="flex h-12 items-center gap-3 border-b border-app-border bg-app-base px-4">
+        <span className="font-mono text-lg font-semibold text-app-success">&lt;/&gt;</span>
+        <span className="ml-2 text-sm font-semibold text-app-primary">Code</span>
         <div className="relative ml-1">
           <select
             value={language}
             onChange={(event) => onLanguageChange(event.target.value)}
-            className="h-8 min-w-[7.5rem] appearance-none rounded-md border border-zinc-700 bg-zinc-900 px-2 pr-7 text-sm text-zinc-100 outline-none transition focus:border-zinc-500"
+            className="h-8 min-w-[7.5rem] appearance-none rounded-md border border-app-border bg-app-base px-2 pr-7 text-sm text-app-primary outline-none transition focus:border-app-border-strong"
           >
             {languages.map((item) => (
               <option key={item} value={item}>
@@ -78,7 +78,7 @@ export default function SoloCodeEditor({
               </option>
             ))}
           </select>
-          <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-zinc-400">
+          <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-app-muted">
             ▼
           </span>
         </div>
@@ -87,7 +87,7 @@ export default function SoloCodeEditor({
             type="button"
             onClick={onRun}
             disabled={runDisabled || !onRun}
-            className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs font-semibold text-zinc-100 transition hover:border-zinc-400 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:text-zinc-500"
+            className="rounded-md border border-app-border-strong bg-app-base px-2.5 py-1 text-xs font-semibold text-app-primary transition hover:border-app-border-strong disabled:cursor-not-allowed disabled:border-app-border disabled:text-app-dim"
           >
             {runLabel}
           </button>
@@ -95,7 +95,7 @@ export default function SoloCodeEditor({
             type="button"
             onClick={onSubmit}
             disabled={submitDisabled || !onSubmit}
-            className="rounded-md border border-zinc-200 bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-900 transition hover:bg-white disabled:cursor-not-allowed disabled:border-zinc-700 disabled:bg-zinc-800 disabled:text-zinc-500"
+            className="rounded-md border border-app-border bg-app-elevated px-2.5 py-1 text-xs font-semibold text-app-primary transition hover:bg-app-surface disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim"
           >
             {submitLabel}
           </button>
@@ -112,7 +112,7 @@ export default function SoloCodeEditor({
           options={editorOptions}
           loading={
             <div
-              className="flex items-center justify-center text-sm text-zinc-300"
+              className="flex items-center justify-center text-sm text-app-secondary"
               style={{ height }}
             >
               에디터를 불러오는 중입니다.

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -42,13 +42,13 @@ const defaultCodeByLanguage: Record<string, string> = {
 };
 
 const fallbackLanguages = ["python3", "java", "javascript"];
-const MIN_LEFT_RATIO = 22;
+const MIN_LEFT_RATIO = 0;
 const MAX_LEFT_RATIO = 78;
 const MIN_TOP_RATIO = 24;
-const MAX_TOP_RATIO = 76;
-const LEFT_RATIO_SNAP_POINTS = [22, 32, 50, 68, 78];
-const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76];
-const SPLIT_SNAP_GAP = 2;
+const MAX_TOP_RATIO = 100;
+const LEFT_RATIO_SNAP_POINTS = [0, 22, 32, 50, 68, 78];
+const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76, 92, 100];
+const SPLIT_SNAP_GAP = 4;
 
 interface SoloCaseRunResult {
   status: "pending" | "done" | "error";
@@ -865,41 +865,96 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   const runActionDisabled = runTargetCaseIndex === null || runningCaseIndex !== null;
   const runActionLabel = runningCaseIndex !== null ? "Running..." : "Run";
   const submitActionLabel = isSubmitting ? "Submitting..." : "Submit";
+  const isLeftPaneCollapsed = leftPaneRatio <= 8;
+  const isTestcaseCollapsed = rightTopPaneRatio >= 96;
 
   return (
-    <div className="space-y-6">
-      <div className="hidden h-[calc(100dvh-10.5rem)] min-h-0 overflow-hidden lg:block">
+    <div className="h-full space-y-6 lg:space-y-0">
+      <div className="hidden h-full min-h-0 overflow-hidden lg:block">
         <div ref={splitContainerRef} className="flex h-full min-h-0">
-          <div className="h-full min-w-0" style={{ width: `${leftPaneRatio}%` }}>
-            <Panel
-              title="문제 상세"
-              className="flex h-full min-h-0 flex-col"
-            >
-              <div className="space-y-4 min-h-0 flex-1 overflow-y-auto pr-1">
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setLeftPanelTab("description")}
-                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                      leftPanelTab === "description"
-                        ? "border-zinc-900 bg-zinc-900 text-white"
-                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                    }`}
-                  >
-                    Description
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setLeftPanelTab("submission")}
-                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                      leftPanelTab === "submission"
-                        ? "border-zinc-900 bg-zinc-900 text-white"
-                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                    }`}
-                  >
-                    Submission
-                  </button>
+          <div
+            className={`h-full ${isLeftPaneCollapsed ? "" : "min-w-0"}`}
+            style={isLeftPaneCollapsed ? { width: "44px" } : { width: `${leftPaneRatio}%` }}
+          >
+            {isLeftPaneCollapsed ? (
+              <div
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-300 bg-white px-1 py-3"
+                onClick={(event) => {
+                  if (event.target === event.currentTarget) {
+                    setLeftPaneRatio(32);
+                  }
+                }}
+              >
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  onMouseDown={startVerticalResize}
+                  onDoubleClick={() => setLeftPaneRatio(50)}
+                  className="absolute inset-y-0 right-0 z-10 flex w-2 cursor-col-resize items-center justify-center"
+                >
+                  <div className="h-14 w-0.5 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
                 </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLeftPanelTab("description");
+                    setLeftPaneRatio(32);
+                  }}
+                  className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
+                    leftPanelTab === "description"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  }`}
+                  style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
+                >
+                  Description
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setLeftPanelTab("submission");
+                    setLeftPaneRatio(32);
+                  }}
+                  className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
+                    leftPanelTab === "submission"
+                      ? "border-zinc-900 bg-zinc-900 text-white"
+                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                  }`}
+                  style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
+                >
+                  Submission
+                </button>
+              </div>
+            ) : (
+              <Panel
+                title="문제 상세"
+                className="flex h-full min-h-0 flex-col"
+              >
+                <div className="space-y-4 min-h-0 flex-1 overflow-y-auto pr-1">
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("description")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "description"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Description
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setLeftPanelTab("submission")}
+                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                        leftPanelTab === "submission"
+                          ? "border-zinc-900 bg-zinc-900 text-white"
+                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                      }`}
+                    >
+                      Submission
+                    </button>
+                  </div>
 
                 {leftPanelTab === "description" ? (
                   <>
@@ -988,8 +1043,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     </div>
                   </div>
                 )}
-              </div>
-            </Panel>
+                </div>
+              </Panel>
+            )}
           </div>
 
           <div
@@ -1004,10 +1060,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
           <div
             ref={rightColumnRef}
-            className="flex h-full min-w-0 flex-col"
-            style={{ width: `${100 - leftPaneRatio}%` }}
+            className={`relative flex h-full min-w-0 flex-col overflow-hidden ${isLeftPaneCollapsed ? "flex-1" : ""}`}
+            style={isLeftPaneCollapsed ? undefined : { width: `${100 - leftPaneRatio}%` }}
           >
-            <div className="min-h-0" style={{ height: `${rightTopPaneRatio}%` }}>
+            <div
+              className={`min-h-0 ${isTestcaseCollapsed ? "pb-[3.25rem]" : ""}`}
+              style={isTestcaseCollapsed ? { height: "100%" } : { height: `${rightTopPaneRatio}%` }}
+            >
               <SoloCodeEditor
                 languages={languages}
                 language={language}
@@ -1034,19 +1093,45 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               aria-orientation="horizontal"
               onMouseDown={startHorizontalResize}
               onDoubleClick={() => setRightTopPaneRatio(50)}
-              className="group my-1 flex h-3 cursor-row-resize items-center justify-center"
+              className={`group flex cursor-row-resize items-center justify-center transition-all ${
+                isTestcaseCollapsed
+                  ? "pointer-events-none my-0 h-0 opacity-0"
+                  : "my-1 h-3 opacity-100"
+              }`}
             >
               <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
             </div>
 
-            <div className="min-h-0" style={{ height: `${100 - rightTopPaneRatio}%` }}>
-              <Panel
-                title="TestCase"
-                className="flex h-full min-h-0 flex-col"
-              >
-                <div className="space-y-4 min-h-0 flex-1 overflow-y-auto">
-                  {sampleCases.length > 0 ? (
-                    <>
+            <div
+              className={isTestcaseCollapsed ? "absolute inset-x-0 bottom-0 z-10 h-10" : "min-h-0"}
+              style={isTestcaseCollapsed ? undefined : { height: `${100 - rightTopPaneRatio}%` }}
+            >
+              {isTestcaseCollapsed ? (
+                <div
+                  role="separator"
+                  aria-orientation="horizontal"
+                  onMouseDown={startHorizontalResize}
+                  onDoubleClick={() => setRightTopPaneRatio(50)}
+                  onClick={() => {
+                    if (isTestcaseCollapsed) {
+                      setRightTopPaneRatio(76);
+                    }
+                  }}
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-300 bg-white px-4"
+                >
+                  <div className="pointer-events-none absolute inset-x-0 top-0 flex h-2 items-start justify-center">
+                    <div className="mt-1 h-0.5 w-14 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  </div>
+                  <p className="text-base font-semibold text-zinc-900">TestCase</p>
+                </div>
+              ) : (
+                <Panel
+                  title="TestCase"
+                  className="flex h-full min-h-0 flex-col"
+                >
+                  <div className="space-y-4 min-h-0 flex-1 overflow-y-auto">
+                    {sampleCases.length > 0 ? (
+                      <>
                       <div className="flex flex-wrap items-center justify-between gap-3">
                         <div className="flex flex-wrap gap-2">
                           {sampleCases.map((_, index) => {
@@ -1193,14 +1278,15 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           </div>
                         </div>
                       ) : null}
-                    </>
-                  ) : (
-                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
-                      실행 가능한 샘플 케이스가 없습니다.
-                    </div>
-                  )}
-                </div>
-              </Panel>
+                      </>
+                    ) : (
+                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                        실행 가능한 샘플 케이스가 없습니다.
+                      </div>
+                    )}
+                  </div>
+                </Panel>
+              )}
             </div>
           </div>
         </div>

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -32,7 +32,7 @@ import {
 const SoloCodeEditor = dynamic(() => import("@/features/problem-solo/code-editor"), {
   ssr: false,
   loading: () => (
-    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-700 bg-[#171c26] text-sm text-zinc-300">
+    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-app-border bg-app-surface text-sm text-app-secondary">
       에디터를 준비하는 중입니다.
     </div>
   ),
@@ -864,7 +864,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   if (!sessionLoaded) {
     return (
       <Panel variant="dark" title="세션 확인" description="인증 상태를 확인하는 중입니다.">
-        <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
+        <p className="text-sm text-app-muted">잠시만 기다려주세요.</p>
       </Panel>
     );
   }
@@ -872,8 +872,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   if (!session.authenticated) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-zinc-700 bg-[#171c26] px-4 py-3">
-          <p className="text-sm font-medium text-zinc-300">
+        <div className="flex items-center justify-between rounded-2xl border border-app-border bg-app-surface px-4 py-3">
+          <p className="text-sm font-medium text-app-secondary">
             개인 풀이는 로그인 후 이용할 수 있습니다.
           </p>
           <StatusPill tone="warn" variant="dark">로그인 필요</StatusPill>
@@ -882,13 +882,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/problems/${problemId}`)}`}
-              className="rounded-2xl border border-violet-400/40 bg-gradient-to-r from-violet-600 to-violet-500 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl border border-app-accent/40 bg-gradient-to-r from-app-accent to-app-accent-hover px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/problems"
-              className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm font-medium text-zinc-200"
+              className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm font-medium text-app-primary"
             >
               문제 목록으로 돌아가기
             </Link>
@@ -902,21 +902,21 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     if (isProblemLoading) {
       return (
         <Panel variant="dark" title="문제 로딩" description="문제 상세를 불러오는 중입니다.">
-          <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
+          <p className="text-sm text-app-muted">잠시만 기다려주세요.</p>
         </Panel>
       );
     }
 
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
-          <p className="text-sm font-medium text-rose-200">
+        <div className="flex items-center justify-between rounded-2xl border border-app-danger/35 bg-app-danger/10 px-4 py-3">
+          <p className="text-sm font-medium text-app-danger">
             문제 정보를 가져오지 못했습니다.
           </p>
           <StatusPill tone="danger" variant="dark">Load failed</StatusPill>
         </div>
         <Panel variant="dark" title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-300">
+          <p className="text-sm leading-7 text-app-secondary">
             {problemError ?? "문제 상세 응답이 없습니다."}
           </p>
         </Panel>
@@ -939,24 +939,24 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     submitCode === "JUDGING";
   const submitHasResult = submitState.status !== "idle";
   const submitCardClass = submitIsAccepted
-    ? "border-emerald-500/30 bg-emerald-500/10"
+    ? "border-app-success/30 bg-app-success/10"
     : submitIsWaiting
-      ? "border-amber-500/30 bg-amber-500/10"
+      ? "border-app-warn/30 bg-app-warn/10"
       : submitState.status === "idle"
-        ? "border-zinc-700 bg-[#1b2130]"
-        : "border-rose-500/30 bg-rose-500/10";
+        ? "border-app-border bg-app-elevated"
+        : "border-app-danger/35 bg-app-danger/10";
   const submitHeadlineClass = submitIsAccepted
-    ? "text-emerald-300"
+    ? "text-app-success"
     : submitIsWaiting
-      ? "text-amber-300"
+      ? "text-app-warn"
       : submitState.status === "idle"
-        ? "text-zinc-200"
-        : "text-rose-300";
+        ? "text-app-primary"
+        : "text-app-danger";
   const submitBadgeClass = submitIsAccepted
-    ? "bg-emerald-500/15 text-emerald-300"
+    ? "bg-app-success/15 text-app-success"
     : submitIsWaiting
-      ? "bg-amber-500/15 text-amber-300"
-      : "bg-rose-500/15 text-rose-300";
+      ? "bg-app-warn/15 text-app-warn"
+      : "bg-app-danger/15 text-app-danger";
   const submitProgressText =
     submitState.passedCount !== null && submitState.totalCount !== null
       ? `${submitState.passedCount}/${submitState.totalCount} testcases passed`
@@ -978,7 +978,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           >
             {isLeftPaneCollapsed ? (
               <div
-                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-700 bg-[#171c26] px-1 py-3"
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-app-border bg-app-surface px-1 py-3"
                 onClick={(event) => {
                   if (event.target === event.currentTarget) {
                     setLeftPaneRatio(32);
@@ -993,9 +993,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   className="absolute inset-y-0 -right-1 z-10 flex w-4 cursor-col-resize items-center justify-center"
                 >
                   <div className="relative flex h-full w-full items-center justify-center">
-                    <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
-                      <div className="h-8 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+                    <div className="h-full w-px rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-app-border-strong bg-app-surface shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-app-accent/60 group-hover:bg-app-accent/15">
+                      <div className="h-8 w-0.5 rounded-full bg-app-border-strong transition group-hover:bg-app-accent-soft" />
                     </div>
                   </div>
                 </div>
@@ -1007,8 +1007,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "description"
-                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                      ? "border-app-border-strong bg-app-elevated text-app-primary"
+                      : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1022,8 +1022,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "submission"
-                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                      ? "border-app-border-strong bg-app-elevated text-app-primary"
+                      : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1043,8 +1043,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       onClick={() => setLeftPanelTab("description")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "description"
-                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                          ? "border-app-border-strong bg-app-elevated text-app-primary"
+                          : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                       }`}
                     >
                       Description
@@ -1054,8 +1054,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       onClick={() => setLeftPanelTab("submission")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "submission"
-                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                          ? "border-app-border-strong bg-app-elevated text-app-primary"
+                          : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                       }`}
                     >
                       Submission
@@ -1064,11 +1064,11 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
                 {leftPanelTab === "description" ? (
                   <>
-                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Solo
                       </p>
-                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
+                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-app-primary">
                         {problem.problemId}. {problem.title}
                       </h1>
                       <div className="mt-3 flex flex-wrap gap-2">
@@ -1084,28 +1084,28 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                         { label: "memoryLimitMb", value: problem.memoryLimitMb },
                       ]}
                     />
-                    <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                    <div className="space-y-4 rounded-2xl border border-app-border bg-app-elevated p-4">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Content
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {problem.content}
                         </MathText>
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {problem.inputFormat}
                         </MathText>
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {problem.outputFormat}
                         </MathText>
                       </div>
@@ -1114,7 +1114,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 ) : (
                   submitHasResult ? (
                     <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Submit Result
                       </p>
                       <div className="flex flex-wrap items-start gap-3">
@@ -1122,7 +1122,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           {submitHeadline}
                         </p>
                         {submitProgressText ? (
-                          <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
+                          <p className="pt-1 text-sm text-app-muted">{submitProgressText}</p>
                         ) : null}
                         <div className="ml-auto flex flex-col items-end gap-1 text-right">
                           {submitCode ? (
@@ -1130,27 +1130,27 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                               {submitCode}
                             </span>
                           ) : null}
-                          <p className="text-xs text-zinc-400">language: {language}</p>
+                          <p className="text-xs text-app-muted">language: {language}</p>
                         </div>
                       </div>
 
                       {submitState.message ? (
-                        <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 px-3 py-2 text-sm text-zinc-300">
+                        <div className="rounded-lg border border-app-border bg-app-base/80 px-3 py-2 text-sm text-app-secondary">
                           {submitState.message}
                         </div>
                       ) : null}
 
-                      <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      <div className="rounded-xl border border-app-border bg-app-base/80 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Current Submission
                         </p>
-                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                           {code}
                         </pre>
                       </div>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                    <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                       아직 제출 결과가 없습니다.
                     </div>
                   )
@@ -1170,9 +1170,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
             }`}
           >
             <div className="relative flex h-full w-full items-center justify-center">
-              <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
-                <div className="h-10 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+              <div className="h-full w-px rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-app-border-strong bg-app-surface shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-app-accent/60 group-hover:bg-app-accent/15">
+                <div className="h-10 w-0.5 rounded-full bg-app-border-strong transition group-hover:bg-app-accent-soft" />
               </div>
             </div>
           </div>
@@ -1219,9 +1219,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               }`}
             >
               <div className="relative flex h-full w-full items-center justify-center">
-                <div className="h-px w-full rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
-                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
-                  <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                <div className="h-px w-full rounded bg-app-elevated transition group-hover:bg-app-accent/80" />
+                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-app-border bg-app-surface/90 transition group-hover:border-app-accent/50 group-hover:bg-app-accent/10">
+                  <div className="h-0.5 w-6 rounded-full bg-app-elevated transition group-hover:bg-app-accent-soft" />
                 </div>
               </div>
             </div>
@@ -1241,20 +1241,20 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       setRightTopPaneRatio(76);
                     }
                   }}
-                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-700 bg-[#171c26] px-4"
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-app-border bg-app-surface px-4"
                 >
                   <div className="pointer-events-none absolute inset-x-0 top-1.5 flex h-2.5 items-center justify-center">
-                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
-                      <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-app-border bg-app-surface/90 transition group-hover:border-app-accent/50 group-hover:bg-app-accent/10">
+                      <div className="h-0.5 w-6 rounded-full bg-app-elevated transition group-hover:bg-app-accent-soft" />
                     </div>
                   </div>
-                  <p className="text-base font-semibold text-zinc-100">TestCase</p>
+                  <p className="text-base font-semibold text-app-primary">TestCase</p>
                 </div>
               ) : (
-                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
                   <div className="mb-4 flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
-                    <p className="shrink-0 text-xs font-medium text-zinc-500">
+                    <h2 className="text-lg font-semibold text-app-primary">TestCase</h2>
+                    <p className="shrink-0 text-xs font-medium text-app-dim">
                       {TESTCASE_SHORTCUT_HINT}
                     </p>
                   </div>
@@ -1268,13 +1268,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                             const caseResult = caseRunResults[index];
                             const badgeState = getCaseBadgeState(caseResult);
                             const isSelected = selectedCaseIndex === index;
-                            const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
-                            const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
-                            const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
-                            const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
+                            const idleClass = "border-app-border bg-app-elevated text-app-secondary hover:bg-app-elevated";
+                            const passClass = "border-app-success/30 bg-app-success/10 text-app-success hover:bg-app-success/15";
+                            const failClass = "border-app-danger/35 bg-app-danger/10 text-app-danger hover:bg-app-danger/15";
+                            const pendingClass = "border-app-warn/30 bg-app-warn/10 text-app-warn hover:bg-app-warn/15";
 
                             const colorClass = isSelected
-                              ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                              ? "border-app-border-strong bg-app-elevated text-app-primary"
                               : badgeState?.tone === "pass"
                                 ? passClass
                                 : badgeState?.tone === "fail"
@@ -1295,10 +1295,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                   <span
                                     className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                       badgeState.tone === "pass"
-                                        ? "bg-emerald-500/15 text-emerald-200"
+                                        ? "bg-app-success/15 text-app-success"
                                         : badgeState.tone === "fail"
-                                          ? "bg-rose-500/15 text-rose-200"
-                                          : "bg-amber-500/15 text-amber-200"
+                                          ? "bg-app-danger/15 text-app-danger"
+                                          : "bg-app-warn/15 text-app-warn"
                                     }`}
                                   >
                                     {badgeState.label}
@@ -1313,47 +1313,47 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
                       {activeCase ? (
                         <div className="grid gap-3 lg:grid-cols-[1fr_0.95fr]">
-                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                          <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
                             <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                                 Input
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                              <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                                 {activeCase.input || "(empty)"}
                               </MathText>
                             </div>
                             <div>
-                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                                 Output
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                              <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                                 {activeCase.output || "(empty)"}
                               </MathText>
                             </div>
                           </div>
 
-                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
+                            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                               Run Result
                             </p>
                             <div
                               className={`rounded-xl border p-3 text-sm ${
                                 !activeCaseResult
-                                  ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
+                                  ? "border-app-border bg-app-base text-app-secondary"
                                   : activeCasePass
-                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-                                    : "border-rose-500/30 bg-rose-500/10 text-rose-200"
+                                    ? "border-app-success/30 bg-app-success/10 text-app-success"
+                                    : "border-app-danger/35 bg-app-danger/10 text-app-danger"
                               }`}
                             >
                               {runningCaseIndex === selectedCaseIndex ? (
-                                <p className="text-amber-300">실행 요청 중입니다...</p>
+                                <p className="text-app-warn">실행 요청 중입니다...</p>
                               ) : activeCaseResult ? (
                                 <div className="space-y-2">
                                   <p
                                     className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                       activeCasePass
-                                        ? "bg-emerald-500/15 text-emerald-200"
-                                        : "bg-rose-500/15 text-rose-200"
+                                        ? "bg-app-success/15 text-app-success"
+                                        : "bg-app-danger/15 text-app-danger"
                                     }`}
                                   >
                                     {activeCasePass
@@ -1363,42 +1363,42 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                         : normalizeVerdict(activeCaseResult.verdict)}
                                   </p>
                                   {activeCaseResult.stderr ? (
-                                    <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
-                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
+                                    <div className="rounded-lg border border-app-danger/35 bg-app-base/80 p-2">
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-danger">
                                         Error
                                       </p>
-                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
+                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-danger">
                                         {activeCaseResult.stderr}
                                       </pre>
                                     </div>
                                   ) : (
                                     <div className="grid gap-2">
-                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                      <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                           Output
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                           {activeCaseResult.output ?? "(empty)"}
                                         </pre>
                                       </div>
-                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                      <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                           Expected
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                           {activeCaseResult.expected ?? "(empty)"}
                                         </pre>
                                       </div>
                                     </div>
                                   )}
                                   {activeCaseResult.message ? (
-                                    <p className={activeCasePass ? "text-emerald-200" : "text-rose-200"}>
+                                    <p className={activeCasePass ? "text-app-success" : "text-app-danger"}>
                                       {activeCaseResult.message}
                                     </p>
                                   ) : null}
                                 </div>
                               ) : (
-                                <p className="text-zinc-400">
+                                <p className="text-app-muted">
                                   아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                                 </p>
                               )}
@@ -1408,7 +1408,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       ) : null}
                       </>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                      <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                         실행 가능한 샘플 케이스가 없습니다.
                       </div>
                     )}
@@ -1429,8 +1429,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 onClick={() => setLeftPanelTab("description")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "description"
-                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                    ? "border-app-border-strong bg-app-elevated text-app-primary"
+                    : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                 }`}
               >
                 Description
@@ -1440,8 +1440,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 onClick={() => setLeftPanelTab("submission")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "submission"
-                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
-                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
+                    ? "border-app-border-strong bg-app-elevated text-app-primary"
+                    : "border-app-border bg-app-elevated text-app-muted hover:bg-app-elevated hover:text-app-primary"
                 }`}
               >
                 Submission
@@ -1450,11 +1450,11 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
             {leftPanelTab === "description" ? (
               <>
-                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                     Solo
                   </p>
-                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
+                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-app-primary">
                     {problem.problemId}. {problem.title}
                   </h1>
                   <div className="mt-3 flex flex-wrap gap-2">
@@ -1470,28 +1470,28 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     { label: "memoryLimitMb", value: problem.memoryLimitMb },
                   ]}
                 />
-                <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                <div className="space-y-4 rounded-2xl border border-app-border bg-app-elevated p-4">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                       Content
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                    <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                       {problem.content}
                     </MathText>
                   </div>
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                       Input
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                    <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                       {problem.inputFormat}
                     </MathText>
                   </div>
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                       Output
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                    <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                       {problem.outputFormat}
                     </MathText>
                   </div>
@@ -1500,7 +1500,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
             ) : (
               submitHasResult ? (
                 <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                     Submit Result
                   </p>
                   <div className="flex flex-wrap items-start gap-3">
@@ -1508,7 +1508,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       {submitHeadline}
                     </p>
                     {submitProgressText ? (
-                      <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
+                      <p className="pt-1 text-sm text-app-muted">{submitProgressText}</p>
                     ) : null}
                     <div className="ml-auto flex flex-col items-end gap-1 text-right">
                       {submitCode ? (
@@ -1516,27 +1516,27 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           {submitCode}
                         </span>
                       ) : null}
-                      <p className="text-xs text-zinc-400">language: {language}</p>
+                      <p className="text-xs text-app-muted">language: {language}</p>
                     </div>
                   </div>
 
                   {submitState.message ? (
-                    <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 px-3 py-2 text-sm text-zinc-300">
+                    <div className="rounded-lg border border-app-border bg-app-base/80 px-3 py-2 text-sm text-app-secondary">
                       {submitState.message}
                     </div>
                   ) : null}
 
-                  <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  <div className="rounded-xl border border-app-border bg-app-base/80 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                       Current Submission
                     </p>
-                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                       {code}
                     </pre>
                   </div>
                 </div>
               ) : (
-                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+                <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                   아직 제출 결과가 없습니다.
                 </div>
               )
@@ -1562,10 +1562,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           submitLabel={submitActionLabel}
         />
 
-        <section className="rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+        <section className="rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
-            <p className="shrink-0 text-xs font-medium text-zinc-500">
+            <h2 className="text-lg font-semibold text-app-primary">TestCase</h2>
+            <p className="shrink-0 text-xs font-medium text-app-dim">
               {TESTCASE_SHORTCUT_HINT}
             </p>
           </div>
@@ -1579,13 +1579,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       const caseResult = caseRunResults[index];
                       const badgeState = getCaseBadgeState(caseResult);
                       const isSelected = selectedCaseIndex === index;
-                      const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
-                      const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
-                      const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
-                      const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
+                      const idleClass = "border-app-border bg-app-elevated text-app-secondary hover:bg-app-elevated";
+                      const passClass = "border-app-success/30 bg-app-success/10 text-app-success hover:bg-app-success/15";
+                      const failClass = "border-app-danger/35 bg-app-danger/10 text-app-danger hover:bg-app-danger/15";
+                      const pendingClass = "border-app-warn/30 bg-app-warn/10 text-app-warn hover:bg-app-warn/15";
 
                       const colorClass = isSelected
-                        ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                        ? "border-app-border-strong bg-app-elevated text-app-primary"
                         : badgeState?.tone === "pass"
                           ? passClass
                           : badgeState?.tone === "fail"
@@ -1606,10 +1606,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                             <span
                               className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                 badgeState.tone === "pass"
-                                  ? "bg-emerald-500/15 text-emerald-200"
+                                  ? "bg-app-success/15 text-app-success"
                                   : badgeState.tone === "fail"
-                                    ? "bg-rose-500/15 text-rose-200"
-                                    : "bg-amber-500/15 text-amber-200"
+                                    ? "bg-app-danger/15 text-app-danger"
+                                    : "bg-app-warn/15 text-app-warn"
                               }`}
                             >
                               {badgeState.label}
@@ -1623,46 +1623,46 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 </div>
                 {activeCase ? (
                   <div className="grid gap-3">
-                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
+                    <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {activeCase.input || "(empty)"}
                         </MathText>
                       </div>
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
+                        <MathText className="mt-2 block text-sm leading-7 text-app-secondary">
                           {activeCase.output || "(empty)"}
                         </MathText>
                       </div>
                     </div>
-                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                    <div className="space-y-3 rounded-2xl border border-app-border bg-app-elevated p-4">
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                         Run Result
                       </p>
                       <div
                         className={`rounded-xl border p-3 text-sm ${
                           !activeCaseResult
-                            ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
+                            ? "border-app-border bg-app-base text-app-secondary"
                             : activeCasePass
-                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-                              : "border-rose-500/30 bg-rose-500/10 text-rose-200"
+                              ? "border-app-success/30 bg-app-success/10 text-app-success"
+                              : "border-app-danger/35 bg-app-danger/10 text-app-danger"
                         }`}
                       >
                         {runningCaseIndex === selectedCaseIndex ? (
-                          <p className="text-amber-300">실행 요청 중입니다...</p>
+                          <p className="text-app-warn">실행 요청 중입니다...</p>
                         ) : activeCaseResult ? (
                           <div className="space-y-2">
                             <p
                               className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                 activeCasePass
-                                  ? "bg-emerald-500/15 text-emerald-200"
-                                  : "bg-rose-500/15 text-rose-200"
+                                  ? "bg-app-success/15 text-app-success"
+                                  : "bg-app-danger/15 text-app-danger"
                               }`}
                             >
                               {activeCasePass
@@ -1672,42 +1672,42 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                   : normalizeVerdict(activeCaseResult.verdict)}
                             </p>
                             {activeCaseResult.stderr ? (
-                              <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
+                              <div className="rounded-lg border border-app-danger/35 bg-app-base/80 p-2">
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-danger">
                                   Error
                                 </p>
-                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
+                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-danger">
                                   {activeCaseResult.stderr}
                                 </pre>
                               </div>
                             ) : (
                               <div className="grid gap-2">
-                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                     Output
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                     {activeCaseResult.output ?? "(empty)"}
                                   </pre>
                                 </div>
-                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
-                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                                <div className="rounded-lg border border-app-border bg-app-base/80 p-2">
+                                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-app-dim">
                                     Expected
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-app-primary">
                                     {activeCaseResult.expected ?? "(empty)"}
                                   </pre>
                                 </div>
                               </div>
                             )}
                             {activeCaseResult.message ? (
-                              <p className={activeCasePass ? "text-emerald-200" : "text-rose-200"}>
+                              <p className={activeCasePass ? "text-app-success" : "text-app-danger"}>
                                 {activeCaseResult.message}
                               </p>
                             ) : null}
                           </div>
                         ) : (
-                          <p className="text-zinc-400">
+                          <p className="text-app-muted">
                             아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                           </p>
                         )}
@@ -1717,7 +1717,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 ) : null}
               </>
             ) : (
-              <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
+              <div className="rounded-2xl border border-app-border bg-app-elevated px-4 py-3 text-sm text-app-muted">
                 실행 가능한 샘플 케이스가 없습니다.
               </div>
             )}

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -56,6 +56,7 @@ const SPLIT_SNAP_GAP = 4;
 const DEFAULT_LEFT_PANE_RATIO = 50;
 const DEFAULT_RIGHT_TOP_PANE_RATIO = 100;
 const SOLO_LAYOUT_STORAGE_KEY = "bracket:solo-editor-layout:v1";
+const TESTCASE_SHORTCUT_HINT = "⌘/Ctrl+Enter: Run · Shift+Enter: Submit";
 
 interface SoloCaseRunResult {
   status: "pending" | "done" | "error";
@@ -214,7 +215,7 @@ function getCaseBadgeState(result: SoloCaseRunResult | undefined): CaseBadgeStat
   }
 
   if (result.status === "pending") {
-    return { label: "RUN", tone: "pending" };
+    return { label: "RUNNING", tone: "pending" };
   }
 
   if (isPassVerdict(result.verdict)) {
@@ -226,6 +227,23 @@ function getCaseBadgeState(result: SoloCaseRunResult | undefined): CaseBadgeStat
   }
 
   return { label: normalizeVerdict(result.verdict) || "FAIL", tone: "fail" };
+}
+
+function createPendingCaseResults(
+  caseCount: number,
+  message: string,
+): Record<number, SoloCaseRunResult> {
+  const nextResults: Record<number, SoloCaseRunResult> = {};
+
+  Array.from({ length: caseCount }, (_, index) => index).forEach((index) => {
+    nextResults[index] = {
+      status: "pending",
+      verdict: "RUNNING",
+      message,
+    };
+  });
+
+  return nextResults;
 }
 
 function resolveLanguages(problem: ProblemDetailResponse | null) {
@@ -516,7 +534,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               }
 
               nextResults[index] = {
-                status: runResult.status === "AC" ? "done" : "error",
+                status: isPassVerdict(runResult.status) ? "done" : "error",
                 verdict: runResult.status,
                 message: runResult.stderr ? "실행 중 오류가 발생했습니다." : "",
                 output: runResult.actualOutput?.trim() || "(empty)",
@@ -556,16 +574,12 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       return;
     }
 
+    const caseCount = problem.sampleCases?.length ?? 0;
+    const runningMessage = "실행 요청을 전송했습니다. 결과를 기다리는 중입니다.";
+
     setSelectedCaseIndex(caseIndex);
     setRunningCaseIndex(caseIndex);
-    setCaseRunResults((prev) => ({
-      ...prev,
-      [caseIndex]: {
-        status: "pending",
-        verdict: "RUNNING",
-        message: "실행 요청을 전송했습니다. 결과를 기다리는 중입니다.",
-      },
-    }));
+    setCaseRunResults(createPendingCaseResults(caseCount, runningMessage));
 
     if (runTimeoutRef.current !== null) {
       window.clearTimeout(runTimeoutRef.current);
@@ -588,57 +602,71 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
       if (!response.ok) {
         const errorPayload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-        setCaseRunResults((prev) => ({
-          ...prev,
-          [caseIndex]: {
-            status: "error",
-            verdict: "REQUEST_FAILED",
-            message: errorPayload?.message ?? "실행 요청에 실패했습니다.",
-          },
-        }));
+        const failMessage = errorPayload?.message ?? "실행 요청에 실패했습니다.";
+        setCaseRunResults(() => {
+          const nextResults: Record<number, SoloCaseRunResult> = {};
+
+          Array.from({ length: caseCount }, (_, index) => index).forEach((index) => {
+            nextResults[index] = {
+              status: "error",
+              verdict: "REQUEST_FAILED",
+              message: failMessage,
+            };
+          });
+
+          return nextResults;
+        });
         setRunningCaseIndex((current) => (current === caseIndex ? null : current));
         return;
       }
 
       const runPayload = (await response.json().catch(() => null)) as SoloRunResponse | null;
-      setCaseRunResults((prev) => ({
-        ...prev,
-        [caseIndex]: {
-          status: "pending",
-          verdict: runPayload?.message ?? "RUNNING",
-          message: "실행이 접수되었습니다. WebSocket 결과를 기다립니다.",
-        },
-      }));
+      const acceptedMessage = runPayload?.message ?? "실행이 접수되었습니다. WebSocket 결과를 기다립니다.";
+      setCaseRunResults(createPendingCaseResults(caseCount, acceptedMessage));
 
       runTimeoutRef.current = window.setTimeout(() => {
         setCaseRunResults((prev) => {
-          const current = prev[caseIndex];
+          let hasPendingCase = false;
+          const nextResults = { ...prev };
 
-          if (!current || current.status !== "pending") {
-            return prev;
-          }
+          Array.from({ length: caseCount }, (_, index) => index).forEach((index) => {
+            const current = prev[index];
 
-          return {
-            ...prev,
-            [caseIndex]: {
+            if (!current || current.status !== "pending") {
+              return;
+            }
+
+            hasPendingCase = true;
+            nextResults[index] = {
               status: "error",
               verdict: "TIMEOUT",
               message: "결과 수신이 지연되고 있습니다. 다시 Run 해주세요.",
-            },
-          };
+            };
+          });
+
+          if (!hasPendingCase) {
+            return prev;
+          }
+
+          return nextResults;
         });
         setRunningCaseIndex((current) => (current === caseIndex ? null : current));
         runTimeoutRef.current = null;
       }, 15000);
     } catch {
-      setCaseRunResults((prev) => ({
-        ...prev,
-        [caseIndex]: {
-          status: "error",
-          verdict: "REQUEST_FAILED",
-          message: "실행 요청 중 네트워크 오류가 발생했습니다.",
-        },
-      }));
+      setCaseRunResults(() => {
+        const nextResults: Record<number, SoloCaseRunResult> = {};
+
+        Array.from({ length: caseCount }, (_, index) => index).forEach((index) => {
+          nextResults[index] = {
+            status: "error",
+            verdict: "REQUEST_FAILED",
+            message: "실행 요청 중 네트워크 오류가 발생했습니다.",
+          };
+        });
+
+        return nextResults;
+      });
       setRunningCaseIndex((current) => (current === caseIndex ? null : current));
     }
   }
@@ -1045,8 +1073,6 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     <DefinitionGrid
                       compact
                       items={[
-                        { label: "problemId", value: problem.problemId },
-                        { label: "difficulty", value: problem.difficulty },
                         { label: "timeLimitMs", value: problem.timeLimitMs },
                         { label: "memoryLimitMb", value: problem.memoryLimitMb },
                       ]}
@@ -1079,42 +1105,48 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     </div>
                   </>
                 ) : (
-                  <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                      Submit Result
-                    </p>
-                    <div className="flex flex-wrap items-start gap-3">
-                      <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
-                        {submitHeadline}
-                      </p>
-                      {submitProgressText ? (
-                        <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
-                      ) : null}
-                      <div className="ml-auto flex flex-col items-end gap-1 text-right">
-                        {submitHasResult && submitCode ? (
-                          <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
-                            {submitCode}
-                          </span>
-                        ) : null}
-                        <p className="text-xs text-zinc-600">language: {language}</p>
-                      </div>
-                    </div>
-
-                    {submitState.message ? (
-                      <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
-                        {submitState.message}
-                      </div>
-                    ) : null}
-
-                    <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                  submitHasResult ? (
+                    <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                        Current Submission
+                        Submit Result
                       </p>
-                      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
-                        {code}
-                      </pre>
+                      <div className="flex flex-wrap items-start gap-3">
+                        <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                          {submitHeadline}
+                        </p>
+                        {submitProgressText ? (
+                          <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                        ) : null}
+                        <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                          {submitCode ? (
+                            <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
+                              {submitCode}
+                            </span>
+                          ) : null}
+                          <p className="text-xs text-zinc-600">language: {language}</p>
+                        </div>
+                      </div>
+
+                      {submitState.message ? (
+                        <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
+                          {submitState.message}
+                        </div>
+                      ) : null}
+
+                      <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                          Current Submission
+                        </p>
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                          {code}
+                        </pre>
+                      </div>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      아직 제출 결과가 없습니다.
+                    </div>
+                  )
                 )}
                 </div>
               </Panel>
@@ -1198,10 +1230,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   <p className="text-base font-semibold text-zinc-900">TestCase</p>
                 </div>
               ) : (
-                <Panel
-                  title="TestCase"
-                  className="flex h-full min-h-0 flex-col"
-                >
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+                  <div className="mb-4 flex items-center justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+                    <p className="shrink-0 text-xs font-medium text-zinc-500">
+                      {TESTCASE_SHORTCUT_HINT}
+                    </p>
+                  </div>
                   <div className="space-y-4 min-h-0 flex-1 overflow-y-auto">
                     {sampleCases.length > 0 ? (
                       <>
@@ -1253,9 +1288,6 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           })}
                           </div>
                         </div>
-                        <p className="shrink-0 text-xs font-medium text-zinc-500">
-                          ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
-                        </p>
                       </div>
 
                       {activeCase ? (
@@ -1360,7 +1392,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       </div>
                     )}
                   </div>
-                </Panel>
+                </section>
               )}
             </div>
           </div>
@@ -1412,8 +1444,6 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 <DefinitionGrid
                   compact
                   items={[
-                    { label: "problemId", value: problem.problemId },
-                    { label: "difficulty", value: problem.difficulty },
                     { label: "timeLimitMs", value: problem.timeLimitMs },
                     { label: "memoryLimitMb", value: problem.memoryLimitMb },
                   ]}
@@ -1446,42 +1476,48 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 </div>
               </>
             ) : (
-              <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                  Submit Result
-                </p>
-                <div className="flex flex-wrap items-start gap-3">
-                  <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
-                    {submitHeadline}
-                  </p>
-                  {submitProgressText ? (
-                    <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
-                  ) : null}
-                  <div className="ml-auto flex flex-col items-end gap-1 text-right">
-                    {submitHasResult && submitCode ? (
-                      <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
-                        {submitCode}
-                      </span>
-                    ) : null}
-                    <p className="text-xs text-zinc-600">language: {language}</p>
-                  </div>
-                </div>
-
-                {submitState.message ? (
-                  <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
-                    {submitState.message}
-                  </div>
-                ) : null}
-
-                <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+              submitHasResult ? (
+                <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
                   <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
-                    Current Submission
+                    Submit Result
                   </p>
-                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
-                    {code}
-                  </pre>
+                  <div className="flex flex-wrap items-start gap-3">
+                    <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
+                      {submitHeadline}
+                    </p>
+                    {submitProgressText ? (
+                      <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                    ) : null}
+                    <div className="ml-auto flex flex-col items-end gap-1 text-right">
+                      {submitCode ? (
+                        <span className={`rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${submitBadgeClass}`}>
+                          {submitCode}
+                        </span>
+                      ) : null}
+                      <p className="text-xs text-zinc-600">language: {language}</p>
+                    </div>
+                  </div>
+
+                  {submitState.message ? (
+                    <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
+                      {submitState.message}
+                    </div>
+                  ) : null}
+
+                  <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Current Submission
+                    </p>
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                      {code}
+                    </pre>
+                  </div>
                 </div>
-              </div>
+              ) : (
+                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                  아직 제출 결과가 없습니다.
+                </div>
+              )
             )}
           </div>
         </Panel>
@@ -1504,7 +1540,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           submitLabel={submitActionLabel}
         />
 
-        <Panel title="TestCase">
+        <section className="rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+            <p className="shrink-0 text-xs font-medium text-zinc-500">
+              {TESTCASE_SHORTCUT_HINT}
+            </p>
+          </div>
           <div className="space-y-4">
             {sampleCases.length > 0 ? (
               <>
@@ -1556,9 +1598,6 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     })}
                     </div>
                   </div>
-                  <p className="shrink-0 text-xs font-medium text-zinc-500">
-                    ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
-                  </p>
                 </div>
                 {activeCase ? (
                   <div className="grid gap-3">
@@ -1661,7 +1700,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               </div>
             )}
           </div>
-        </Panel>
+        </section>
       </div>
     </div>
   );

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -32,7 +32,7 @@ import {
 const SoloCodeEditor = dynamic(() => import("@/features/problem-solo/code-editor"), {
   ssr: false,
   loading: () => (
-    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-300 bg-zinc-950 text-sm text-zinc-300">
+    <div className="flex h-[26rem] items-center justify-center rounded-2xl border border-zinc-700 bg-[#171c26] text-sm text-zinc-300">
       에디터를 준비하는 중입니다.
     </div>
   ),
@@ -863,8 +863,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
   if (!sessionLoaded) {
     return (
-      <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
-        <p className="text-sm text-zinc-600">잠시만 기다려주세요.</p>
+      <Panel variant="dark" title="세션 확인" description="인증 상태를 확인하는 중입니다.">
+        <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
       </Panel>
     );
   }
@@ -872,23 +872,23 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   if (!session.authenticated) {
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-zinc-300 bg-white px-4 py-3">
-          <p className="text-sm font-medium text-zinc-700">
+        <div className="flex items-center justify-between rounded-2xl border border-zinc-700 bg-[#171c26] px-4 py-3">
+          <p className="text-sm font-medium text-zinc-300">
             개인 풀이는 로그인 후 이용할 수 있습니다.
           </p>
-          <StatusPill tone="warn">로그인 필요</StatusPill>
+          <StatusPill tone="warn" variant="dark">로그인 필요</StatusPill>
         </div>
-        <Panel title="이동" description="로그인 후 다시 개인 풀이로 돌아올 수 있습니다.">
+        <Panel variant="dark" title="이동" description="로그인 후 다시 개인 풀이로 돌아올 수 있습니다.">
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/problems/${problemId}`)}`}
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl border border-violet-400/40 bg-gradient-to-r from-violet-600 to-violet-500 px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/problems"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+              className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm font-medium text-zinc-200"
             >
               문제 목록으로 돌아가기
             </Link>
@@ -901,22 +901,22 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   if (!problem) {
     if (isProblemLoading) {
       return (
-        <Panel title="문제 로딩" description="문제 상세를 불러오는 중입니다.">
-          <p className="text-sm text-zinc-600">잠시만 기다려주세요.</p>
+        <Panel variant="dark" title="문제 로딩" description="문제 상세를 불러오는 중입니다.">
+          <p className="text-sm text-zinc-400">잠시만 기다려주세요.</p>
         </Panel>
       );
     }
 
     return (
       <div className="space-y-8">
-        <div className="flex items-center justify-between rounded-2xl border border-rose-300 bg-rose-50 px-4 py-3">
-          <p className="text-sm font-medium text-rose-900">
+        <div className="flex items-center justify-between rounded-2xl border border-rose-500/30 bg-rose-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-rose-200">
             문제 정보를 가져오지 못했습니다.
           </p>
-          <StatusPill tone="danger">Load failed</StatusPill>
+          <StatusPill tone="danger" variant="dark">Load failed</StatusPill>
         </div>
-        <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-700">
+        <Panel variant="dark" title="오류" description="응답 메시지">
+          <p className="text-sm leading-7 text-zinc-300">
             {problemError ?? "문제 상세 응답이 없습니다."}
           </p>
         </Panel>
@@ -939,24 +939,24 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     submitCode === "JUDGING";
   const submitHasResult = submitState.status !== "idle";
   const submitCardClass = submitIsAccepted
-    ? "border-emerald-300 bg-emerald-50"
+    ? "border-emerald-500/30 bg-emerald-500/10"
     : submitIsWaiting
-      ? "border-amber-300 bg-amber-50"
+      ? "border-amber-500/30 bg-amber-500/10"
       : submitState.status === "idle"
-        ? "border-zinc-300 bg-zinc-50"
-        : "border-rose-300 bg-rose-50";
+        ? "border-zinc-700 bg-[#1b2130]"
+        : "border-rose-500/30 bg-rose-500/10";
   const submitHeadlineClass = submitIsAccepted
-    ? "text-emerald-700"
+    ? "text-emerald-300"
     : submitIsWaiting
-      ? "text-amber-700"
+      ? "text-amber-300"
       : submitState.status === "idle"
-        ? "text-zinc-700"
-        : "text-rose-700";
+        ? "text-zinc-200"
+        : "text-rose-300";
   const submitBadgeClass = submitIsAccepted
-    ? "bg-emerald-700/15 text-emerald-700"
+    ? "bg-emerald-500/15 text-emerald-300"
     : submitIsWaiting
-      ? "bg-amber-700/15 text-amber-700"
-      : "bg-rose-700/15 text-rose-700";
+      ? "bg-amber-500/15 text-amber-300"
+      : "bg-rose-500/15 text-rose-300";
   const submitProgressText =
     submitState.passedCount !== null && submitState.totalCount !== null
       ? `${submitState.passedCount}/${submitState.totalCount} testcases passed`
@@ -978,7 +978,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           >
             {isLeftPaneCollapsed ? (
               <div
-                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-300 bg-white px-1 py-3"
+                className="group relative flex h-full flex-col items-center gap-2 rounded-xl border border-zinc-700 bg-[#171c26] px-1 py-3"
                 onClick={(event) => {
                   if (event.target === event.currentTarget) {
                     setLeftPaneRatio(32);
@@ -990,9 +990,14 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   aria-orientation="vertical"
                   onMouseDown={startVerticalResize}
                   onDoubleClick={() => setLeftPaneRatio(50)}
-                  className="absolute inset-y-0 right-0 z-10 flex w-2 cursor-col-resize items-center justify-center"
+                  className="absolute inset-y-0 -right-1 z-10 flex w-4 cursor-col-resize items-center justify-center"
                 >
-                  <div className="h-14 w-0.5 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  <div className="relative flex h-full w-full items-center justify-center">
+                    <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+                    <div className="absolute flex h-16 w-1.5 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
+                      <div className="h-8 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+                    </div>
+                  </div>
                 </div>
                 <button
                   type="button"
@@ -1002,8 +1007,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "description"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1017,8 +1022,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   }}
                   className={`w-full rounded-md border px-1 py-2 text-xs font-semibold transition ${
                     leftPanelTab === "submission"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-600 hover:bg-zinc-200"
+                      ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                      : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                   }`}
                   style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
                 >
@@ -1027,6 +1032,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               </div>
             ) : (
               <Panel
+                variant="dark"
                 title="문제 상세"
                 className="flex h-full min-h-0 flex-col"
               >
@@ -1037,8 +1043,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       onClick={() => setLeftPanelTab("description")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "description"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                       }`}
                     >
                       Description
@@ -1048,8 +1054,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       onClick={() => setLeftPanelTab("submission")}
                       className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                         leftPanelTab === "submission"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                          ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                          : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                       }`}
                     >
                       Submission
@@ -1058,31 +1064,32 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
                 {leftPanelTab === "description" ? (
                   <>
-                    <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Solo
                       </p>
-                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                      <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
                         {problem.problemId}. {problem.title}
                       </h1>
                       <div className="mt-3 flex flex-wrap gap-2">
-                        <StatusPill>{problem.difficulty}</StatusPill>
-                        <StatusPill>오프라인 솔로</StatusPill>
+                        <StatusPill variant="dark">{problem.difficulty}</StatusPill>
+                        <StatusPill variant="dark">오프라인 솔로</StatusPill>
                       </div>
                     </div>
                     <DefinitionGrid
                       compact
+                      variant="dark"
                       items={[
                         { label: "timeLimitMs", value: problem.timeLimitMs },
                         { label: "memoryLimitMb", value: problem.memoryLimitMb },
                       ]}
                     />
-                    <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                    <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <div>
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Content
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {problem.content}
                         </MathText>
                       </div>
@@ -1090,7 +1097,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {problem.inputFormat}
                         </MathText>
                       </div>
@@ -1098,7 +1105,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {problem.outputFormat}
                         </MathText>
                       </div>
@@ -1115,7 +1122,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           {submitHeadline}
                         </p>
                         {submitProgressText ? (
-                          <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                          <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
                         ) : null}
                         <div className="ml-auto flex flex-col items-end gap-1 text-right">
                           {submitCode ? (
@@ -1123,27 +1130,27 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                               {submitCode}
                             </span>
                           ) : null}
-                          <p className="text-xs text-zinc-600">language: {language}</p>
+                          <p className="text-xs text-zinc-400">language: {language}</p>
                         </div>
                       </div>
 
                       {submitState.message ? (
-                        <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
+                        <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 px-3 py-2 text-sm text-zinc-300">
                           {submitState.message}
                         </div>
                       ) : null}
 
-                      <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                      <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Current Submission
                         </p>
-                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                        <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                           {code}
                         </pre>
                       </div>
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                    <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                       아직 제출 결과가 없습니다.
                     </div>
                   )
@@ -1158,9 +1165,16 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
             aria-orientation="vertical"
             onMouseDown={startVerticalResize}
             onDoubleClick={() => setLeftPaneRatio(50)}
-            className="group mx-1 flex w-3 cursor-col-resize items-center justify-center"
+            className={`group mx-1 items-center justify-center ${
+              isLeftPaneCollapsed ? "pointer-events-none hidden opacity-0" : "flex w-3 cursor-col-resize opacity-100"
+            }`}
           >
-            <div className="h-full w-px rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+            <div className="relative flex h-full w-full items-center justify-center">
+              <div className="h-full w-px rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+              <div className="absolute top-1/2 flex h-20 w-2 -translate-y-1/2 items-center justify-center rounded-full border border-zinc-600 bg-[#171c26] shadow-[0_0_0_1px_rgba(255,255,255,0.02)] transition group-hover:border-violet-500/60 group-hover:bg-violet-500/15">
+                <div className="h-10 w-0.5 rounded-full bg-zinc-500 transition group-hover:bg-violet-300" />
+              </div>
+            </div>
           </div>
 
           <div
@@ -1204,7 +1218,12 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   : "my-1 h-3 opacity-100"
               }`}
             >
-              <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
+              <div className="relative flex h-full w-full items-center justify-center">
+                <div className="h-px w-full rounded bg-zinc-700 transition group-hover:bg-violet-500/80" />
+                <div className="absolute left-1/2 flex h-2.5 w-12 -translate-x-1/2 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
+                  <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                </div>
+              </div>
             </div>
 
             <div
@@ -1222,17 +1241,19 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       setRightTopPaneRatio(76);
                     }
                   }}
-                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-300 bg-white px-4"
+                  className="group relative flex h-full cursor-row-resize items-center rounded-xl border border-zinc-700 bg-[#171c26] px-4"
                 >
-                  <div className="pointer-events-none absolute inset-x-0 top-0 flex h-2 items-start justify-center">
-                    <div className="mt-1 h-0.5 w-14 rounded-full bg-zinc-400 transition group-hover:bg-zinc-600" />
+                  <div className="pointer-events-none absolute inset-x-0 top-1.5 flex h-2.5 items-center justify-center">
+                    <div className="flex h-2.5 w-12 items-center justify-center rounded-full border border-zinc-700 bg-[#171c26]/90 transition group-hover:border-violet-500/50 group-hover:bg-violet-500/10">
+                      <div className="h-0.5 w-6 rounded-full bg-zinc-600 transition group-hover:bg-violet-300" />
+                    </div>
                   </div>
-                  <p className="text-base font-semibold text-zinc-900">TestCase</p>
+                  <p className="text-base font-semibold text-zinc-100">TestCase</p>
                 </div>
               ) : (
-                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+                <section className="flex h-full min-h-0 flex-col rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
                   <div className="mb-4 flex items-center justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+                    <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
                     <p className="shrink-0 text-xs font-medium text-zinc-500">
                       {TESTCASE_SHORTCUT_HINT}
                     </p>
@@ -1247,13 +1268,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                             const caseResult = caseRunResults[index];
                             const badgeState = getCaseBadgeState(caseResult);
                             const isSelected = selectedCaseIndex === index;
-                            const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
-                            const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
-                            const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
-                            const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+                            const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
+                            const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
+                            const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
+                            const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
 
                             const colorClass = isSelected
-                              ? "border-zinc-900 bg-zinc-900 text-white"
+                              ? "border-zinc-100 bg-zinc-100 text-zinc-950"
                               : badgeState?.tone === "pass"
                                 ? passClass
                                 : badgeState?.tone === "fail"
@@ -1274,10 +1295,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                   <span
                                     className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                       badgeState.tone === "pass"
-                                        ? "bg-emerald-700/15 text-emerald-700"
+                                        ? "bg-emerald-500/15 text-emerald-200"
                                         : badgeState.tone === "fail"
-                                          ? "bg-rose-700/15 text-rose-700"
-                                          : "bg-amber-700/15 text-amber-700"
+                                          ? "bg-rose-500/15 text-rose-200"
+                                          : "bg-amber-500/15 text-amber-200"
                                     }`}
                                   >
                                     {badgeState.label}
@@ -1292,12 +1313,12 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
                       {activeCase ? (
                         <div className="grid gap-3 lg:grid-cols-[1fr_0.95fr]">
-                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                             <div>
                               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                                 Input
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                                 {activeCase.input || "(empty)"}
                               </MathText>
                             </div>
@@ -1305,34 +1326,34 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                                 Output
                               </p>
-                              <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                              <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                                 {activeCase.output || "(empty)"}
                               </MathText>
                             </div>
                           </div>
 
-                          <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                          <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                               Run Result
                             </p>
                             <div
                               className={`rounded-xl border p-3 text-sm ${
                                 !activeCaseResult
-                                  ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                                  ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
                                   : activeCasePass
-                                    ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-                                    : "border-rose-200 bg-rose-50 text-rose-900"
+                                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+                                    : "border-rose-500/30 bg-rose-500/10 text-rose-200"
                               }`}
                             >
                               {runningCaseIndex === selectedCaseIndex ? (
-                                <p className="text-amber-700">실행 요청 중입니다...</p>
+                                <p className="text-amber-300">실행 요청 중입니다...</p>
                               ) : activeCaseResult ? (
                                 <div className="space-y-2">
                                   <p
                                     className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                       activeCasePass
-                                        ? "bg-emerald-700/15 text-emerald-700"
-                                        : "bg-rose-700/15 text-rose-700"
+                                        ? "bg-emerald-500/15 text-emerald-200"
+                                        : "bg-rose-500/15 text-rose-200"
                                     }`}
                                   >
                                     {activeCasePass
@@ -1342,42 +1363,42 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                         : normalizeVerdict(activeCaseResult.verdict)}
                                   </p>
                                   {activeCaseResult.stderr ? (
-                                    <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
-                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                                    <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
+                                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
                                         Error
                                       </p>
-                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                      <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
                                         {activeCaseResult.stderr}
                                       </pre>
                                     </div>
                                   ) : (
                                     <div className="grid gap-2">
-                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                           Output
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                           {activeCaseResult.output ?? "(empty)"}
                                         </pre>
                                       </div>
-                                      <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                      <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                           Expected
                                         </p>
-                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                        <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                           {activeCaseResult.expected ?? "(empty)"}
                                         </pre>
                                       </div>
                                     </div>
                                   )}
                                   {activeCaseResult.message ? (
-                                    <p className={activeCasePass ? "text-emerald-800" : "text-rose-800"}>
+                                    <p className={activeCasePass ? "text-emerald-200" : "text-rose-200"}>
                                       {activeCaseResult.message}
                                     </p>
                                   ) : null}
                                 </div>
                               ) : (
-                                <p className="text-zinc-600">
+                                <p className="text-zinc-400">
                                   아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                                 </p>
                               )}
@@ -1387,7 +1408,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       ) : null}
                       </>
                     ) : (
-                      <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                      <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                         실행 가능한 샘플 케이스가 없습니다.
                       </div>
                     )}
@@ -1400,7 +1421,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       </div>
 
       <div className="space-y-6 lg:hidden">
-        <Panel title="문제 상세">
+        <Panel variant="dark" title="문제 상세">
           <div className="space-y-4">
             <div className="flex flex-wrap gap-2">
               <button
@@ -1408,8 +1429,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 onClick={() => setLeftPanelTab("description")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "description"
-                    ? "border-zinc-900 bg-zinc-900 text-white"
-                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                 }`}
               >
                 Description
@@ -1419,8 +1440,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 onClick={() => setLeftPanelTab("submission")}
                 className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
                   leftPanelTab === "submission"
-                    ? "border-zinc-900 bg-zinc-900 text-white"
-                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    ? "border-zinc-100 bg-zinc-100 text-zinc-950"
+                    : "border-zinc-700 bg-[#1b2130] text-zinc-400 hover:bg-[#222b3c] hover:text-zinc-200"
                 }`}
               >
                 Submission
@@ -1429,31 +1450,32 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
 
             {leftPanelTab === "description" ? (
               <>
-                <div className="rounded-2xl border border-zinc-300 bg-white p-4">
+                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                     Solo
                   </p>
-                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-950">
+                  <h1 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-100">
                     {problem.problemId}. {problem.title}
                   </h1>
                   <div className="mt-3 flex flex-wrap gap-2">
-                    <StatusPill>{problem.difficulty}</StatusPill>
-                    <StatusPill>오프라인 솔로</StatusPill>
+                    <StatusPill variant="dark">{problem.difficulty}</StatusPill>
+                    <StatusPill variant="dark">오프라인 솔로</StatusPill>
                   </div>
                 </div>
                 <DefinitionGrid
                   compact
+                  variant="dark"
                   items={[
                     { label: "timeLimitMs", value: problem.timeLimitMs },
                     { label: "memoryLimitMb", value: problem.memoryLimitMb },
                   ]}
                 />
-                <div className="space-y-4 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                <div className="space-y-4 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                   <div>
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                       Content
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                       {problem.content}
                     </MathText>
                   </div>
@@ -1461,7 +1483,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                       Input
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                       {problem.inputFormat}
                     </MathText>
                   </div>
@@ -1469,7 +1491,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                       Output
                     </p>
-                    <MathText className="mt-2 block text-sm leading-7 text-zinc-700">
+                    <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                       {problem.outputFormat}
                     </MathText>
                   </div>
@@ -1486,7 +1508,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       {submitHeadline}
                     </p>
                     {submitProgressText ? (
-                      <p className="pt-1 text-sm text-zinc-600">{submitProgressText}</p>
+                      <p className="pt-1 text-sm text-zinc-400">{submitProgressText}</p>
                     ) : null}
                     <div className="ml-auto flex flex-col items-end gap-1 text-right">
                       {submitCode ? (
@@ -1494,27 +1516,27 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                           {submitCode}
                         </span>
                       ) : null}
-                      <p className="text-xs text-zinc-600">language: {language}</p>
+                      <p className="text-xs text-zinc-400">language: {language}</p>
                     </div>
                   </div>
 
                   {submitState.message ? (
-                    <div className="rounded-lg border border-zinc-200 bg-white/60 px-3 py-2 text-sm text-zinc-700">
+                    <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 px-3 py-2 text-sm text-zinc-300">
                       {submitState.message}
                     </div>
                   ) : null}
 
-                  <div className="rounded-xl border border-zinc-200 bg-white/60 p-3">
+                  <div className="rounded-xl border border-zinc-700 bg-[#0f1521]/80 p-3">
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                       Current Submission
                     </p>
-                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                    <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                       {code}
                     </pre>
                   </div>
                 </div>
               ) : (
-                <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+                <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                   아직 제출 결과가 없습니다.
                 </div>
               )
@@ -1540,9 +1562,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           submitLabel={submitActionLabel}
         />
 
-        <section className="rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm">
+        <section className="rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
           <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-lg font-semibold text-zinc-950">TestCase</h2>
+            <h2 className="text-lg font-semibold text-zinc-100">TestCase</h2>
             <p className="shrink-0 text-xs font-medium text-zinc-500">
               {TESTCASE_SHORTCUT_HINT}
             </p>
@@ -1557,13 +1579,13 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       const caseResult = caseRunResults[index];
                       const badgeState = getCaseBadgeState(caseResult);
                       const isSelected = selectedCaseIndex === index;
-                      const idleClass = "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200";
-                      const passClass = "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100";
-                      const failClass = "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100";
-                      const pendingClass = "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100";
+                      const idleClass = "border-zinc-700 bg-[#1b2130] text-zinc-300 hover:bg-[#222b3c]";
+                      const passClass = "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/15";
+                      const failClass = "border-rose-500/30 bg-rose-500/10 text-rose-200 hover:bg-rose-500/15";
+                      const pendingClass = "border-amber-500/30 bg-amber-500/10 text-amber-200 hover:bg-amber-500/15";
 
                       const colorClass = isSelected
-                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        ? "border-zinc-100 bg-zinc-100 text-zinc-950"
                         : badgeState?.tone === "pass"
                           ? passClass
                           : badgeState?.tone === "fail"
@@ -1584,10 +1606,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                             <span
                               className={`rounded-md px-1.5 py-0.5 text-[10px] font-semibold tracking-wide ${
                                 badgeState.tone === "pass"
-                                  ? "bg-emerald-700/15 text-emerald-700"
+                                  ? "bg-emerald-500/15 text-emerald-200"
                                   : badgeState.tone === "fail"
-                                    ? "bg-rose-700/15 text-rose-700"
-                                    : "bg-amber-700/15 text-amber-700"
+                                    ? "bg-rose-500/15 text-rose-200"
+                                    : "bg-amber-500/15 text-amber-200"
                               }`}
                             >
                               {badgeState.label}
@@ -1601,12 +1623,12 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 </div>
                 {activeCase ? (
                   <div className="grid gap-3">
-                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
+                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <div>
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Input
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {activeCase.input || "(empty)"}
                         </MathText>
                       </div>
@@ -1614,33 +1636,33 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                           Output
                         </p>
-                        <MathText className="mt-2 block text-sm leading-7 text-zinc-800">
+                        <MathText className="mt-2 block text-sm leading-7 text-zinc-300">
                           {activeCase.output || "(empty)"}
                         </MathText>
                       </div>
                     </div>
-                    <div className="space-y-3 rounded-2xl border border-zinc-300 bg-white p-4">
+                    <div className="space-y-3 rounded-2xl border border-zinc-700 bg-[#1b2130] p-4">
                       <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
                         Run Result
                       </p>
                       <div
                         className={`rounded-xl border p-3 text-sm ${
                           !activeCaseResult
-                            ? "border-zinc-200 bg-zinc-50 text-zinc-800"
+                            ? "border-zinc-700 bg-[#0f1521] text-zinc-300"
                             : activeCasePass
-                              ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-                              : "border-rose-200 bg-rose-50 text-rose-900"
+                              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+                              : "border-rose-500/30 bg-rose-500/10 text-rose-200"
                         }`}
                       >
                         {runningCaseIndex === selectedCaseIndex ? (
-                          <p className="text-amber-700">실행 요청 중입니다...</p>
+                          <p className="text-amber-300">실행 요청 중입니다...</p>
                         ) : activeCaseResult ? (
                           <div className="space-y-2">
                             <p
                               className={`inline-flex rounded-md px-2 py-1 text-xs font-semibold tracking-wide ${
                                 activeCasePass
-                                  ? "bg-emerald-700/15 text-emerald-700"
-                                  : "bg-rose-700/15 text-rose-700"
+                                  ? "bg-emerald-500/15 text-emerald-200"
+                                  : "bg-rose-500/15 text-rose-200"
                               }`}
                             >
                               {activeCasePass
@@ -1650,42 +1672,42 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                                   : normalizeVerdict(activeCaseResult.verdict)}
                             </p>
                             {activeCaseResult.stderr ? (
-                              <div className="rounded-lg border border-rose-200 bg-white/60 p-2">
-                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-600">
+                              <div className="rounded-lg border border-rose-500/30 bg-[#0f1521]/80 p-2">
+                                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-300">
                                   Error
                                 </p>
-                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-800">
+                                <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-rose-200">
                                   {activeCaseResult.stderr}
                                 </pre>
                               </div>
                             ) : (
                               <div className="grid gap-2">
-                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                     Output
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                     {activeCaseResult.output ?? "(empty)"}
                                   </pre>
                                 </div>
-                                <div className="rounded-lg border border-zinc-200 bg-white/60 p-2">
+                                <div className="rounded-lg border border-zinc-700 bg-[#0f1521]/80 p-2">
                                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
                                     Expected
                                   </p>
-                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800">
+                                  <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-200">
                                     {activeCaseResult.expected ?? "(empty)"}
                                   </pre>
                                 </div>
                               </div>
                             )}
                             {activeCaseResult.message ? (
-                              <p className={activeCasePass ? "text-emerald-800" : "text-rose-800"}>
+                              <p className={activeCasePass ? "text-emerald-200" : "text-rose-200"}>
                                 {activeCaseResult.message}
                               </p>
                             ) : null}
                           </div>
                         ) : (
-                          <p className="text-zinc-600">
+                          <p className="text-zinc-400">
                             아직 실행 결과가 없습니다. Run 버튼으로 해당 케이스를 실행하세요.
                           </p>
                         )}
@@ -1695,7 +1717,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 ) : null}
               </>
             ) : (
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+              <div className="rounded-2xl border border-zinc-700 bg-[#1b2130] px-4 py-3 text-sm text-zinc-400">
                 실행 가능한 샘플 케이스가 없습니다.
               </div>
             )}

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -244,7 +244,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   const runTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia("(min-width: 1280px)");
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
     const body = document.body;
     const html = document.documentElement;
     const previousBodyOverflow = body.style.overflow;
@@ -683,6 +683,56 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     window.addEventListener("mouseup", onUp);
   }
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      const isRunShortcut =
+        event.key === "Enter" && (event.metaKey || event.ctrlKey) && !event.shiftKey;
+      const isSubmitShortcut = event.key === "Enter" && event.shiftKey;
+
+      if (!isRunShortcut && !isSubmitShortcut) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof HTMLInputElement || target instanceof HTMLSelectElement) {
+        return;
+      }
+
+      if (isSubmitShortcut) {
+        if (isSubmitting) {
+          return;
+        }
+
+        event.preventDefault();
+        void handleSubmit();
+        return;
+      }
+
+      if (runningCaseIndex !== null) {
+        return;
+      }
+
+      const sampleCaseCount = problem?.sampleCases?.length ?? 0;
+      const runCaseIndex = selectedCaseIndex ?? (sampleCaseCount > 0 ? 0 : null);
+
+      if (runCaseIndex === null) {
+        return;
+      }
+
+      event.preventDefault();
+      void handleRunCase(runCaseIndex);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [handleRunCase, handleSubmit, isSubmitting, problem, runningCaseIndex, selectedCaseIndex]);
+
   if (!sessionLoaded) {
     return (
       <Panel title="세션 확인" description="인증 상태를 확인하는 중입니다.">
@@ -783,6 +833,10 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     submitState.passedCount !== null && submitState.totalCount !== null
       ? `${submitState.passedCount}/${submitState.totalCount} testcases passed`
       : null;
+  const runTargetCaseIndex = selectedCaseIndex ?? (sampleCases.length > 0 ? 0 : null);
+  const runActionDisabled = runTargetCaseIndex === null || runningCaseIndex !== null;
+  const runActionLabel = runningCaseIndex !== null ? "Running..." : "Run";
+  const submitActionLabel = isSubmitting ? "Submitting..." : "Submit";
 
   return (
     <div className="space-y-6">
@@ -794,38 +848,28 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               className="flex h-full min-h-0 flex-col"
             >
               <div className="space-y-4 min-h-0 flex-1 overflow-y-auto pr-1">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setLeftPanelTab("description")}
-                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                        leftPanelTab === "description"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                      }`}
-                    >
-                      Description
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setLeftPanelTab("submission")}
-                      className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                        leftPanelTab === "submission"
-                          ? "border-zinc-900 bg-zinc-900 text-white"
-                          : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                      }`}
-                    >
-                      Submission
-                    </button>
-                  </div>
+                <div className="flex flex-wrap gap-2">
                   <button
                     type="button"
-                    onClick={() => void handleSubmit()}
-                    disabled={isSubmitting}
-                    className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                    onClick={() => setLeftPanelTab("description")}
+                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                      leftPanelTab === "description"
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    }`}
                   >
-                    {isSubmitting ? "Submitting..." : "Submit"}
+                    Description
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setLeftPanelTab("submission")}
+                    className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                      leftPanelTab === "submission"
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                    }`}
+                  >
+                    Submission
                   </button>
                 </div>
 
@@ -880,6 +924,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   </>
                 ) : (
                   <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                      Submit Result
+                    </p>
                     <div className="flex flex-wrap items-start gap-3">
                       <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
                         {submitHeadline}
@@ -938,6 +985,16 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                 onLanguageChange={(nextLanguage) => handleLanguageChange(nextLanguage)}
                 value={code}
                 onChange={setCode}
+                onRun={() => {
+                  if (runTargetCaseIndex !== null) {
+                    void handleRunCase(runTargetCaseIndex);
+                  }
+                }}
+                onSubmit={() => void handleSubmit()}
+                runDisabled={runActionDisabled}
+                submitDisabled={isSubmitting}
+                runLabel={runActionLabel}
+                submitLabel={submitActionLabel}
                 height="100%"
                 className="h-full"
               />
@@ -1006,20 +1063,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                             );
                           })}
                         </div>
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() =>
-                              selectedCaseIndex !== null
-                                ? void handleRunCase(selectedCaseIndex)
-                                : null
-                            }
-                            disabled={selectedCaseIndex === null || runningCaseIndex !== null}
-                            className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-                          >
-                            {runningCaseIndex !== null ? "실행 중..." : "▶ Run"}
-                          </button>
-                        </div>
+                        <p className="text-xs font-medium text-zinc-500">
+                          ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
+                        </p>
                       </div>
 
                       {activeCase ? (
@@ -1133,38 +1179,28 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       <div className="space-y-6 lg:hidden">
         <Panel title="문제 상세">
           <div className="space-y-4">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={() => setLeftPanelTab("description")}
-                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                    leftPanelTab === "description"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                  }`}
-                >
-                  Description
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setLeftPanelTab("submission")}
-                  className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
-                    leftPanelTab === "submission"
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
-                  }`}
-                >
-                  Submission
-                </button>
-              </div>
+            <div className="flex flex-wrap gap-2">
               <button
                 type="button"
-                onClick={() => void handleSubmit()}
-                disabled={isSubmitting}
-                className="rounded-lg bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                onClick={() => setLeftPanelTab("description")}
+                className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                  leftPanelTab === "description"
+                    ? "border-zinc-900 bg-zinc-900 text-white"
+                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                }`}
               >
-                {isSubmitting ? "Submitting..." : "Submit"}
+                Description
+              </button>
+              <button
+                type="button"
+                onClick={() => setLeftPanelTab("submission")}
+                className={`rounded-lg border px-3 py-1.5 text-sm font-semibold transition ${
+                  leftPanelTab === "submission"
+                    ? "border-zinc-900 bg-zinc-900 text-white"
+                    : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                }`}
+              >
+                Submission
               </button>
             </div>
 
@@ -1219,6 +1255,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               </>
             ) : (
               <div className={`space-y-4 rounded-2xl border p-4 ${submitCardClass}`}>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+                  Submit Result
+                </p>
                 <div className="flex flex-wrap items-start gap-3">
                   <p className={`text-2xl font-semibold ${submitHeadlineClass}`}>
                     {submitHeadline}
@@ -1261,6 +1300,16 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           onLanguageChange={(nextLanguage) => handleLanguageChange(nextLanguage)}
           value={code}
           onChange={setCode}
+          onRun={() => {
+            if (runTargetCaseIndex !== null) {
+              void handleRunCase(runTargetCaseIndex);
+            }
+          }}
+          onSubmit={() => void handleSubmit()}
+          runDisabled={runActionDisabled}
+          submitDisabled={isSubmitting}
+          runLabel={runActionLabel}
+          submitLabel={submitActionLabel}
         />
 
         <Panel title="TestCase">
@@ -1313,18 +1362,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       );
                     })}
                   </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        selectedCaseIndex !== null ? void handleRunCase(selectedCaseIndex) : null
-                      }
-                      disabled={selectedCaseIndex === null || runningCaseIndex !== null}
-                      className="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 transition hover:border-zinc-500 disabled:cursor-not-allowed disabled:text-zinc-400"
-                    >
-                      {runningCaseIndex !== null ? "실행 중..." : "▶ Run"}
-                    </button>
-                  </div>
+                  <p className="text-xs font-medium text-zinc-500">
+                    ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
+                  </p>
                 </div>
                 {activeCase ? (
                   <div className="grid gap-3">

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -19,6 +19,10 @@ import type {
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
 import {
+  readPreferredEditorLanguage,
+  writePreferredEditorLanguage,
+} from "@/shared/utils/editor-language";
+import {
   DefinitionGrid,
   MathText,
   Panel,
@@ -49,6 +53,9 @@ const MAX_TOP_RATIO = 100;
 const LEFT_RATIO_SNAP_POINTS = [0, 22, 32, 50, 68, 78];
 const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76, 92, 100];
 const SPLIT_SNAP_GAP = 4;
+const DEFAULT_LEFT_PANE_RATIO = 50;
+const DEFAULT_RIGHT_TOP_PANE_RATIO = 100;
+const SOLO_LAYOUT_STORAGE_KEY = "bracket:solo-editor-layout:v1";
 
 interface SoloCaseRunResult {
   status: "pending" | "done" | "error";
@@ -81,6 +88,40 @@ function clamp(value: number, min: number, max: number) {
 function snapRatio(value: number, points: number[], gap: number) {
   const nearest = points.find((point) => Math.abs(value - point) <= gap);
   return nearest ?? value;
+}
+
+function readStoredLayout() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SOLO_LAYOUT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as {
+      leftPaneRatio?: number;
+      rightTopPaneRatio?: number;
+    };
+
+    const leftPaneRatio =
+      typeof parsed.leftPaneRatio === "number"
+        ? clamp(parsed.leftPaneRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO)
+        : DEFAULT_LEFT_PANE_RATIO;
+    const rightTopPaneRatio =
+      typeof parsed.rightTopPaneRatio === "number"
+        ? clamp(parsed.rightTopPaneRatio, MIN_TOP_RATIO, MAX_TOP_RATIO)
+        : DEFAULT_RIGHT_TOP_PANE_RATIO;
+
+    return {
+      leftPaneRatio,
+      rightTopPaneRatio,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function isRunResultEvent(payload: unknown): payload is SoloRunWsMessage {
@@ -207,6 +248,11 @@ function resolveStarterCode(problem: ProblemDetailResponse | null, language: str
 
 function resolveDefaultLanguage(problem: ProblemDetailResponse | null) {
   const languages = resolveLanguages(problem);
+  const preferredLanguage = readPreferredEditorLanguage();
+
+  if (preferredLanguage && languages.includes(preferredLanguage)) {
+    return preferredLanguage;
+  }
 
   if (problem?.defaultLanguage && languages.includes(problem.defaultLanguage)) {
     return problem.defaultLanguage;
@@ -237,16 +283,27 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [problemError, setProblemError] = useState<string | null>(null);
   const [isProblemLoading, setIsProblemLoading] = useState(true);
-  const [language, setLanguage] = useState("javascript");
-  const [code, setCode] = useState(defaultCodeByLanguage.javascript);
+  const [language, setLanguage] = useState(
+    () => readPreferredEditorLanguage() ?? "javascript",
+  );
+  const [code, setCode] = useState(() => {
+    const preferredLanguage = readPreferredEditorLanguage() ?? "javascript";
+    return defaultCodeByLanguage[preferredLanguage] ?? defaultCodeByLanguage.javascript;
+  });
   const [selectedCaseIndex, setSelectedCaseIndex] = useState<number | null>(null);
   const [runningCaseIndex, setRunningCaseIndex] = useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [caseRunResults, setCaseRunResults] = useState<Record<number, SoloCaseRunResult>>({});
   const [leftPanelTab, setLeftPanelTab] = useState<LeftPanelTab>("description");
   const [submitState, setSubmitState] = useState<SoloSubmitState>(createInitialSubmitState);
-  const [leftPaneRatio, setLeftPaneRatio] = useState(54);
-  const [rightTopPaneRatio, setRightTopPaneRatio] = useState(52);
+  const [leftPaneRatio, setLeftPaneRatio] = useState(() => {
+    const stored = readStoredLayout();
+    return stored?.leftPaneRatio ?? DEFAULT_LEFT_PANE_RATIO;
+  });
+  const [rightTopPaneRatio, setRightTopPaneRatio] = useState(() => {
+    const stored = readStoredLayout();
+    return stored?.rightTopPaneRatio ?? DEFAULT_RIGHT_TOP_PANE_RATIO;
+  });
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
   const runTimeoutRef = useRef<number | null>(null);
@@ -359,6 +416,20 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   useEffect(() => {
     rightTopPaneRatioRef.current = rightTopPaneRatio;
   }, [rightTopPaneRatio]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      SOLO_LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        leftPaneRatio,
+        rightTopPaneRatio,
+      }),
+    );
+  }, [leftPaneRatio, rightTopPaneRatio]);
 
   useEffect(() => {
     const memberId = session.member?.memberId;
@@ -477,6 +548,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   function handleLanguageChange(nextLanguage: string) {
     setLanguage(nextLanguage);
     setCode(resolveStarterCode(problem, nextLanguage));
+    writePreferredEditorLanguage(nextLanguage);
   }
 
   async function handleRunCase(caseIndex: number) {
@@ -971,6 +1043,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                       </div>
                     </div>
                     <DefinitionGrid
+                      compact
                       items={[
                         { label: "problemId", value: problem.problemId },
                         { label: "difficulty", value: problem.difficulty },
@@ -1132,8 +1205,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   <div className="space-y-4 min-h-0 flex-1 overflow-y-auto">
                     {sampleCases.length > 0 ? (
                       <>
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <div className="flex flex-wrap gap-2">
+                      <div className="flex items-center gap-3">
+                        <div className="min-w-0 flex-1 overflow-x-auto pb-1">
+                          <div className="flex w-max gap-2 pr-1">
                           {sampleCases.map((_, index) => {
                             const caseResult = caseRunResults[index];
                             const badgeState = getCaseBadgeState(caseResult);
@@ -1177,8 +1251,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                               </button>
                             );
                           })}
+                          </div>
                         </div>
-                        <p className="text-xs font-medium text-zinc-500">
+                        <p className="shrink-0 text-xs font-medium text-zinc-500">
                           ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
                         </p>
                       </div>
@@ -1335,6 +1410,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                   </div>
                 </div>
                 <DefinitionGrid
+                  compact
                   items={[
                     { label: "problemId", value: problem.problemId },
                     { label: "difficulty", value: problem.difficulty },
@@ -1432,8 +1508,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
           <div className="space-y-4">
             {sampleCases.length > 0 ? (
               <>
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex flex-wrap gap-2">
+                <div className="flex items-center gap-3">
+                  <div className="min-w-0 flex-1 overflow-x-auto pb-1">
+                    <div className="flex w-max gap-2 pr-1">
                     {sampleCases.map((_, index) => {
                       const caseResult = caseRunResults[index];
                       const badgeState = getCaseBadgeState(caseResult);
@@ -1477,8 +1554,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
                         </button>
                       );
                     })}
+                    </div>
                   </div>
-                  <p className="text-xs font-medium text-zinc-500">
+                  <p className="shrink-0 text-xs font-medium text-zinc-500">
                     ⌘/Ctrl+Enter: Run · Shift+Enter: Submit
                   </p>
                 </div>

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -42,10 +42,13 @@ const defaultCodeByLanguage: Record<string, string> = {
 };
 
 const fallbackLanguages = ["python3", "java", "javascript"];
-const MIN_LEFT_RATIO = 32;
-const MAX_LEFT_RATIO = 68;
-const MIN_TOP_RATIO = 28;
-const MAX_TOP_RATIO = 72;
+const MIN_LEFT_RATIO = 22;
+const MAX_LEFT_RATIO = 78;
+const MIN_TOP_RATIO = 24;
+const MAX_TOP_RATIO = 76;
+const LEFT_RATIO_SNAP_POINTS = [22, 32, 50, 68, 78];
+const TOP_RATIO_SNAP_POINTS = [24, 34, 50, 66, 76];
+const SPLIT_SNAP_GAP = 2;
 
 interface SoloCaseRunResult {
   status: "pending" | "done" | "error";
@@ -73,6 +76,11 @@ interface SoloSubmitState {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function snapRatio(value: number, points: number[], gap: number) {
+  const nearest = points.find((point) => Math.abs(value - point) <= gap);
+  return nearest ?? value;
 }
 
 function isRunResultEvent(payload: unknown): payload is SoloRunWsMessage {
@@ -242,6 +250,8 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
   const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const rightColumnRef = useRef<HTMLDivElement | null>(null);
   const runTimeoutRef = useRef<number | null>(null);
+  const leftPaneRatioRef = useRef(leftPaneRatio);
+  const rightTopPaneRatioRef = useRef(rightTopPaneRatio);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
@@ -341,6 +351,14 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       }
     };
   }, []);
+
+  useEffect(() => {
+    leftPaneRatioRef.current = leftPaneRatio;
+  }, [leftPaneRatio]);
+
+  useEffect(() => {
+    rightTopPaneRatioRef.current = rightTopPaneRatio;
+  }, [rightTopPaneRatio]);
 
   useEffect(() => {
     const memberId = session.member?.memberId;
@@ -637,7 +655,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     const onMove = (moveEvent: MouseEvent) => {
       const rect = container.getBoundingClientRect();
       const nextRatio = ((moveEvent.clientX - rect.left) / rect.width) * 100;
-      setLeftPaneRatio(clamp(nextRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO));
+      const clamped = clamp(nextRatio, MIN_LEFT_RATIO, MAX_LEFT_RATIO);
+      leftPaneRatioRef.current = clamped;
+      setLeftPaneRatio(clamped);
     };
 
     const onUp = () => {
@@ -645,6 +665,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       window.removeEventListener("mouseup", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
+      const snapped = snapRatio(leftPaneRatioRef.current, LEFT_RATIO_SNAP_POINTS, SPLIT_SNAP_GAP);
+      leftPaneRatioRef.current = snapped;
+      setLeftPaneRatio(snapped);
     };
 
     document.body.style.userSelect = "none";
@@ -667,7 +690,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       }
 
       const nextRatio = ((moveEvent.clientY - rect.top) / rect.height) * 100;
-      setRightTopPaneRatio(clamp(nextRatio, MIN_TOP_RATIO, MAX_TOP_RATIO));
+      const clamped = clamp(nextRatio, MIN_TOP_RATIO, MAX_TOP_RATIO);
+      rightTopPaneRatioRef.current = clamped;
+      setRightTopPaneRatio(clamped);
     };
 
     const onUp = () => {
@@ -675,6 +700,9 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
       window.removeEventListener("mouseup", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
+      const snapped = snapRatio(rightTopPaneRatioRef.current, TOP_RATIO_SNAP_POINTS, SPLIT_SNAP_GAP);
+      rightTopPaneRatioRef.current = snapped;
+      setRightTopPaneRatio(snapped);
     };
 
     document.body.style.userSelect = "none";
@@ -968,6 +996,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
             role="separator"
             aria-orientation="vertical"
             onMouseDown={startVerticalResize}
+            onDoubleClick={() => setLeftPaneRatio(50)}
             className="group mx-1 flex w-3 cursor-col-resize items-center justify-center"
           >
             <div className="h-full w-px rounded bg-zinc-300 transition group-hover:bg-zinc-500" />
@@ -1004,6 +1033,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
               role="separator"
               aria-orientation="horizontal"
               onMouseDown={startHorizontalResize}
+              onDoubleClick={() => setRightTopPaneRatio(50)}
               className="group my-1 flex h-3 cursor-row-resize items-center justify-center"
             >
               <div className="h-px w-full rounded bg-zinc-300 transition group-hover:bg-zinc-500" />

--- a/src/features/problems/screen.tsx
+++ b/src/features/problems/screen.tsx
@@ -123,10 +123,10 @@ export default function ProblemsScreen() {
   const pageTokens = getPageTokens(problemPage, totalPages);
 
   return (
-    <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
-      <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
-        <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-          <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+    <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+        <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+          <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
             <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
               <path
                 d="M4 2.5h5l3 3V13a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1Z"
@@ -138,20 +138,20 @@ export default function ProblemsScreen() {
             </svg>
           </span>
           <span>problem-list.json</span>
-          <span className="text-zinc-500">×</span>
-          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+          <span className="text-app-dim">×</span>
+          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto bg-[#1e1f22]">
+      <div className="flex-1 overflow-auto bg-app-base">
         <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
-          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-zinc-700/70 pb-3">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-app-border/70 pb-3">
             <div>
-              <h1 className="text-xl font-semibold text-zinc-100">문제 목록</h1>
-              <p className="mt-1 text-sm text-zinc-400">문제를 선택해 개인 풀이 화면으로 이동합니다.</p>
+              <h1 className="text-xl font-semibold text-app-primary">문제 목록</h1>
+              <p className="mt-1 text-sm text-app-muted">문제를 선택해 개인 풀이 화면으로 이동합니다.</p>
             </div>
             {session.authenticated ? (
-              <p className="text-xs text-zinc-500">
+              <p className="text-xs text-app-dim">
                 {problemPageInfo
                   ? `총 ${problemPageInfo.totalElements.toLocaleString()}개 · ${problemPageInfo.page + 1}/${problemPageInfo.totalPages} 페이지`
                   : isProblemLoading
@@ -162,24 +162,24 @@ export default function ProblemsScreen() {
           </div>
 
           {!sessionLoaded ? (
-            <div className="rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4 text-sm text-zinc-300">
+            <div className="rounded-md border border-app-border bg-app-elevated px-4 py-4 text-sm text-app-secondary">
               세션 상태를 확인하는 중입니다.
             </div>
           ) : !session.authenticated ? (
-            <div className="space-y-4 rounded-md border border-zinc-700 bg-[#2b2d30] px-4 py-4">
-              <p className="text-sm text-zinc-300">
+            <div className="space-y-4 rounded-md border border-app-border bg-app-elevated px-4 py-4">
+              <p className="text-sm text-app-secondary">
                 문제 목록 조회는 로그인 후 이용할 수 있습니다.
               </p>
               <div className="flex flex-wrap gap-2">
                 <Link
                   href="/login?next=/problems"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa]"
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover"
                 >
                   로그인
                 </Link>
                 <Link
                   href="/"
-                  className="inline-flex h-10 items-center justify-center rounded-md border border-zinc-700 bg-[#1e1f22] px-4 text-sm font-medium text-zinc-200 transition hover:bg-zinc-700/30"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-app-border bg-app-base px-4 text-sm font-medium text-app-primary transition hover:bg-app-elevated/90"
                 >
                   메인으로
                 </Link>
@@ -188,7 +188,7 @@ export default function ProblemsScreen() {
           ) : (
             <div className="space-y-5">
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-sm text-zinc-400">
+                <p className="text-sm text-app-muted">
                   {isProblemLoading
                     ? "문제 목록을 불러오는 중입니다."
                     : "문제를 선택한 뒤 열기를 눌러 개인 풀이를 시작하세요."}
@@ -198,7 +198,7 @@ export default function ProblemsScreen() {
                     type="button"
                     onClick={() => setProblemPage((current) => Math.max(0, current - 1))}
                     disabled={!canMovePrevProblemPage}
-                    className="inline-flex h-9 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-200 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
+                    className="inline-flex h-9 items-center justify-center rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary transition hover:bg-app-elevated/90 disabled:cursor-not-allowed disabled:text-app-dim"
                   >
                     이전
                   </button>
@@ -206,7 +206,7 @@ export default function ProblemsScreen() {
                     type="button"
                     onClick={() => setProblemPage((current) => current + 1)}
                     disabled={!canMoveNextProblemPage}
-                    className="inline-flex h-9 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-200 transition hover:bg-zinc-700/40 disabled:cursor-not-allowed disabled:text-zinc-500"
+                    className="inline-flex h-9 items-center justify-center rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary transition hover:bg-app-elevated/90 disabled:cursor-not-allowed disabled:text-app-dim"
                   >
                     다음
                   </button>
@@ -220,7 +220,7 @@ export default function ProblemsScreen() {
                       token === "ellipsis" ? (
                         <span
                           key={`ellipsis-${index}`}
-                          className="inline-flex h-8 w-8 items-center justify-center text-sm text-zinc-500"
+                          className="inline-flex h-8 w-8 items-center justify-center text-sm text-app-dim"
                         >
                           ...
                         </span>
@@ -232,9 +232,9 @@ export default function ProblemsScreen() {
                           disabled={isProblemLoading}
                           className={`inline-flex h-8 w-9 items-center justify-center rounded-md border text-sm font-semibold transition ${
                             token === problemPage
-                              ? "border-violet-400/60 bg-[#9146ff] text-white shadow-[0_0_0_1px_rgba(167,139,250,0.3)]"
-                              : "border-zinc-700 bg-[#2b2d30] text-zinc-200 hover:bg-zinc-700/40"
-                          } disabled:cursor-not-allowed disabled:text-zinc-500`}
+                              ? "border-app-accent/60 bg-app-accent text-white shadow-[0_0_0_1px_var(--app-accent-glow)]"
+                              : "border-app-border bg-app-elevated text-app-primary hover:bg-app-elevated/90"
+                          } disabled:cursor-not-allowed disabled:text-app-dim`}
                         >
                           {token + 1}
                         </button>
@@ -243,22 +243,22 @@ export default function ProblemsScreen() {
                   </div>
                 </div>
                 {problemPageInfo ? (
-                  <p className="text-xs text-zinc-500">
+                  <p className="text-xs text-app-dim">
                     현재 {problemPageInfo.page + 1} / {problemPageInfo.totalPages}
                   </p>
                 ) : null}
               </div>
 
               {problemError ? (
-                <div className="rounded-md border border-rose-400/60 bg-rose-900/25 px-3 py-2 text-sm text-rose-200">
+                <div className="rounded-md border border-app-danger/60 bg-app-danger/20 px-3 py-2 text-sm text-app-danger">
                   {problemError}
                 </div>
               ) : null}
 
-              <div className="overflow-hidden rounded-md border border-zinc-700">
+              <div className="overflow-hidden rounded-md border border-app-border">
                 <div className="overflow-x-auto">
                   <table className="min-w-full border-collapse text-sm">
-                    <thead className="bg-[#2b2d30] text-zinc-300">
+                    <thead className="bg-app-elevated text-app-secondary">
                       <tr>
                         <th className="px-4 py-3 text-left font-semibold">ID</th>
                         <th className="px-4 py-3 text-left font-semibold">제목</th>
@@ -269,29 +269,29 @@ export default function ProblemsScreen() {
                         <th className="px-4 py-3 text-left font-semibold">개인 풀이</th>
                       </tr>
                     </thead>
-                    <tbody className="bg-[#1e1f22]">
+                    <tbody className="bg-app-base">
                       {problemRows.length > 0 ? (
                         problemRows.map((problem) => (
-                          <tr key={problem.problemId} className="border-t border-zinc-700">
-                            <td className="px-4 py-3 font-medium text-zinc-100">
+                          <tr key={problem.problemId} className="border-t border-app-border">
+                            <td className="px-4 py-3 font-medium text-app-primary">
                               {problem.problemId}
                             </td>
-                            <td className="px-4 py-3 text-zinc-200">
+                            <td className="px-4 py-3 text-app-primary">
                               <Link
                                 href={`/problems/${problem.problemId}`}
-                                className="font-medium text-zinc-100 underline-offset-4 hover:text-violet-300 hover:underline"
+                                className="font-medium text-app-primary underline-offset-4 hover:text-app-accent-soft hover:underline"
                               >
                                 {problem.title}
                               </Link>
                             </td>
-                            <td className="px-4 py-3 text-zinc-300">{problem.difficulty}</td>
-                            <td className="px-4 py-3 text-zinc-300">{problem.difficultyRating}</td>
-                            <td className="px-4 py-3 text-zinc-300">{problem.timeLimitMs}ms</td>
-                            <td className="px-4 py-3 text-zinc-300">{problem.memoryLimitMb}MB</td>
+                            <td className="px-4 py-3 text-app-secondary">{problem.difficulty}</td>
+                            <td className="px-4 py-3 text-app-secondary">{problem.difficultyRating}</td>
+                            <td className="px-4 py-3 text-app-secondary">{problem.timeLimitMs}ms</td>
+                            <td className="px-4 py-3 text-app-secondary">{problem.memoryLimitMb}MB</td>
                             <td className="px-4 py-3">
                               <Link
                                 href={`/problems/${problem.problemId}`}
-                                className="inline-flex h-8 items-center justify-center rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-xs font-medium text-zinc-200 transition hover:bg-zinc-700/40"
+                                className="inline-flex h-8 items-center justify-center rounded-md border border-app-border bg-app-elevated px-3 text-xs font-medium text-app-primary transition hover:bg-app-elevated/90"
                               >
                                 열기
                               </Link>
@@ -299,8 +299,8 @@ export default function ProblemsScreen() {
                           </tr>
                         ))
                       ) : (
-                        <tr className="border-t border-zinc-700">
-                          <td colSpan={7} className="px-4 py-6 text-center text-zinc-500">
+                        <tr className="border-t border-app-border">
+                          <td colSpan={7} className="px-4 py-6 text-center text-app-dim">
                             {isProblemLoading
                               ? "목록을 불러오는 중입니다."
                               : "표시할 문제가 없습니다."}

--- a/src/features/signup/screen.tsx
+++ b/src/features/signup/screen.tsx
@@ -54,10 +54,10 @@ export default function SignupScreen() {
 
   return (
     <form onSubmit={handleSubmit} className="h-full min-h-0">
-      <main className="flex h-full min-h-0 flex-col border-b border-zinc-700/80 bg-[#1e1f22] lg:border-b-0 lg:border-r">
-        <div className="flex h-12 items-center border-b border-zinc-700/80 bg-[#1e1f22] px-3">
-          <div className="relative flex h-10 items-center gap-2 border-r border-zinc-700/70 bg-[#1e1f22] px-3 font-mono text-xs text-zinc-200">
-            <span className="inline-flex h-4 w-4 items-center justify-center text-[#a78bfa]">
+      <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
               <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
                 <path
                   d="M5.3 6.1a2.1 2.1 0 1 0 0-4.2 2.1 2.1 0 0 0 0 4.2Z"
@@ -79,23 +79,23 @@ export default function SignupScreen() {
               </svg>
             </span>
             <span>join-request.json</span>
-            <span className="text-zinc-500">×</span>
-            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-zinc-300" />
+            <span className="text-app-dim">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
           </div>
         </div>
 
-        <div className="flex-1 overflow-auto bg-[#1e1f22]">
+        <div className="flex-1 overflow-auto bg-app-base">
           <div className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6">
             <div className="mb-6">
-              <h1 className="text-xl font-semibold text-zinc-100">회원가입</h1>
-              <p className="mt-1 text-sm text-zinc-400">
+              <h1 className="text-xl font-semibold text-app-primary">회원가입</h1>
+              <p className="mt-1 text-sm text-app-muted">
                 이메일, 비밀번호, 닉네임을 입력해 계정을 생성합니다.
               </p>
             </div>
 
             <div className="grid gap-4 sm:grid-cols-2">
               <label className="space-y-2 sm:col-span-2">
-                <span className="text-sm font-medium text-zinc-200">이메일</span>
+                <span className="text-sm font-medium text-app-primary">이메일</span>
                 <input
                   type="email"
                   value={form.email}
@@ -103,13 +103,13 @@ export default function SignupScreen() {
                     setForm((current) => ({ ...current, email: event.target.value }))
                   }
                   placeholder="rookie@example.com"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
               </label>
 
               <label className="space-y-2">
-                <span className="text-sm font-medium text-zinc-200">비밀번호</span>
+                <span className="text-sm font-medium text-app-primary">비밀번호</span>
                 <input
                   type="password"
                   value={form.password}
@@ -117,16 +117,16 @@ export default function SignupScreen() {
                     setForm((current) => ({ ...current, password: event.target.value }))
                   }
                   placeholder="영문, 숫자, 특수문자 포함"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-app-dim">
                   8~12자, 영문/숫자/특수문자를 포함해주세요.
                 </p>
               </label>
 
               <label className="space-y-2">
-                <span className="text-sm font-medium text-zinc-200">비밀번호 확인</span>
+                <span className="text-sm font-medium text-app-primary">비밀번호 확인</span>
                 <input
                   type="password"
                   value={form.passwordConfirm}
@@ -137,13 +137,13 @@ export default function SignupScreen() {
                     }))
                   }
                   placeholder="비밀번호를 다시 입력하세요"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
               </label>
 
               <label className="space-y-2 sm:col-span-2">
-                <span className="text-sm font-medium text-zinc-200">닉네임</span>
+                <span className="text-sm font-medium text-app-primary">닉네임</span>
                 <input
                   type="text"
                   value={form.name}
@@ -151,7 +151,7 @@ export default function SignupScreen() {
                     setForm((current) => ({ ...current, name: event.target.value }))
                   }
                   placeholder="2~20자 닉네임"
-                  className="h-10 w-full rounded-md border border-zinc-700 bg-[#2b2d30] px-3 text-sm text-zinc-100 outline-none transition focus:border-[#4e89ff]/70"
+                  className="h-10 w-full rounded-md border border-app-border bg-app-elevated px-3 text-sm text-app-primary outline-none transition focus:border-app-accent/60"
                   required
                 />
               </label>
@@ -160,8 +160,8 @@ export default function SignupScreen() {
             <div
               className={`mt-5 rounded-md border px-3 py-2 text-sm ${
                 error
-                  ? "border-rose-400/60 bg-rose-900/25 text-rose-200"
-                  : "border-zinc-700 bg-[#2b2d30] text-zinc-300"
+                  ? "border-app-danger/60 bg-app-danger/20 text-app-danger"
+                  : "border-app-border bg-app-elevated text-app-secondary"
               }`}
             >
               {error
@@ -174,16 +174,16 @@ export default function SignupScreen() {
             <button
               type="submit"
               disabled={isPending || !passwordMatched}
-              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-[#9146ff] px-4 text-sm font-semibold text-white transition hover:bg-[#7f39fa] disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:bg-app-elevated disabled:text-app-secondary"
             >
               {isPending ? "가입 중..." : "회원가입"}
             </button>
 
-            <div className="mt-3 text-sm text-zinc-400">
+            <div className="mt-3 text-sm text-app-muted">
               이미 계정이 있다면{" "}
               <Link
                 href="/login"
-                className="font-medium text-violet-300 transition hover:text-violet-200"
+                className="font-medium text-app-accent-soft transition hover:text-app-primary"
               >
                 로그인
               </Link>

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -191,13 +191,13 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
           <div className="flex flex-wrap gap-3">
             <Link
               href={`/login?next=${encodeURIComponent(`/spectate/rooms/${roomId}`)}`}
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/spectate"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
             >
               관전 목록으로 돌아가기
             </Link>
@@ -221,7 +221,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
           actions={<StatusPill tone="danger">Load failed</StatusPill>}
         />
         <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-zinc-700">{error ?? message}</p>
+          <p className="text-sm leading-7 text-app-secondary">{error ?? message}</p>
         </Panel>
       </div>
     );
@@ -241,7 +241,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         }
       />
 
-      <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-700">
+      <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm text-app-secondary">
         {error ?? message}
       </div>
 
@@ -277,7 +277,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
       <div className="flex flex-wrap gap-3">
         <Link
           href="/spectate"
-          className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+          className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
         >
           관전 목록으로 돌아가기
         </Link>

--- a/src/features/spectate/screen.tsx
+++ b/src/features/spectate/screen.tsx
@@ -61,13 +61,13 @@ export default function SpectateScreen() {
           <div className="flex flex-wrap gap-3">
             <Link
               href="/login?next=/spectate"
-              className="rounded-2xl bg-zinc-950 px-4 py-3 text-sm font-medium text-white"
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
             >
               로그인하러 가기
             </Link>
             <Link
               href="/"
-              className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm font-medium text-zinc-900"
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
             >
               메인으로 돌아가기
             </Link>
@@ -91,7 +91,7 @@ export default function SpectateScreen() {
         }
       />
 
-      <div className="rounded-2xl border border-zinc-300 bg-white px-4 py-3 text-sm text-zinc-700">
+      <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm text-app-secondary">
         {error ?? message}
       </div>
 
@@ -111,31 +111,31 @@ export default function SpectateScreen() {
           <Link
             key={room.roomId}
             href={`/spectate/rooms/${room.roomId}`}
-            className="rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm transition hover:border-zinc-500"
+            className="rounded-2xl border border-app-border bg-app-surface p-5 shadow-sm transition hover:border-app-border-strong"
           >
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-sm text-zinc-500">roomId {room.roomId}</p>
-                <h2 className="mt-1 text-xl font-semibold text-zinc-950">
+                <p className="text-sm text-app-dim">roomId {room.roomId}</p>
+                <h2 className="mt-1 text-xl font-semibold text-app-primary">
                   {room.problemTitle}
                 </h2>
               </div>
               <StatusPill tone="success">{room.status}</StatusPill>
             </div>
-            <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-zinc-600">
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+            <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-app-secondary">
+              <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                   Current Players
                 </p>
-                <p className="mt-2 text-lg font-semibold text-zinc-950">
+                <p className="mt-2 text-lg font-semibold text-app-primary">
                   {room.currentPlayers} / {room.maxPlayers}
                 </p>
               </div>
-              <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                   Detail Route
                 </p>
-                <p className="mt-2 font-medium text-zinc-950">
+                <p className="mt-2 font-medium text-app-primary">
                   /spectate/rooms/{room.roomId}
                 </p>
               </div>

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -104,7 +104,7 @@ export type MatchingWsMessage =
 export interface ParticipantInfo {
   userId: number;
   nickname: string;
-  status: "READY" | "PLAYING" | "EXIT";
+  status: "READY" | "PLAYING" | "EXIT" | "ABANDONED";
 }
 
 export interface RoomResponse {
@@ -120,6 +120,10 @@ export interface JoinRoomResponse {
   roomId: number;
   status: string;
   timerEnd: string | null;
+}
+
+export interface BattleRoomStateResponse {
+  myCode: string | null;
 }
 
 export interface ProblemDetailResponse {

--- a/src/shared/ui/api-callout.tsx
+++ b/src/shared/ui/api-callout.tsx
@@ -8,14 +8,14 @@ export function ApiCallout({
   note: string;
 }) {
   return (
-    <div className="rounded-2xl border border-dashed border-zinc-400 bg-zinc-50 p-4">
+    <div className="rounded-2xl border border-dashed border-app-border-strong bg-app-elevated p-4">
       <div className="flex flex-wrap items-center gap-2 text-sm">
-        <span className="rounded-md bg-zinc-900 px-2 py-1 font-semibold text-zinc-50">
+        <span className="rounded-md bg-app-base px-2 py-1 font-semibold text-app-accent-soft">
           {method}
         </span>
-        <code className="text-zinc-900">{path}</code>
+        <code className="text-app-primary">{path}</code>
       </div>
-      <p className="mt-2 text-sm leading-6 text-zinc-600">{note}</p>
+      <p className="mt-2 text-sm leading-6 text-app-secondary">{note}</p>
     </div>
   );
 }

--- a/src/shared/ui/code-window.tsx
+++ b/src/shared/ui/code-window.tsx
@@ -10,15 +10,15 @@ export function CodeWindow({
   footer?: ReactNode;
 }) {
   return (
-    <div className="overflow-hidden rounded-2xl border border-zinc-300 bg-zinc-950 text-zinc-50">
-      <div className="border-b border-zinc-800 px-4 py-3 text-sm font-medium text-zinc-300">
+    <div className="overflow-hidden rounded-2xl border border-app-border bg-app-base text-app-primary">
+      <div className="border-b border-app-border px-4 py-3 text-sm font-medium text-app-secondary">
         {title}
       </div>
-      <pre className="overflow-x-auto p-4 text-sm leading-6 text-zinc-100">
+      <pre className="overflow-x-auto p-4 text-sm leading-6 text-app-primary">
         <code>{code}</code>
       </pre>
       {footer ? (
-        <div className="border-t border-zinc-800 px-4 py-3 text-xs text-zinc-400">
+        <div className="border-t border-app-border px-4 py-3 text-xs text-app-muted">
           {footer}
         </div>
       ) : null}

--- a/src/shared/ui/confirm-dialog.tsx
+++ b/src/shared/ui/confirm-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmTone?: "default" | "danger";
+  disabled?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  confirmTone = "default",
+  disabled = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeydown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    };
+
+    window.addEventListener("keydown", onKeydown);
+    return () => {
+      window.removeEventListener("keydown", onKeydown);
+    };
+  }, [onCancel, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const confirmButtonClass =
+    confirmTone === "danger"
+      ? "border-rose-400/30 bg-rose-500/15 text-rose-100 hover:border-rose-300/40 hover:bg-rose-500/20"
+      : "border-violet-400/45 bg-gradient-to-r from-violet-600 to-violet-500 text-white hover:from-violet-500 hover:to-violet-400";
+
+  return (
+    <div
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-zinc-950/45 px-4 backdrop-blur-[1px]"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-sm rounded-xl border border-zinc-700/80 bg-[#12161f] p-4 text-zinc-200 shadow-[0_18px_48px_rgba(0,0,0,0.55)]"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <p className="text-sm font-semibold">{title}</p>
+        {description ? (
+          <p className="mt-2 text-xs leading-6 text-zinc-300">{description}</p>
+        ) : null}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={disabled}
+            className="rounded-md border border-zinc-600 bg-[#171f2c] px-3 py-1.5 text-xs font-semibold text-zinc-200 transition hover:border-zinc-500 hover:bg-zinc-700/60 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={disabled}
+            className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${confirmButtonClass}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/confirm-dialog.tsx
+++ b/src/shared/ui/confirm-dialog.tsx
@@ -48,24 +48,24 @@ export function ConfirmDialog({
 
   const confirmButtonClass =
     confirmTone === "danger"
-      ? "border-rose-400/30 bg-rose-500/15 text-rose-100 hover:border-rose-300/40 hover:bg-rose-500/20"
-      : "border-violet-400/45 bg-gradient-to-r from-violet-600 to-violet-500 text-white hover:from-violet-500 hover:to-violet-400";
+      ? "border-app-danger/35 bg-app-danger/15 text-app-danger hover:border-app-danger/50 hover:bg-app-danger/20"
+      : "border-app-accent/45 bg-gradient-to-r from-app-accent to-app-accent-hover text-white hover:from-app-accent-hover hover:to-app-accent";
 
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-zinc-950/45 px-4 backdrop-blur-[1px]"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-app-base/55 px-4 backdrop-blur-[1px]"
       onClick={onCancel}
       role="presentation"
     >
       <div
-        className="w-full max-w-sm rounded-xl border border-zinc-700/80 bg-[#12161f] p-4 text-zinc-200 shadow-[0_18px_48px_rgba(0,0,0,0.55)]"
+        className="w-full max-w-sm rounded-xl border border-app-border/80 bg-app-surface p-4 text-app-primary shadow-[0_18px_48px_rgba(0,0,0,0.55)]"
         onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
       >
         <p className="text-sm font-semibold">{title}</p>
         {description ? (
-          <p className="mt-2 text-xs leading-6 text-zinc-300">{description}</p>
+          <p className="mt-2 text-xs leading-6 text-app-secondary">{description}</p>
         ) : null}
 
         <div className="mt-4 flex justify-end gap-2">
@@ -73,7 +73,7 @@ export function ConfirmDialog({
             type="button"
             onClick={onCancel}
             disabled={disabled}
-            className="rounded-md border border-zinc-600 bg-[#171f2c] px-3 py-1.5 text-xs font-semibold text-zinc-200 transition hover:border-zinc-500 hover:bg-zinc-700/60 disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-md border border-app-border bg-app-elevated px-3 py-1.5 text-xs font-semibold text-app-secondary transition hover:border-app-border-strong hover:bg-app-elevated/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {cancelLabel}
           </button>

--- a/src/shared/ui/definition-grid.tsx
+++ b/src/shared/ui/definition-grid.tsx
@@ -11,10 +11,10 @@ export function DefinitionGrid({
 }) {
   const cardClass =
     variant === "dark"
-      ? "rounded-2xl border border-zinc-700 bg-[#1b2130]"
-      : "rounded-2xl border border-zinc-300 bg-zinc-50";
-  const labelClass = variant === "dark" ? "text-zinc-500" : "text-zinc-500";
-  const valueClass = variant === "dark" ? "text-zinc-100" : "text-zinc-900";
+      ? "rounded-2xl border border-app-border bg-app-elevated"
+      : "rounded-2xl border border-app-border bg-app-surface";
+  const labelClass = "text-app-dim";
+  const valueClass = variant === "dark" ? "text-app-primary" : "text-app-secondary";
 
   return (
     <dl className={`grid sm:grid-cols-2 ${compact ? "gap-3" : "gap-4"}`}>

--- a/src/shared/ui/definition-grid.tsx
+++ b/src/shared/ui/definition-grid.tsx
@@ -3,21 +3,30 @@ import type { ReactNode } from "react";
 export function DefinitionGrid({
   items,
   compact = false,
+  variant = "default",
 }: {
   items: Array<{ label: string; value: ReactNode }>;
   compact?: boolean;
+  variant?: "default" | "dark";
 }) {
+  const cardClass =
+    variant === "dark"
+      ? "rounded-2xl border border-zinc-700 bg-[#1b2130]"
+      : "rounded-2xl border border-zinc-300 bg-zinc-50";
+  const labelClass = variant === "dark" ? "text-zinc-500" : "text-zinc-500";
+  const valueClass = variant === "dark" ? "text-zinc-100" : "text-zinc-900";
+
   return (
     <dl className={`grid sm:grid-cols-2 ${compact ? "gap-3" : "gap-4"}`}>
       {items.map((item) => (
         <div
           key={item.label}
-          className={`rounded-2xl border border-zinc-300 bg-zinc-50 ${compact ? "p-3" : "p-4"}`}
+          className={`${cardClass} ${compact ? "p-3" : "p-4"}`}
         >
-          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+          <dt className={`text-xs font-semibold uppercase tracking-[0.2em] ${labelClass}`}>
             {item.label}
           </dt>
-          <dd className={`mt-1.5 text-sm text-zinc-900 ${compact ? "leading-6" : "leading-7"}`}>
+          <dd className={`mt-1.5 text-sm ${valueClass} ${compact ? "leading-6" : "leading-7"}`}>
             {item.value}
           </dd>
         </div>

--- a/src/shared/ui/definition-grid.tsx
+++ b/src/shared/ui/definition-grid.tsx
@@ -2,20 +2,24 @@ import type { ReactNode } from "react";
 
 export function DefinitionGrid({
   items,
+  compact = false,
 }: {
   items: Array<{ label: string; value: ReactNode }>;
+  compact?: boolean;
 }) {
   return (
-    <dl className="grid gap-4 sm:grid-cols-2">
+    <dl className={`grid sm:grid-cols-2 ${compact ? "gap-3" : "gap-4"}`}>
       {items.map((item) => (
         <div
           key={item.label}
-          className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4"
+          className={`rounded-2xl border border-zinc-300 bg-zinc-50 ${compact ? "p-3" : "p-4"}`}
         >
           <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
             {item.label}
           </dt>
-          <dd className="mt-2 text-sm leading-7 text-zinc-900">{item.value}</dd>
+          <dd className={`mt-1.5 text-sm text-zinc-900 ${compact ? "leading-6" : "leading-7"}`}>
+            {item.value}
+          </dd>
         </div>
       ))}
     </dl>

--- a/src/shared/ui/empty-panel.tsx
+++ b/src/shared/ui/empty-panel.tsx
@@ -6,9 +6,9 @@ export function EmptyPanel({
   description: string;
 }) {
   return (
-    <div className="rounded-2xl border border-dashed border-zinc-400 bg-zinc-50 p-6 text-center">
-      <p className="font-medium text-zinc-900">{title}</p>
-      <p className="mt-2 text-sm leading-6 text-zinc-600">{description}</p>
+    <div className="rounded-2xl border border-dashed border-app-border-strong bg-app-elevated p-6 text-center">
+      <p className="font-medium text-app-primary">{title}</p>
+      <p className="mt-2 text-sm leading-6 text-app-secondary">{description}</p>
     </div>
   );
 }

--- a/src/shared/ui/event-timeline.tsx
+++ b/src/shared/ui/event-timeline.tsx
@@ -1,9 +1,9 @@
 const toneByType: Record<string, string> = {
-  BATTLE_STARTED: "border-emerald-300 bg-emerald-50 text-emerald-900",
-  SUBMISSION: "border-sky-300 bg-sky-50 text-sky-900",
-  PARTICIPANT_DONE: "border-indigo-300 bg-indigo-50 text-indigo-900",
-  BATTLE_FINISHED: "border-zinc-400 bg-zinc-200 text-zinc-900",
-  CODE_UPDATE: "border-amber-300 bg-amber-50 text-amber-900",
+  BATTLE_STARTED: "border-app-success/35 bg-app-success/10 text-app-success",
+  SUBMISSION: "border-sky-400/35 bg-sky-400/10 text-sky-300",
+  PARTICIPANT_DONE: "border-indigo-400/35 bg-indigo-400/10 text-indigo-300",
+  BATTLE_FINISHED: "border-app-border-strong bg-app-elevated text-app-primary",
+  CODE_UPDATE: "border-app-warn/35 bg-app-warn/10 text-app-warn",
 };
 
 export function EventTimeline({
@@ -21,15 +21,15 @@ export function EventTimeline({
       {events.map((event) => {
         const toneClass =
           toneByType[event.type] ??
-          "border-zinc-300 bg-zinc-100 text-zinc-800";
+          "border-app-border bg-app-elevated text-app-secondary";
 
         return (
           <li
             key={`${event.timestamp}-${event.type}-${event.headline}`}
-            className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4"
+            className="rounded-2xl border border-app-border bg-app-surface p-4"
           >
             <div className="flex flex-wrap items-center gap-3">
-              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
                 {event.timestamp}
               </span>
               <span
@@ -38,8 +38,8 @@ export function EventTimeline({
                 {event.type}
               </span>
             </div>
-            <p className="mt-3 font-medium text-zinc-950">{event.headline}</p>
-            <p className="mt-2 text-sm leading-6 text-zinc-600">{event.detail}</p>
+            <p className="mt-3 font-medium text-app-primary">{event.headline}</p>
+            <p className="mt-2 text-sm leading-6 text-app-secondary">{event.detail}</p>
           </li>
         );
       })}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,6 +1,7 @@
 export { ApiCallout } from "./api-callout";
 export { MathText } from "./math-text";
 export { CodeWindow } from "./code-window";
+export { ConfirmDialog } from "./confirm-dialog";
 export { DefinitionGrid } from "./definition-grid";
 export { EmptyPanel } from "./empty-panel";
 export { EventTimeline } from "./event-timeline";

--- a/src/shared/ui/metric.tsx
+++ b/src/shared/ui/metric.tsx
@@ -14,12 +14,12 @@ export function MetricCard({
   hint?: string;
 }) {
   return (
-    <div className="rounded-2xl border border-zinc-300 bg-zinc-50 p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">
+    <div className="rounded-2xl border border-app-border bg-app-elevated p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-dim">
         {label}
       </p>
-      <div className="mt-2 text-2xl font-semibold text-zinc-950">{value}</div>
-      {hint ? <p className="mt-2 text-sm text-zinc-600">{hint}</p> : null}
+      <div className="mt-2 text-2xl font-semibold text-app-primary">{value}</div>
+      {hint ? <p className="mt-2 text-sm text-app-secondary">{hint}</p> : null}
     </div>
   );
 }

--- a/src/shared/ui/page-hero.tsx
+++ b/src/shared/ui/page-hero.tsx
@@ -17,11 +17,11 @@ export function PageHero({
 }) {
   const rootToneClass =
     tone === "dark"
-      ? "border-zinc-700 bg-zinc-900 text-zinc-100"
-      : "border-zinc-300 bg-white text-zinc-950";
-  const eyebrowToneClass = tone === "dark" ? "text-zinc-400" : "text-zinc-500";
-  const titleToneClass = tone === "dark" ? "text-zinc-50" : "text-zinc-950";
-  const descriptionToneClass = tone === "dark" ? "text-zinc-300" : "text-zinc-600";
+      ? "border-app-border bg-app-surface text-app-primary"
+      : "border-app-border bg-app-elevated text-app-primary";
+  const eyebrowToneClass = "text-app-dim";
+  const titleToneClass = "text-app-primary";
+  const descriptionToneClass = tone === "dark" ? "text-app-secondary" : "text-app-muted";
 
   return (
     <section

--- a/src/shared/ui/panel.tsx
+++ b/src/shared/ui/panel.tsx
@@ -5,20 +5,29 @@ export function Panel({
   description,
   children,
   className = "",
+  variant = "default",
 }: {
   title: string;
   description?: string;
   children: ReactNode;
   className?: string;
+  variant?: "default" | "dark";
 }) {
+  const panelClass =
+    variant === "dark"
+      ? "rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]"
+      : "rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm";
+  const titleClass = variant === "dark" ? "text-zinc-100" : "text-zinc-950";
+  const descriptionClass = variant === "dark" ? "text-zinc-400" : "text-zinc-600";
+
   return (
     <section
-      className={`rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm ${className}`.trim()}
+      className={`${panelClass} ${className}`.trim()}
     >
       <div className="mb-4">
-        <h2 className="text-lg font-semibold text-zinc-950">{title}</h2>
+        <h2 className={`text-lg font-semibold ${titleClass}`}>{title}</h2>
         {description ? (
-          <p className="mt-1 text-sm leading-6 text-zinc-600">{description}</p>
+          <p className={`mt-1 text-sm leading-6 ${descriptionClass}`}>{description}</p>
         ) : null}
       </div>
       {children}

--- a/src/shared/ui/panel.tsx
+++ b/src/shared/ui/panel.tsx
@@ -15,10 +15,10 @@ export function Panel({
 }) {
   const panelClass =
     variant === "dark"
-      ? "rounded-2xl border border-zinc-700 bg-[#171c26] p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]"
-      : "rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm";
-  const titleClass = variant === "dark" ? "text-zinc-100" : "text-zinc-950";
-  const descriptionClass = variant === "dark" ? "text-zinc-400" : "text-zinc-600";
+      ? "rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]"
+      : "rounded-2xl border border-app-border bg-app-elevated p-5 shadow-[0_10px_24px_rgba(0,0,0,0.18)]";
+  const titleClass = "text-app-primary";
+  const descriptionClass = variant === "dark" ? "text-app-muted" : "text-app-secondary";
 
   return (
     <section

--- a/src/shared/ui/route-card.tsx
+++ b/src/shared/ui/route-card.tsx
@@ -14,16 +14,16 @@ export function RouteCard({
   return (
     <Link
       href={href}
-      className="group rounded-2xl border border-zinc-300 bg-white p-5 shadow-sm transition hover:border-zinc-500"
+      className="group rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition hover:border-app-accent/55"
     >
       <div className="flex items-center justify-between gap-3">
-        <h3 className="text-lg font-semibold text-zinc-950">{title}</h3>
-        <span className="rounded-full border border-zinc-300 px-2 py-1 text-xs text-zinc-500">
+        <h3 className="text-lg font-semibold text-app-primary">{title}</h3>
+        <span className="rounded-full border border-app-border px-2 py-1 text-xs text-app-dim">
           {meta}
         </span>
       </div>
-      <p className="mt-3 text-sm leading-6 text-zinc-600">{description}</p>
-      <span className="mt-4 inline-flex text-sm font-medium text-zinc-950 group-hover:underline">
+      <p className="mt-3 text-sm leading-6 text-app-secondary">{description}</p>
+      <span className="mt-4 inline-flex text-sm font-medium text-app-primary group-hover:text-app-accent-soft group-hover:underline">
         화면 열기
       </span>
     </Link>

--- a/src/shared/ui/simple-table.tsx
+++ b/src/shared/ui/simple-table.tsx
@@ -8,9 +8,9 @@ export function SimpleTable({
   rows: ReactNode[][];
 }) {
   return (
-    <div className="overflow-hidden rounded-2xl border border-zinc-300">
-      <table className="min-w-full border-collapse bg-white text-sm">
-        <thead className="bg-zinc-100 text-zinc-700">
+    <div className="overflow-hidden rounded-2xl border border-app-border">
+      <table className="min-w-full border-collapse bg-app-surface text-sm">
+        <thead className="bg-app-elevated text-app-secondary">
           <tr>
             {headers.map((header) => (
               <th key={header} className="px-4 py-3 text-left font-semibold">
@@ -21,9 +21,9 @@ export function SimpleTable({
         </thead>
         <tbody>
           {rows.map((row, index) => (
-            <tr key={index} className="border-t border-zinc-200">
+            <tr key={index} className="border-t border-app-border">
               {row.map((cell, cellIndex) => (
-                <td key={cellIndex} className="px-4 py-3 align-top text-zinc-700">
+                <td key={cellIndex} className="px-4 py-3 align-top text-app-secondary">
                   {cell}
                 </td>
               ))}

--- a/src/shared/ui/status-pill.tsx
+++ b/src/shared/ui/status-pill.tsx
@@ -12,19 +12,19 @@ export function StatusPill({
   const toneClass =
     variant === "dark"
       ? tone === "success"
-        ? "border-emerald-500/35 bg-emerald-500/10 text-emerald-200"
+        ? "border-app-success/35 bg-app-success/10 text-app-success"
         : tone === "warn"
-          ? "border-amber-500/35 bg-amber-500/10 text-amber-200"
+          ? "border-app-warn/35 bg-app-warn/10 text-app-warn"
           : tone === "danger"
-            ? "border-rose-500/35 bg-rose-500/10 text-rose-200"
-            : "border-zinc-700 bg-[#1f2736] text-zinc-200"
+            ? "border-app-danger/35 bg-app-danger/10 text-app-danger"
+            : "border-app-border bg-app-elevated text-app-secondary"
       : tone === "success"
-        ? "border-emerald-300 bg-emerald-50 text-emerald-900"
+        ? "border-app-success/35 bg-app-success/10 text-app-success"
         : tone === "warn"
-          ? "border-amber-300 bg-amber-50 text-amber-900"
+          ? "border-app-warn/35 bg-app-warn/10 text-app-warn"
           : tone === "danger"
-            ? "border-rose-300 bg-rose-50 text-rose-900"
-            : "border-zinc-300 bg-zinc-100 text-zinc-800";
+            ? "border-app-danger/35 bg-app-danger/10 text-app-danger"
+            : "border-app-border bg-app-elevated text-app-secondary";
 
   return (
     <span

--- a/src/shared/ui/status-pill.tsx
+++ b/src/shared/ui/status-pill.tsx
@@ -3,18 +3,28 @@ import type { ReactNode } from "react";
 export function StatusPill({
   children,
   tone = "default",
+  variant = "default",
 }: {
   children: ReactNode;
   tone?: "default" | "success" | "warn" | "danger";
+  variant?: "default" | "dark";
 }) {
   const toneClass =
-    tone === "success"
-      ? "border-emerald-300 bg-emerald-50 text-emerald-900"
-      : tone === "warn"
-        ? "border-amber-300 bg-amber-50 text-amber-900"
-        : tone === "danger"
-          ? "border-rose-300 bg-rose-50 text-rose-900"
-          : "border-zinc-300 bg-zinc-100 text-zinc-800";
+    variant === "dark"
+      ? tone === "success"
+        ? "border-emerald-500/35 bg-emerald-500/10 text-emerald-200"
+        : tone === "warn"
+          ? "border-amber-500/35 bg-amber-500/10 text-amber-200"
+          : tone === "danger"
+            ? "border-rose-500/35 bg-rose-500/10 text-rose-200"
+            : "border-zinc-700 bg-[#1f2736] text-zinc-200"
+      : tone === "success"
+        ? "border-emerald-300 bg-emerald-50 text-emerald-900"
+        : tone === "warn"
+          ? "border-amber-300 bg-amber-50 text-amber-900"
+          : tone === "danger"
+            ? "border-rose-300 bg-rose-50 text-rose-900"
+            : "border-zinc-300 bg-zinc-100 text-zinc-800";
 
   return (
     <span

--- a/src/shared/utils/editor-language.ts
+++ b/src/shared/utils/editor-language.ts
@@ -1,0 +1,26 @@
+const EDITOR_LANGUAGE_STORAGE_KEY = "bracket:editor-language:v1";
+
+export function readPreferredEditorLanguage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(EDITOR_LANGUAGE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writePreferredEditorLanguage(language: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(EDITOR_LANGUAGE_STORAGE_KEY, language);
+  } catch {
+    // ignore storage errors
+  }
+}
+


### PR DESCRIPTION
## 작업 개요

- 배틀룸/솔로룸 화면 구조를 통일하고, 전체 색감을 하나의 톤으로 맞췄습니다.
- 매칭 대기 모달과 테스트케이스 영역의 사용성을 개선했습니다.

## 영향 범위

- 메인 화면
- 로그인 / 회원가입
- 문제 목록
- 마이페이지
- 관전 화면
- 솔로룸 / 배틀룸

## 작업 내용

- [x] 배틀룸 UI를 솔로룸과 같은 구조로 정리
- [x] 분할 패널(드래그/접힘) 동작 개선
- [x] TestCase 헤더/상태 표시 방식 정리
- [x] 전역 색상 체계를 토큰 기반으로 통일
- [x] 다크 보라 → 그래파이트 중심 팔레트로 최종 조정
- [x] 매칭 모달 콘솔 스타일 및 취소 확인 UX 개선

## 변경 사항

- 전체 페이지 색상/보더/텍스트 톤 일관화
- 공용 컴포넌트 스타일 통일(패널, 상태 배지, 확인 다이얼로그 등)
- 메인 매칭 화면의 콘솔형 모달 가독성 개선
- 솔로/배틀의 코드-문제-테스트케이스 레이아웃 정리
- 배틀 재입장(ABANDONED) 흐름 보강

## 테스트 및 확인

- [ ] `npm run lint` (현재 로컬 eslint 설정 이슈로 미완료)
- [x] `npx tsc --noEmit`
- [x] 주요 화면 수동 확인
- [x] API/BFF 연동 확인

## 관련 이슈

- close #41

## 스크린샷 / 영상

- UI 변경 범위가 넓어 주요 화면은 코멘트로 추가 예정

## 참고 자료

- `docs/frontend-wireframe.md`
