### PR TITLE
[Feat] 메인 홈 매칭 흐름을 websocket 중심으로 전환

### DIFF
--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -994,7 +994,7 @@ export default function HomeScreen() {
 
       setFeedback(
         payload.message ??
-          "留ㅼ묶 ?섎씫??瑜?전송했습니다. ?ㅻⅨ 참가자의 응답을 기다리고 있습니다.",
+          "매칭 수락 요청을 전송했습니다. 다른 참가자의 응답을 기다리고 있습니다.",
       );
     } finally {
       setBusyAction(null);
@@ -1019,7 +1019,7 @@ export default function HomeScreen() {
         return;
       }
 
-      setFeedback(payload.message ?? "留ㅼ묶 嫄곗젅??瑜?전송했습니다.");
+      setFeedback(payload.message ?? "매칭 거절 요청을 전송했습니다.");
     } finally {
       setBusyAction(null);
     }

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -217,7 +217,11 @@ function parseMatchingWsMessage(body: string): MatchingWsMessage | null {
 
     if (
       typed.type === "QUEUE_STATE_CHANGED" ||
-      typed.type === "READY_CHECK_STARTED"
+      typed.type === "READY_CHECK_STARTED" ||
+      typed.type === "READY_DECISION_CHANGED" ||
+      typed.type === "MATCH_CANCELLED" ||
+      typed.type === "MATCH_EXPIRED" ||
+      typed.type === "ROOM_READY"
     ) {
       return payload as MatchingWsMessage;
     }
@@ -264,6 +268,7 @@ export default function HomeScreen() {
   const personalSubscriptionRef = useRef<SubscriptionHandle | null>(null);
   const queueTopicSubscriptionRef = useRef<SubscriptionHandle | null>(null);
   const queueTopicDestinationRef = useRef<string | null>(null);
+  const hasConnectedOnceRef = useRef(false);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
   const [editorLineCount, setEditorLineCount] = useState(28);
   const [editorLineHeight, setEditorLineHeight] = useState(32);
@@ -376,7 +381,7 @@ export default function HomeScreen() {
   }, []);
 
   const handleReadyCheckStartedEvent = useCallback(
-    (nextMatchState: MatchStateResponse | null) => {
+    async (nextMatchState: MatchStateResponse | null) => {
       logMatchingDebug("ws READY_CHECK_STARTED", nextMatchState);
       clearQueueTopicSubscription();
 
@@ -389,9 +394,39 @@ export default function HomeScreen() {
         return;
       }
 
+      const restoredMatchState = await readMatchState();
+
+      if (restoredMatchState && restoredMatchState.status !== "IDLE") {
+        logMatchingDebug("ws READY_CHECK_STARTED fallback matches/me", restoredMatchState);
+        applyMatchSnapshot(restoredMatchState);
+        return;
+      }
+
+      setMatchState(defaultMatchState);
       setModalMode("READY_CHECK");
       setPollStage("MATCH");
       setFeedback("ready-check 세션을 확인하는 중입니다.");
+    },
+    [applyMatchSnapshot, clearQueueTopicSubscription],
+  );
+
+  const handleMatchStateEvent = useCallback(
+    (
+      eventType:
+        | "READY_DECISION_CHANGED"
+        | "MATCH_CANCELLED"
+        | "MATCH_EXPIRED"
+        | "ROOM_READY",
+      nextMatchState: MatchStateResponse | null,
+    ) => {
+      logMatchingDebug(`ws ${eventType}`, nextMatchState);
+
+      if (!nextMatchState) {
+        return;
+      }
+
+      clearQueueTopicSubscription();
+      applyMatchSnapshot(nextMatchState);
     },
     [applyMatchSnapshot, clearQueueTopicSubscription],
   );
@@ -451,6 +486,7 @@ export default function HomeScreen() {
       personalSubscriptionRef.current = null;
       clearQueueTopicSubscription();
       stompClientRef.current = null;
+      hasConnectedOnceRef.current = false;
       return;
     }
 
@@ -465,11 +501,23 @@ export default function HomeScreen() {
           (message) => {
             const payload = parseMatchingWsMessage(message.body);
 
-            if (!payload || payload.type !== "READY_CHECK_STARTED") {
+            if (!payload) {
               return;
             }
 
-            handleReadyCheckStartedEvent(payload.match);
+            if (payload.type === "READY_CHECK_STARTED") {
+              void handleReadyCheckStartedEvent(payload.match);
+              return;
+            }
+
+            if (
+              payload.type === "READY_DECISION_CHANGED" ||
+              payload.type === "MATCH_CANCELLED" ||
+              payload.type === "MATCH_EXPIRED" ||
+              payload.type === "ROOM_READY"
+            ) {
+              handleMatchStateEvent(payload.type, payload.match);
+            }
           },
         );
 
@@ -492,6 +540,51 @@ export default function HomeScreen() {
             },
           );
         }
+
+        const shouldResync = hasConnectedOnceRef.current;
+        hasConnectedOnceRef.current = true;
+
+        if (!shouldResync) {
+          return;
+        }
+
+        void (async () => {
+          const [restoredQueueState, restoredMatchState] = await Promise.all([
+            readQueueState(),
+            readMatchState(),
+          ]);
+
+          if (stompClientRef.current !== client) {
+            return;
+          }
+
+          if (restoredQueueState?.inQueue) {
+            logMatchingDebug("ws reconnect resync queue/me", restoredQueueState);
+            setQueueState({
+              ...restoredQueueState,
+              requiredCount: restoredQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
+            });
+            setMatchState(defaultMatchState);
+            setQueueStartedAt((current) => current ?? new Date().toISOString());
+            setTerminalMessage(null);
+            setModalMode("SEARCHING");
+            setPollStage("QUEUE");
+            setError(null);
+            setFeedback("?湲곗뿴?먯꽌 ?곷?瑜?李얘퀬 ?덉뒿?덈떎.");
+            return;
+          }
+
+          if (restoredMatchState && restoredMatchState.status !== "IDLE") {
+            logMatchingDebug("ws reconnect resync matches/me", restoredMatchState);
+            clearQueueTopicSubscription();
+            applyMatchSnapshot(restoredMatchState);
+            return;
+          }
+
+          clearQueueTopicSubscription();
+          logMatchingDebug("ws reconnect resync idle");
+          resetFlow();
+        })();
       },
     });
 
