### PR TITLE
[feat] 관전페이지 디바운싱 적용

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -287,6 +287,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const leftPaneRatioRef = useRef(leftPaneRatio);
   const rightTopPaneRatioRef = useRef(rightTopPaneRatio);
   const sampleCasesRef = useRef(problem?.sampleCases ?? []);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
@@ -698,13 +699,17 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   function handleCodeChange(nextCode: string) {
     setCode(nextCode);
 
-    if (stompClientRef.current?.connected && room?.status === "PLAYING") {
-      stompClientRef.current.publish({
+    if (!stompClientRef.current?.connected || room?.status !== "PLAYING") return;
+
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+
+    debounceTimerRef.current = setTimeout(() => {
+      stompClientRef.current?.publish({
         destination: `/app/room/${roomId}/code`,
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ code: nextCode }),
       });
-    }
+    }, 1000);
   }
 
   async function handleRunCase(caseIndex: number) {

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -687,6 +687,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     return () => {
       stompClientRef.current = null;
       void client.deactivate();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
     };
   }, [roomId, session.authenticated, session.member?.memberId]);
 
@@ -704,7 +708,8 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
 
     debounceTimerRef.current = setTimeout(() => {
-      stompClientRef.current?.publish({
+      if (!stompClientRef.current?.connected || room?.status !== "PLAYING") return;
+      stompClientRef.current.publish({
         destination: `/app/room/${roomId}/code`,
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ code: nextCode }),

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -7,6 +7,7 @@ import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
+  CodeSyncWsMessage,
   CodeUpdateWsMessage,
   ProblemDetailResponse,
   RoomResponse,
@@ -33,6 +34,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
   const [codeByUserId, setCodeByUserId] = useState<Record<number, string>>({});
   const [lastUpdatedByUserId, setLastUpdatedByUserId] = useState<Record<number, string>>({});
   const stompClientRef = useRef<Client | null>(null);
+  const participantsRef = useRef<RoomResponse["participants"]>([]);
 
   // 세션 및 방 정보 로드
   useEffect(() => {
@@ -96,6 +98,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         return;
       }
       setRoom(nextRoom);
+      participantsRef.current = nextRoom.participants;
 
       const problemResponse = await fetch(`/api/problems/${nextRoom.problemId}`, {
         cache: "no-store",
@@ -160,13 +163,23 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
             return;
           }
 
-          if ((payload as { type: unknown }).type === "CODE_UPDATE") {
-            const msg = payload as CodeUpdateWsMessage;
+          const type = (payload as { type: unknown }).type;
+          if (type === "CODE_UPDATE" || type === "CODE_SYNC") {
+            const msg = payload as CodeUpdateWsMessage | CodeSyncWsMessage;
             const now = new Date().toLocaleTimeString("ko-KR");
             setCodeByUserId((prev) => ({ ...prev, [msg.userId]: msg.code }));
             setLastUpdatedByUserId((prev) => ({ ...prev, [msg.userId]: now }));
           }
         });
+
+        // 구독 직후 모든 참여자의 최신 코드 동기화 요청
+        for (const participant of participantsRef.current) {
+          client.publish({
+            destination: `/app/room/${roomId}/code/sync`,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ targetUserId: participant.userId }),
+          });
+        }
       },
     });
 

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
+  BattleFinishedWsMessage,
   CodeSyncWsMessage,
   CodeUpdateWsMessage,
   ProblemDetailResponse,
