### PR TITLE
fix: connect SockJS directly to backend to bypass Vercel serverless

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -588,7 +588,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS("/ws"),
+      webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
       reconnectDelay: 3000,
       beforeConnect: async () => {
         client.connectHeaders = {};

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -455,7 +455,7 @@ export default function HomeScreen() {
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS("/ws"),
+      webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
       reconnectDelay: 3000,
       onConnect: () => {
         logMatchingDebug("ws connected");

--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -457,7 +457,7 @@ export default function ProblemSoloScreen({ problemId }: { problemId: string }) 
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS("/ws"),
+      webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
       reconnectDelay: 3000,
       // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
       // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -124,7 +124,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
     if (!session.authenticated) return;
 
     const client = new Client({
-      webSocketFactory: () => new SockJS("/ws"),
+      webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
       reconnectDelay: 3000,
       // 연결(및 재연결) 시마다 1회용 토큰을 새로 발급해 STOMP CONNECT 헤더에 주입.
       // 토큰은 30초 TTL이고 1회 사용 후 폐기되므로 재연결 시에도 반드시 새 토큰이 필요.


### PR DESCRIPTION
## 작업 개요

- connect SockJS directly to backend to bypass Vercel serverless

## 영향 범위


## 작업 내용

- [ ] connect SockJS directly to backend to bypass Vercel serverless

## 변경 사항

**1. src/features/home/screen.tsx:458**

// 전

webSocketFactory: () => new SockJS("/ws"),

// 후

webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),

**2. src/features/battle-room/screen.tsx:205**

// 전

webSocketFactory: () => new SockJS("/ws"),

// 후

webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),

**3. src/features/spectate-room/screen.tsx:127**

// 전

webSocketFactory: () => new SockJS("/ws"),

// 후

webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),

**4. src/features/problem-solo/screen.tsx:353**

// 전

webSocketFactory: () => new SockJS("/ws"),

// 후

webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