@@ -503,12 +596,16 @@ export default function HomeScreen() {
       personalSubscriptionRef.current = null;
       clearQueueTopicSubscription();
       stompClientRef.current = null;
+      hasConnectedOnceRef.current = false;
       void client.deactivate();
     };
   }, [
+    applyMatchSnapshot,
     clearQueueTopicSubscription,
+    handleMatchStateEvent,
     handleQueueStateChangedEvent,
     handleReadyCheckStartedEvent,
+    resetFlow,
     session.authenticated,
     sessionLoaded,
   ]);
@@ -615,8 +712,7 @@ export default function HomeScreen() {
           ...nextQueueState,
           requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
         });
-        logMatchingDebug("poll matches/me status=IDLE", nextMatchState);
-        logMatchingDebug("poll matches/me status=IDLE", nextMatchState);
+        logMatchingDebug("initial restore queue/me inQueue=true", nextQueueState);
         setMatchState(defaultMatchState);
         setQueueStartedAt((current) => current ?? new Date().toISOString());
         setTerminalMessage(null);
@@ -628,6 +724,7 @@ export default function HomeScreen() {
       }
 
       if (nextMatchState && nextMatchState.status !== "IDLE") {
+        logMatchingDebug("initial restore matches/me", nextMatchState);
         applyMatchSnapshot(nextMatchState);
         return;
       }
@@ -667,6 +764,9 @@ export default function HomeScreen() {
     if (!session.authenticated || pollStage !== "QUEUE") {
       return;
     }
+
+    // SEARCHING 단계에서는 queue/me interval polling 대신 queue topic WebSocket만 사용한다.
+    return;
 
     let active = true;
 
@@ -737,6 +837,9 @@ export default function HomeScreen() {
     if (!session.authenticated || pollStage !== "MATCH") {
       return;
     }
+
+    // READY_CHECK 상태는 개인 matching WebSocket snapshot으로만 갱신한다.
+    return;
 
     let active = true;
 
@@ -889,7 +992,10 @@ export default function HomeScreen() {
         return;
       }
 
-      applyMatchSnapshot(payload);
+      setFeedback(
+        payload.message ??
+          "留ㅼ묶 ?섎씫??瑜?전송했습니다. ?ㅻⅨ 참가자의 응답을 기다리고 있습니다.",
+      );
     } finally {
       setBusyAction(null);
     }
@@ -913,7 +1019,7 @@ export default function HomeScreen() {
         return;
       }
 
-      applyMatchSnapshot(payload);
+      setFeedback(payload.message ?? "留ㅼ묶 嫄곗젅??瑜?전송했습니다.");
     } finally {
       setBusyAction(null);
     }

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -97,9 +97,37 @@ export interface ReadyCheckStartedWsMessage {
   match: MatchStateResponse | null;
 }
 