@@ -15,6 +17,7 @@ import type {
 import { useAppSession } from "@/features/layout/session-context";
 import {
   CodeWindow,
+  ConfirmDialog,
   MetricCard,
   MetricGrid,
   PageHero,
@@ -25,12 +28,14 @@ import {
 import { getSpectateRoom } from "./data";
 
 export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
+  const router = useRouter();
   const { session, sessionLoaded, refreshSession } = useAppSession();
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [message, setMessage] = useState("관전 정보를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
   const [requiresLogin, setRequiresLogin] = useState(false);
+  const [battleFinished, setBattleFinished] = useState(false);
   const [codeByUserId, setCodeByUserId] = useState<Record<number, string>>({});
   const [lastUpdatedByUserId, setLastUpdatedByUserId] = useState<Record<number, string>>({});
   const stompClientRef = useRef<Client | null>(null);
@@ -148,6 +153,23 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
         }
       },
       onConnect: () => {
+        client.subscribe(`/topic/room/${roomId}`, (frame) => {
+          let payload: unknown;
+          try {
+            payload = JSON.parse(frame.body) as unknown;
+          } catch {
+            return;
+          }
+          if (
+            typeof payload === "object" &&
+            payload !== null &&
+            "type" in payload &&
+            (payload as { type: unknown }).type === "BATTLE_FINISHED"
+          ) {
+            setBattleFinished(true);
+          }
+        });
+
         client.subscribe(`/topic/room/${roomId}/spectate`, (frame) => {
           let payload: unknown;
           try {
@@ -247,6 +269,15 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
 
   return (
     <div className="space-y-8">
+      <ConfirmDialog
+        open={battleFinished}
+        title="배틀이 종료되었습니다"
+        description="참여자들의 최종 코드를 확인하거나 관전 목록으로 돌아갈 수 있습니다."
+        confirmLabel="관전 목록으로"
+        cancelLabel="계속 보기"
+        onConfirm={() => router.push("/spectate")}
+        onCancel={() => setBattleFinished(false)}
+      />
       <PageHero
         eyebrow="Spectate Room"
         title={`관전 Room ${roomId} — ${problemTitle}`}

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -35,6 +35,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
   const [lastUpdatedByUserId, setLastUpdatedByUserId] = useState<Record<number, string>>({});
   const stompClientRef = useRef<Client | null>(null);
   const participantsRef = useRef<RoomResponse["participants"]>([]);
+  const roomStatusRef = useRef<RoomResponse["status"] | null>(null);
 
   // 세션 및 방 정보 로드
   useEffect(() => {
@@ -99,6 +100,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
       }
       setRoom(nextRoom);
       participantsRef.current = nextRoom.participants;
+      roomStatusRef.current = nextRoom.status;
 
       const problemResponse = await fetch(`/api/problems/${nextRoom.problemId}`, {
         cache: "no-store",
@@ -166,19 +168,22 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
           const type = (payload as { type: unknown }).type;
           if (type === "CODE_UPDATE" || type === "CODE_SYNC") {
             const msg = payload as CodeUpdateWsMessage | CodeSyncWsMessage;
+            if (!msg.code) return;
             const now = new Date().toLocaleTimeString("ko-KR");
             setCodeByUserId((prev) => ({ ...prev, [msg.userId]: msg.code }));
             setLastUpdatedByUserId((prev) => ({ ...prev, [msg.userId]: now }));
           }
         });
 
-        // 구독 직후 모든 참여자의 최신 코드 동기화 요청
-        for (const participant of participantsRef.current) {
-          client.publish({
-            destination: `/app/room/${roomId}/code/sync`,
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ targetUserId: participant.userId }),
-          });
+        // 구독 직후 모든 참여자의 최신 코드 동기화 요청 (방이 종료된 경우 코드가 삭제됐으므로 스킵)
+        if (roomStatusRef.current !== "FINISHED") {
+          for (const participant of participantsRef.current) {
+            client.publish({
+              destination: `/app/room/${roomId}/code/sync`,
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ targetUserId: participant.userId }),
+            });
+          }
         }
       },
     });

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -276,6 +276,12 @@ export interface CodeUpdateWsMessage {
   code: string;
 }
 
+export interface CodeSyncWsMessage {
+  type: "CODE_SYNC";
+  userId: number;
+  code: string;
+}
+
 export interface ParticipantDoneWsMessage {
   type: "PARTICIPANT_DONE";
   userId: number;

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -282,6 +282,10 @@ export interface CodeSyncWsMessage {
   code: string;
 }
 
+export interface BattleFinishedWsMessage {
+  type: "BATTLE_FINISHED";
+}
+
 export interface ParticipantDoneWsMessage {
   type: "PARTICIPANT_DONE";
   userId: number;


### PR DESCRIPTION
## 작업 개요

- 서버 부하 최소화를 위해 관전 채널로의 코드 전송에 디바운싱 적용(1초)
- 관전 페이지 새로고침 시 받아온 코드가 초기화되는 문제 수정
- 방 종료 후 관전 새로고침 시 Redis에서 삭제된 코드를 null로 수신하는 경우 state 업데이트를 건너뜀
- 방이 FINISHED 상태인 경우 sync 요청 자체를 스킵하도록 처리
- 관전자가 메인 채널(`/topic/room/{roomId}`)을 구독하여 `BATTLE_FINISHED` 이벤트 수신 시 종료 알림 모달 표시
- 디바운스 타이머 실행 시점에 연결 상태·방 상태를 재검증하고, 컴포넌트 언마운트 시 타이머 cleanup 추가

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용


## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인


## 관련 이슈

- close #52 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
