### PR TITLE
[fix] 홈 매칭 websocket 연결을 /ws 경로로 복구

### DIFF
--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -491,7 +491,7 @@ export default function HomeScreen() {
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
+      webSocketFactory: () => new SockJS("/ws"),
       reconnectDelay: 3000,
       onConnect: () => {
         logMatchingDebug("ws connected");


### PR DESCRIPTION
refs #49 
closes #49 

<p>
배포 환경에서 홈 매칭 화면의 WebSocket 연결이 direct backend 방식으로 변경된 이후,
매칭 진행 상태부터 ready-check 진입, 수락/거절 상태까지 실시간 반영이 불안정해지는 문제가 있었습니다.
일부 참여자 화면에서는 상태가 바로 반영되지 않았고, 새로고침 이후에만 현재 상태가 복구되는 현상이 발생했습니다.
</p>

<h2>문제 상황</h2>
<ul>
  <li>매칭 진행 상태가 참여자별로 다르게 보이거나 늦게 반영됨</li>
  <li>ready-check 진입 상태가 즉시 반영되지 않음</li>
  <li>수락/거절 상태도 실시간으로 동기화되지 않음</li>
  <li>결과적으로 홈 매칭 전 과정이 새로고침 이후에만 정상 복구되는 현상이 있었음</li>
</ul>

<h2>원인</h2>
<p>
기존에는 홈 매칭 WebSocket이 <code>new SockJS("/ws")</code> 방식으로 동작하면서,
브라우저가 프론트 origin으로 먼저 요청한 뒤 Vercel/Next rewrite를 통해 백엔드로 전달되는 구조였습니다.
</p>

<pre><code>기존: 브라우저 -&gt; 프론트(Vercel) -&gt; 백엔드(EC2)</code></pre>

<p>
이후 WebSocket 연결이 direct backend 방식으로 변경되면서 브라우저가
<code>api.the-bracket.site/ws</code>로 직접 연결을 시도하게 되었습니다.
</p>

<pre><code>변경 후: 브라우저 -&gt; 백엔드(EC2)</code></pre>

<p>
문제는 홈 매칭 화면이 direct backend로 바뀌는 과정에서,
배틀룸/솔로/관전 화면처럼 <code>X-WS-Token</code> 기반 인증 보완이 함께 적용되지 않았다는 점입니다.
그 결과 배포 환경에서는 인증 정보가 충분하지 않은 상태로 WebSocket/STOMP 연결 재시도가 반복되었고,
홈 매칭 실시간 상태 동기화가 깨졌습니다.
</p>

<h2>변경 사항</h2>
<ul>
  <li>홈 매칭 화면의 WebSocket 연결 경로를 direct backend 방식에서 same-origin <code>/ws</code> 방식으로 복구</li>
  <li><code>new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL}/ws`)</code> 대신 <code>new SockJS("/ws")</code> 사용</li>
  <li>기존 Vercel/Next rewrite 기반 경로를 다시 사용하도록 복원</li>
  <li>관련 배경과 원인을 팀 문서로 남기기 위해 회고 문서 추가</li>
</ul>

<h2>변경 의도</h2>
<p>
이번 수정은 WebSocket 구조를 새로 설계하는 작업이 아니라,
운영 환경에서 홈 매칭 실시간 동기화를 우선 안정화하기 위한 복구 성격의 변경입니다.
direct backend 방식 자체가 잘못된 것은 아니지만,
현재 코드 기준으로는 홈 매칭 화면의 인증 흐름까지 완전히 이관되지 않아 배포 환경에서 문제가 발생하고 있었습니다.
</p>

<h2>기대 효과</h2>
<ul>
  <li>배포 환경에서도 홈 매칭 진행 상태가 새로고침 없이 반영됨</li>
  <li>ready-check 진입 상태가 참여자 화면에 일관되게 표시됨</li>
  <li>수락/거절 상태 변경이 다른 참여자 화면에도 즉시 반영됨</li>
  <li>홈 매칭 전 과정의 실시간 상태 동기화 안정성 향상</li>
</ul>

<h2>테스트 및 확인 포인트</h2>
<ul>
  <li>4인 매칭 시 모든 참여자 화면에서 매칭 진행 상태가 동일하게 반영되는지 확인</li>
  <li>ready-check 진입이 새로고침 없이 즉시 반영되는지 확인</li>
  <li>수락/거절 상태 변경이 다른 참여자 화면에도 즉시 반영되는지 확인</li>
  <li>배포 환경에서 이전처럼 새로고침이 필요하지 않은지 확인</li>
</ul>