+export interface ReadyDecisionChangedWsMessage {
+  type: "READY_DECISION_CHANGED";
+  queue: null;
+  match: MatchStateResponse | null;
+}
+
+export interface MatchCancelledWsMessage {
+  type: "MATCH_CANCELLED";
+  queue: null;
+  match: MatchStateResponse | null;
+}
+
+export interface MatchExpiredWsMessage {
+  type: "MATCH_EXPIRED";
+  queue: null;
+  match: MatchStateResponse | null;
+}
+
+export interface RoomReadyWsMessage {
+  type: "ROOM_READY";
+  queue: null;
+  match: MatchStateResponse | null;
+}
+
 export type MatchingWsMessage =
   | QueueStateChangedWsMessage
-  | ReadyCheckStartedWsMessage;
+  | ReadyCheckStartedWsMessage
+  | ReadyDecisionChangedWsMessage
+  | MatchCancelledWsMessage
+  | MatchExpiredWsMessage
+  | RoomReadyWsMessage;
 
 export interface ParticipantInfo {
   userId: number;


### PR DESCRIPTION
refs #42
closes #42

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈 매칭 흐름을 <strong>matching WebSocket Stage 2</strong> 기준으로 확장한 작업입니다.
기존에는 SEARCHING 단계 이후 ready-check 상태 반영에 <code>matches/me</code> polling 흐름이 일부 남아 있었고,
개인 채널 WebSocket도 <code>READY_CHECK_STARTED</code>까지만 처리하고 있었습니다.
</p>

<p>
이번 변경에서는 메인 홈에서 <strong>matching 상태 변화는 WebSocket snapshot을 우선 반영</strong>하도록 정리했습니다.
즉,
</p>

<ul>
  <li>명령은 HTTP 유지</li>
  <li>상태 변화는 WebSocket 반영</li>
  <li>초기 진입 / 새로고침 / 재연결 복구만 REST 1회 조회 유지</li>
</ul>

<p>
구조로 맞췄습니다.
</p>

<hr />

<h3>1) matching WebSocket 이벤트 타입 확장</h3>
<p>
먼저 <code>src/shared/api/contracts.ts</code>에서 Stage 2 이벤트 타입을 추가했습니다.
기존에는 아래 두 이벤트만 프론트 타입으로 정의되어 있었습니다.
</p>

<ul>
  <li><code>QUEUE_STATE_CHANGED</code></li>
  <li><code>READY_CHECK_STARTED</code></li>
</ul>

<p>
이번 PR에서는 아래 4개를 추가했습니다.
</p>

<ul>
  <li><code>READY_DECISION_CHANGED</code></li>
  <li><code>MATCH_CANCELLED</code></li>
  <li><code>MATCH_EXPIRED</code></li>
  <li><code>ROOM_READY</code></li>
</ul>

<pre><code class="language-ts">export interface ReadyDecisionChangedWsMessage {
  type: "READY_DECISION_CHANGED";
  queue: null;
  match: MatchStateResponse | null;
}

export interface MatchCancelledWsMessage {
  type: "MATCH_CANCELLED";
  queue: null;
  match: MatchStateResponse | null;
}

export interface MatchExpiredWsMessage {
  type: "MATCH_EXPIRED";
  queue: null;
  match: MatchStateResponse | null;
}

export interface RoomReadyWsMessage {
  type: "ROOM_READY";
  queue: null;
  match: MatchStateResponse | null;
}</code></pre>

<p>
그리고 <code>MatchingWsMessage</code> union에도 포함해,
홈 화면에서 matching 이벤트를 타입 안전하게 분기할 수 있도록 정리했습니다.
</p>

<hr />

<h3>2) 개인 matching 채널 처리 범위 확장</h3>
<p>
<code>src/features/home/screen.tsx</code>의 개인 채널
<code>/user/queue/matching</code> 구독 로직을 확장했습니다.
기존에는 <code>READY_CHECK_STARTED</code>만 처리하고 있었지만,
이제는 아래 이벤트를 모두 받을 수 있습니다.
</p>

<ul>
  <li><code>READY_CHECK_STARTED</code></li>
  <li><code>READY_DECISION_CHANGED</code></li>
  <li><code>MATCH_CANCELLED</code></li>
  <li><code>MATCH_EXPIRED</code></li>
  <li><code>ROOM_READY</code></li>
</ul>

<pre><code class="language-ts">if (payload.type === "READY_CHECK_STARTED") {
  void handleReadyCheckStartedEvent(payload.match);
  return;
}

if (
  payload.type === "READY_DECISION_CHANGED" ||
  payload.type === "MATCH_CANCELLED" ||
  payload.type === "MATCH_EXPIRED" ||
  payload.type === "ROOM_READY"
) {
  handleMatchStateEvent(payload.type, payload.match);
}</code></pre>

<p>
즉 ready-check 시작 handoff뿐 아니라,
ready-check 진행 중 수락 인원 변화 / 취소 / 만료 / room ready까지
개인 채널 WebSocket으로 바로 반영합니다.
</p>

<hr />

<h3>3) <code>READY_CHECK_STARTED</code> fallback 보강</h3>
<p>
<code>READY_CHECK_STARTED</code> 이벤트를 받았는데 payload의 <code>match</code>가 비어 있거나
클라이언트가 snapshot을 바로 적용하기 어려운 경우를 대비해,
<code>matches/me</code> 1회 조회 fallback을 추가했습니다.
</p>

<pre><code class="language-ts">const restoredMatchState = await readMatchState();

if (restoredMatchState && restoredMatchState.status !== "IDLE") {
  logMatchingDebug("ws READY_CHECK_STARTED fallback matches/me", restoredMatchState);
  applyMatchSnapshot(restoredMatchState);
  return;
}</code></pre>

<p>
즉 ready-check 시작 이벤트는 WebSocket으로 받되,
필요한 경우 서버 상태를 한 번 다시 읽어 UI를 맞출 수 있도록 보완했습니다.
</p>

<hr />

<h3>4) SEARCHING → READY_CHECK 이후 상태도 WebSocket snapshot으로 반영</h3>
<p>
이번 PR의 핵심은 ready-check 이후 상태 전이를
<code>matches/me</code> polling이 아니라 WebSocket snapshot 중심으로 반영하도록 바꾼 것입니다.
</p>

<p>
이를 위해 <code>handleMatchStateEvent()</code>를 추가했고,
아래 이벤트가 오면 현재 queue topic 구독을 정리한 뒤
<code>applyMatchSnapshot()</code>으로 화면 상태를 갱신합니다.
</p>

<ul>
  <li><code>READY_DECISION_CHANGED</code></li>
  <li><code>MATCH_CANCELLED</code></li>
  <li><code>MATCH_EXPIRED</code></li>
  <li><code>ROOM_READY</code></li>
</ul>

<pre><code class="language-ts">const handleMatchStateEvent = useCallback((eventType, nextMatchState) => {
  logMatchingDebug(`ws ${eventType}`, nextMatchState);

  if (!nextMatchState) {
    return;
  }

  clearQueueTopicSubscription();
  applyMatchSnapshot(nextMatchState);
}, [...]);</code></pre>

<p>
즉 이제 프론트는 ready-check 상태를
“받은 snapshot으로 그대로 덮어쓰는 방식”으로 반영합니다.
</p>

<hr />

<h3>5) SEARCHING / READY_CHECK 주기 polling 런타임 제거</h3>
<p>
기존 코드에는 SEARCHING 단계의 <code>queue/me</code> interval polling과
READY_CHECK 단계의 <code>matches/me</code> interval polling effect가 남아 있었지만,
이번 변경에서는 두 effect 모두 시작 직후 <code>return</code> 하도록 바꿔
런타임 기준으로 interval polling이 돌지 않도록 정리했습니다.
</p>

<p>
즉 현재 구조는 다음과 같습니다.
</p>

<pre><code class="language-text">SEARCHING
  → queue topic WebSocket으로 waitingCount 갱신

READY_CHECK
  → 개인 matching WebSocket으로 상태 갱신

refresh / reconnect
  → queue/me, matches/me 1회 조회로 복구
</code></pre>

<p>
즉 polling을 완전히 소스에서 지운 것은 아니지만,
실제 동작 기준으로는 주기 polling을 끄고 WebSocket 반영으로 전환한 상태입니다.
</p>

<hr />

<h3>6) WebSocket 재연결 시 1회 resync 추가</h3>
<p>
주기 polling을 제거한 대신,
WebSocket 재연결 직후에는 상태를 한 번 다시 읽는 resync 로직을 추가했습니다.
이를 위해 <code>hasConnectedOnceRef</code>를 두고,
첫 연결이 아닌 재연결에서만 아래 흐름을 수행합니다.
</p>

<pre><code class="language-text">STOMP reconnect
  ↓
queue/me 1회 조회
matches/me 1회 조회
  ↓
queue 상태면 SEARCHING 복구
match 상태면 READY_CHECK / ROOM_READY 복구
둘 다 아니면 IDLE 복구
</code></pre>

<p>
즉 연결이 잠깐 끊겼다가 다시 붙더라도,
현재 매칭 상태를 1회 동기화해서 화면을 복구할 수 있습니다.
</p>

<hr />

<h3>7) 초기 진입 / 새로고침 복구 로그 정리</h3>
<p>
초기 복구 effect에서도 로그를 조금 더 명확하게 정리했습니다.
기존에는 중복되거나 의미가 불분명한 debug log가 있었는데,
이번 PR에서는 아래처럼 복구 경로가 바로 보이도록 바꿨습니다.
</p>

<ul>
  <li><code>initial restore queue/me inQueue=true</code></li>
  <li><code>initial restore matches/me</code></li>
</ul>

<p>
이를 통해 브라우저 콘솔에서
초기 진입 시 SEARCHING 복구인지, ready-check 복구인지
즉시 구분할 수 있도록 했습니다.
</p>

<hr />

<h3>8) accept / decline는 명령만 HTTP, 상태 반영은 WebSocket</h3>
<p>
accept / decline 요청은 여전히 HTTP로 전송하지만,
이번 PR에서는 성공 응답을 즉시 <code>applyMatchSnapshot()</code>에 넣지 않도록 변경했습니다.
</p>

<p>
즉 아래처럼 피드백 메시지만 갱신하고,
실제 acceptedCount, participants decision, cancel/expire/room ready 전이는
WebSocket 이벤트를 기다리도록 정리했습니다.
</p>

<pre><code class="language-ts">setFeedback(
  payload.message ??
    "매칭 수락 요청을 전송했습니다. 다른 참가자의 응답을 기다리고 있습니다.",
);</code></pre>

<pre><code class="language-ts">setFeedback(payload.message ?? "매칭 거절 요청을 전송했습니다.");</code></pre>

<p>
즉 이번 PR에서는
</p>

<ul>
  <li>HTTP = 명령 전송</li>
  <li>WebSocket = 상태 반영</li>
</ul>

<p>
역할을 더 명확하게 분리했습니다.
</p>

<hr />

<h3>9) 홈 매칭 피드백 문구 한글 깨짐 수정</h3>
<p>
이번 브랜치에는 추가로 홈 매칭 피드백 문구의 한글 깨짐 수정도 함께 포함되어 있습니다.
특히 accept / decline 이후 사용자에게 보여주는 피드백 문구를
정상적인 한국어 문장으로 정리했습니다.
</p>

<ul>
  <li><code>매칭 수락 요청을 전송했습니다. 다른 참가자의 응답을 기다리고 있습니다.</code></li>
  <li><code>매칭 거절 요청을 전송했습니다.</code></li>
</ul>

<hr />

<h3>10) 변경 파일</h3>
<ul>
  <li><code>src/features/home/screen.tsx</code></li>
  <li><code>src/shared/api/contracts.ts</code></li>
</ul>

<p>
이번 PR은 메인 홈 매칭 상태 전이와 matching 이벤트 타입 정의만 수정했고,
다른 feature 영역이나 설정 파일은 건드리지 않았습니다.
</p>

<hr />

<h3>11) 테스트 / 확인 포인트</h3>
<ol>
  <li>로그인 후 홈 진입 시 <code>/user/queue/matching</code> 구독이 생성되는지 확인</li>
  <li>queue join 성공 후 queue topic 구독이 시작되는지 확인</li>
  <li><code>QUEUE_STATE_CHANGED</code> 수신으로 waitingCount가 실시간 반영되는지 확인</li>
  <li><code>READY_CHECK_STARTED</code> 수신 시 SEARCHING에서 READY_CHECK로 전환되는지 확인</li>
  <li><code>READY_DECISION_CHANGED</code> 수신 시 accepted count, acceptedByMe, participants decision이 갱신되는지 확인</li>
  <li><code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code> 수신 시 terminal UI가 정상 노출되는지 확인</li>
  <li><code>ROOM_READY</code> 수신 시 roomId를 확보하고 기존 battle room join 흐름으로 이동하는지 확인</li>
  <li>accept / decline 성공 후 상태 반영이 HTTP 응답이 아니라 WebSocket snapshot으로 이뤄지는지 확인</li>
  <li>새로고침 시 <code>queue/me</code>, <code>matches/me</code> 1회 조회로 SEARCHING / READY_CHECK / ROOM_READY 복구가 되는지 확인</li>
  <li>WebSocket 재연결 시 1회 resync로 상태를 복구할 수 있는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx.cmd tsc --noEmit</code> 기준으로 확인했습니다.
</p>
