### PR TITLE
[refactor] 마이페이지/배틀결과 UI 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from "next";
 
-const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+const DEFAULT_BACKEND_BASE_URL = "http://localhost:8080";
+
+function normalizeBackendBaseUrl(url: string) {
+  return url.trim().replace(/\/+$/, "");
+}
+
+const BACKEND_BASE_URL = normalizeBackendBaseUrl(
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_BACKEND_BASE_URL,
+);
 
 const nextConfig: NextConfig = {
   async rewrites() {

--- a/src/app/api/members/me/rating-progress/route.ts
+++ b/src/app/api/members/me/rating-progress/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { RatingProgressApiResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET() {
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      "/api/v1/members/me/rating-progress",
+      {},
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json(
+        {
+          resultCode: "MEMBER_401",
+          msg: "로그인이 필요합니다.",
+          data: null,
+        } satisfies RatingProgressApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await readJsonBody<RatingProgressApiResponse>(response.clone());
+
+    if (!response.ok) {
+      return NextResponse.json(
+        body ?? {
+          resultCode: String(response.status),
+          msg: await getErrorMessage(response),
+          data: null,
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(
+      body ?? {
+        resultCode: "200",
+        msg: "내 레이팅 진행도 조회 성공",
+        data: null,
+      } satisfies RatingProgressApiResponse,
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        resultCode: "MEMBER_503",
+        msg: "내 레이팅 진행도 조회에 실패했습니다.",
+        data: null,
+      } satisfies RatingProgressApiResponse,
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/members/me/route.ts
+++ b/src/app/api/members/me/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { MyInfoApiResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET() {
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue("/api/v1/members/me", {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json(
+        {
+          resultCode: "MEMBER_401",
+          msg: "로그인이 필요합니다.",
+          data: null,
+        } satisfies MyInfoApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await readJsonBody<MyInfoApiResponse>(response.clone());
+
+    if (!response.ok) {
+      return NextResponse.json(
+        body ?? {
+          resultCode: String(response.status),
+          msg: await getErrorMessage(response),
+          data: null,
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(
+      body ?? {
+        resultCode: "200",
+        msg: "내 정보 조회 성공",
+        data: null,
+      } satisfies MyInfoApiResponse,
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        resultCode: "MEMBER_503",
+        msg: "내 정보 조회에 실패했습니다.",
+        data: null,
+      } satisfies MyInfoApiResponse,
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/battle-result/screen.tsx
+++ b/src/features/battle-result/screen.tsx
@@ -8,19 +8,19 @@ import type {
   BattleResultResponse,
 } from "@/shared/api/contracts";
 import {
-  ApiCallout,
   MetricCard,
   MetricGrid,
-  PageHero,
   Panel,
   SimpleTable,
   StatusPill,
 } from "@/shared/ui";
 import { formatDateTime } from "@/shared/utils/format-date-time";
+import { useAppSession } from "@/features/layout/session-context";
 
 import { getBattleResult } from "./data";
 
 export default function BattleResultScreen({ roomId }: { roomId: string }) {
+  const { session } = useAppSession();
   const [result, setResult] = useState<BattleResultResponse | null>(null);
   const [message, setMessage] = useState("배틀 결과를 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
@@ -62,128 +62,232 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
 
   if (requiresLogin) {
     return (
-      <div className="space-y-8">
-        <PageHero
-          eyebrow="Battle Result"
-          title="로그인 후 결과를 확인할 수 있습니다."
-          description="결과 조회는 보호된 배틀 API를 사용합니다."
-          actions={<StatusPill tone="warn">로그인 필요</StatusPill>}
-        />
-        <Panel title="이동" description="보호 화면 진입 전 처리">
-          <div className="flex flex-wrap gap-3">
-            <Link
-              href={`/login?next=${encodeURIComponent(`/battle/results/${roomId}`)}`}
-              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
-            >
-              로그인하러 가기
-            </Link>
-            <Link
-              href="/"
-              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
-            >
-              메인으로 돌아가기
-            </Link>
+      <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
+              <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                <path d="M3 2.5V13.5" stroke="currentColor" strokeWidth="1.2" />
+                <path
+                  d="M3.7 3.5H12L10.4 5.3L12 7.1H3.7V3.5Z"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+              </svg>
+            </span>
+            <span>result-room-{roomId}.json</span>
+            <span className="text-app-dim">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
           </div>
-        </Panel>
-      </div>
+        </div>
+
+        <div className="flex-1 overflow-auto bg-app-base">
+          <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+            <section className="space-y-4 rounded-2xl border border-app-border bg-app-surface p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h1 className="text-xl font-semibold text-app-primary">로그인 후 결과를 확인할 수 있습니다.</h1>
+                <StatusPill tone="warn">로그인 필요</StatusPill>
+              </div>
+              <p className="text-sm text-app-muted">결과 조회는 보호된 배틀 API를 사용합니다.</p>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href={`/login?next=${encodeURIComponent(`/battle/results/${roomId}`)}`}
+                  className="inline-flex h-10 items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover"
+                >
+                  로그인하러 가기
+                </Link>
+                <Link
+                  href="/"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-app-border bg-app-elevated px-4 text-sm font-medium text-app-primary transition hover:bg-app-surface"
+                >
+                  메인으로 돌아가기
+                </Link>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
     );
   }
 
   if (!result) {
     return (
-      <div className="space-y-8">
-        <PageHero
-          eyebrow="Battle Result"
-          title="결과를 열지 못했습니다."
-          description="현재 roomId에 해당하는 결과를 찾지 못했습니다."
-          actions={<StatusPill tone="danger">Load failed</StatusPill>}
-        />
-        <Panel title="오류" description="응답 메시지">
-          <p className="text-sm leading-7 text-app-secondary">{error ?? message}</p>
-        </Panel>
-      </div>
+      <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+        <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+          <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+            <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
+              <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+                <path d="M3 2.5V13.5" stroke="currentColor" strokeWidth="1.2" />
+                <path
+                  d="M3.7 3.5H12L10.4 5.3L12 7.1H3.7V3.5Z"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+              </svg>
+            </span>
+            <span>result-room-{roomId}.json</span>
+            <span className="text-app-dim">×</span>
+            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto bg-app-base">
+          <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+            <section className="space-y-4 rounded-2xl border border-app-danger/35 bg-app-danger/10 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h1 className="text-xl font-semibold text-app-danger">결과를 열지 못했습니다.</h1>
+                <StatusPill tone="danger">Load failed</StatusPill>
+              </div>
+              <p className="text-sm text-app-secondary">{error ?? message}</p>
+            </section>
+          </div>
+        </div>
+      </main>
     );
   }
 
   const winner = result.participants.find((participant) => participant.finalRank === 1);
+  const myParticipant = session.member
+    ? result.participants.find((participant) => participant.userId === session.member?.memberId)
+    : null;
+  const myScoreDelta = myParticipant ? `${myParticipant.scoreDelta > 0 ? "+" : ""}${myParticipant.scoreDelta}` : "-";
 
   return (
-    <div className="space-y-8">
-      <PageHero
-        eyebrow="Battle Result"
-        title={`Room ${result.roomId} 결과 정산`}
-        description="배틀이 끝난 뒤에는 최종 순위, 점수 변동, 통과 수를 확인합니다. 실제 결과 조회를 우선하고, 연결 실패 시에만 샘플 결과를 표시합니다."
-        actions={
-          <>
-            <StatusPill tone="success">FINISHED</StatusPill>
-            <StatusPill>{source === "api" ? "API" : "Fallback"}</StatusPill>
-          </>
-        }
-      />
-
-      <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm text-app-secondary">
-        {error ?? message}
-      </div>
-
-      <MetricGrid>
-        <MetricCard label="Winner" value={winner?.nickname ?? "-"} />
-        <MetricCard label="Participants" value={result.participants.length} />
-        <MetricCard label="Top Score Delta" value={`+${winner?.scoreDelta ?? 0}`} />
-        <MetricCard label="Problem" value={result.problemTitle} />
-      </MetricGrid>
-
-      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-        <Panel
-          title="최종 리더보드"
-          description="`finalRank`, `scoreDelta`, `passedCount`, `finishTime`를 우선 노출합니다."
-        >
-          <SimpleTable
-            headers={[
-              "순위",
-              "닉네임",
-              "결과",
-              "통과",
-              "점수 변동",
-              "완료 시각",
-            ]}
-            rows={result.participants.map((participant) => [
-              participant.finalRank,
-              participant.nickname,
-              participant.result ?? "미제출",
-              `${participant.passedCount}/${participant.totalCount}`,
-              `+${participant.scoreDelta}`,
-              formatDateTime(participant.finishTime),
-            ])}
-          />
-        </Panel>
-
-        <Panel
-          title="정산 정책 메모"
-          description="현재 백엔드 서비스에 정의된 점수 정책"
-        >
-          <ul className="space-y-3 text-sm leading-7 text-app-secondary">
-            <li>1등 +100, 2등 +70, 3등 +40, 4등 +20</li>
-            <li>WA 1회당 20초 패널티가 순위 계산에 반영됩니다.</li>
-            <li>AC가 없는 참여자는 뒤 순위로 밀립니다.</li>
-            <li>방 상태가 FINISHED가 아니면 결과 조회가 실패합니다.</li>
-          </ul>
-        </Panel>
-      </div>
-
-      <Panel title="연결 엔드포인트" description="결과와 관전 허브가 붙는 실제 지점">
-        <div className="grid gap-4 lg:grid-cols-2">
-          <ApiCallout
-            method="GET"
-            path={`/api/battle/rooms/${result.roomId}/result`}
-            note="정산이 끝난 방의 최종 결과를 조회합니다."
-          />
-          <ApiCallout
-            method="GET"
-            path="/api/battle/rooms"
-            note="진행 중인 방 목록 조회는 관전 허브에서 사용합니다."
-          />
+    <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
+      <div className="flex h-12 items-center border-b border-app-border/80 bg-app-base px-3">
+        <div className="relative flex h-10 items-center gap-2 border-r border-app-border/70 bg-app-base px-3 font-mono text-xs text-app-primary">
+          <span className="inline-flex h-4 w-4 items-center justify-center text-app-accent-soft">
+            <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4">
+              <path d="M3 2.5V13.5" stroke="currentColor" strokeWidth="1.2" />
+              <path
+                d="M3.7 3.5H12L10.4 5.3L12 7.1H3.7V3.5Z"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+            </svg>
+          </span>
+          <span>result-room-{result.roomId}.json</span>
+          <span className="text-app-dim">×</span>
+          <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
         </div>
-      </Panel>
-    </div>
+      </div>
+
+      <div className="flex-1 overflow-auto bg-app-base">
+        <div className="mx-auto w-full max-w-6xl space-y-5 px-4 py-6 sm:px-6">
+          <section className="rounded-2xl border border-app-border bg-gradient-to-r from-app-surface to-app-elevated p-5 shadow-[0_14px_32px_rgba(0,0,0,0.28)]">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-2">
+                <p className="font-mono text-xs uppercase tracking-[0.22em] text-app-dim">battle-result.log</p>
+                <h1 className="text-xl font-semibold text-app-primary">Room {result.roomId} 결과 정산</h1>
+                <p className="text-sm text-app-muted">마이페이지에서 선택한 경기의 최종 순위와 점수 변동을 확인합니다.</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <StatusPill tone="success">FINISHED</StatusPill>
+                <StatusPill>{source === "api" ? "API" : "Fallback"}</StatusPill>
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-app-border bg-app-base px-3 py-2 text-sm text-app-secondary">
+              <span>{error ?? message}</span>
+              <Link
+                href="/mypage"
+                className="inline-flex h-9 items-center justify-center rounded-md border border-app-border bg-app-elevated px-3 text-sm font-medium text-app-primary transition hover:bg-app-surface"
+              >
+                내 전적으로 돌아가기
+              </Link>
+            </div>
+          </section>
+
+          <MetricGrid>
+            <MetricCard label="Winner" value={winner?.nickname ?? "-"} />
+            <MetricCard label="Participants" value={result.participants.length} />
+            <MetricCard label="Top Score Delta" value={`+${winner?.scoreDelta ?? 0}`} />
+            <MetricCard label="Problem" value={result.problemTitle} />
+          </MetricGrid>
+
+          <div className="grid gap-5 xl:grid-cols-[0.95fr_1.05fr]">
+            <Panel
+              variant="dark"
+              title="내 결과 요약"
+              description="현재 로그인한 내 계정 기준 정산 요약"
+            >
+              {myParticipant ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
+                    <p className="text-xs text-app-dim">최종 순위</p>
+                    <p className="mt-1 text-lg font-semibold text-app-primary">
+                      {myParticipant.finalRank}등
+                    </p>
+                  </div>
+                  <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
+                    <p className="text-xs text-app-dim">제출 결과</p>
+                    <p className="mt-1 text-lg font-semibold text-app-primary">
+                      {myParticipant.result ?? "미제출"}
+                    </p>
+                  </div>
+                  <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
+                    <p className="text-xs text-app-dim">통과 수</p>
+                    <p className="mt-1 text-lg font-semibold text-app-primary">
+                      {myParticipant.passedCount}/{myParticipant.totalCount}
+                    </p>
+                  </div>
+                  <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
+                    <p className="text-xs text-app-dim">점수 변화</p>
+                    <p
+                      className={`mt-1 text-lg font-semibold ${
+                        myParticipant.scoreDelta > 0
+                          ? "text-app-success"
+                          : myParticipant.scoreDelta < 0
+                            ? "text-app-danger"
+                            : "text-app-secondary"
+                      }`}
+                    >
+                      {myScoreDelta}
+                    </p>
+                  </div>
+                  <div className="rounded-xl border border-app-border bg-app-base px-3 py-2 sm:col-span-2">
+                    <p className="text-xs text-app-dim">완료 시각</p>
+                    <p className="mt-1 text-sm font-medium text-app-primary">
+                      {formatDateTime(myParticipant.finishTime)}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-xl border border-app-border bg-app-base px-3 py-3 text-sm text-app-secondary">
+                  현재 로그인 계정의 제출 기록을 찾지 못했습니다.
+                </div>
+              )}
+            </Panel>
+
+            <Panel
+              variant="dark"
+              title="최종 리더보드"
+              description="전체 참가자 결과"
+            >
+              <SimpleTable
+                headers={[
+                  "구분",
+                  "순위",
+                  "닉네임",
+                  "결과",
+                  "통과",
+                  "점수 변동",
+                  "완료 시각",
+                ]}
+                rows={result.participants.map((participant) => [
+                  session.member?.memberId === participant.userId ? "ME" : "-",
+                  participant.finalRank,
+                  participant.nickname,
+                  participant.result ?? "미제출",
+                  `${participant.passedCount}/${participant.totalCount}`,
+                  `${participant.scoreDelta > 0 ? "+" : ""}${participant.scoreDelta}`,
+                  formatDateTime(participant.finishTime),
+                ])}
+              />
+            </Panel>
+          </div>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -6,7 +6,12 @@ import { useEffect, useState } from "react";
 import type {
   MyBattleResultItem,
   MyBattleResultsResponse,
+  MyInfoApiResponse,
+  MyInfoResponse,
   PageInfo,
+  RatingProgressApiResponse,
+  RatingProgressResponse,
+  RatingRequirementProgress,
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
 import { formatDateTime } from "@/shared/utils/format-date-time";
@@ -37,6 +42,36 @@ async function readMyBattleResults(page: number, size: number) {
   };
 }
 
+async function readMyInfo() {
+  const response = await fetch("/api/members/me", {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as MyInfoApiResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
+async function readMyRatingProgress() {
+  const response = await fetch("/api/members/me/rating-progress", {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as RatingProgressApiResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
 function formatRank(rank: number) {
   return `${rank}등`;
 }
@@ -56,6 +91,34 @@ function toneForScore(scoreDelta: number) {
   }
 
   return "text-app-secondary";
+}
+
+function formatRequirementValue(requirement: RatingRequirementProgress, value: number) {
+  if (requirement.key === "recentTop2Ratio") {
+    return `${Math.round(value * 100)}%`;
+  }
+
+  if (requirement.key === "godSeatRank") {
+    return `${Math.max(1, Math.round(value))}위`;
+  }
+
+  return `${Math.round(value)}`;
+}
+
+function formatRequirementRemaining(requirement: RatingRequirementProgress) {
+  if (requirement.remaining <= 0) {
+    return "0";
+  }
+
+  if (requirement.key === "recentTop2Ratio") {
+    return `${Math.round(requirement.remaining * 100)}%`;
+  }
+
+  if (requirement.key === "godSeatRank") {
+    return `${Math.round(requirement.remaining)}위`;
+  }
+
+  return `${Math.round(requirement.remaining)}`;
 }
 
 function ResultCard({ item }: { item: MyBattleResultItem }) {
@@ -134,6 +197,10 @@ function LoadingRows() {
 
 export default function MyPageScreen() {
   const { session, sessionLoaded, refreshSession } = useAppSession();
+  const [myInfo, setMyInfo] = useState<MyInfoResponse | null>(null);
+  const [myInfoError, setMyInfoError] = useState<string | null>(null);
+  const [ratingProgress, setRatingProgress] = useState<RatingProgressResponse | null>(null);
+  const [ratingProgressError, setRatingProgressError] = useState<string | null>(null);
   const [battleResults, setBattleResults] = useState<MyBattleResultItem[]>([]);
   const [pageInfo, setPageInfo] = useState(defaultPageInfo);
   const [message, setMessage] = useState("내 전적을 불러오는 중입니다.");
@@ -150,26 +217,84 @@ export default function MyPageScreen() {
 
     void (async () => {
       if (!session.authenticated) {
+        setMyInfo(null);
+        setMyInfoError(null);
+        setRatingProgress(null);
+        setRatingProgressError(null);
+        setBattleResults([]);
+        setPageInfo(defaultPageInfo);
+        setError(null);
         setIsLoading(false);
         setMessage("로그인 후 내 전적을 확인할 수 있습니다.");
         return;
       }
 
-      const { ok, status, payload } = await readMyBattleResults(0, PAGE_SIZE);
+      const [myInfoResponse, battleResultsResponse, ratingProgressResponse] = await Promise.all([
+        readMyInfo(),
+        readMyBattleResults(0, PAGE_SIZE),
+        readMyRatingProgress(),
+      ]);
 
       if (!active) {
         return;
       }
 
-      if (status === 401 || payload?.resultCode === "MEMBER_401") {
+      const isUnauthorized =
+        myInfoResponse.status === 401 ||
+        myInfoResponse.payload?.resultCode === "MEMBER_401" ||
+        ratingProgressResponse.status === 401 ||
+        ratingProgressResponse.payload?.resultCode === "MEMBER_401" ||
+        battleResultsResponse.status === 401 ||
+        battleResultsResponse.payload?.resultCode === "MEMBER_401";
+
+      if (isUnauthorized) {
         void refreshSession();
+        setMyInfo(null);
+        setMyInfoError(null);
+        setRatingProgress(null);
+        setRatingProgressError(null);
         setBattleResults([]);
         setPageInfo(defaultPageInfo);
         setError(null);
-        setMessage(payload?.msg ?? "로그인이 필요합니다.");
+        setMessage(
+          myInfoResponse.payload?.msg ??
+            ratingProgressResponse.payload?.msg ??
+            battleResultsResponse.payload?.msg ??
+            "로그인이 필요합니다.",
+        );
         setIsLoading(false);
         return;
       }
+
+      if (
+        myInfoResponse.ok &&
+        myInfoResponse.payload &&
+        myInfoResponse.payload.resultCode === "200" &&
+        myInfoResponse.payload.data
+      ) {
+        setMyInfo(myInfoResponse.payload.data);
+        setMyInfoError(null);
+      } else {
+        setMyInfo(null);
+        setMyInfoError(myInfoResponse.payload?.msg ?? "내 레이팅 정보를 불러오지 못했습니다.");
+      }
+
+      if (
+        ratingProgressResponse.ok &&
+        ratingProgressResponse.payload &&
+        ratingProgressResponse.payload.resultCode === "200" &&
+        ratingProgressResponse.payload.data
+      ) {
+        setRatingProgress(ratingProgressResponse.payload.data);
+        setRatingProgressError(null);
+      } else {
+        setRatingProgress(null);
+        setRatingProgressError(
+          ratingProgressResponse.payload?.msg ?? "다음 티어 조건을 불러오지 못했습니다.",
+        );
+      }
+
+      const { ok, payload } = battleResultsResponse;
 
       if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
         setBattleResults([]);
@@ -228,6 +353,26 @@ export default function MyPageScreen() {
   const solvedCount = battleResults.filter((item) => item.solved).length;
   const loadedCount = battleResults.length;
   const currentPage = pageInfo.totalPages > 0 ? pageInfo.page + 1 : 0;
+
+  const battleMatchCount = ratingProgress?.current.battleMatchCount ?? myInfo?.battleMatchCount ?? null;
+  const firstSolvedProblemCount =
+    ratingProgress?.current.firstSolvedProblemCount ?? myInfo?.firstSolvedProblemCount ?? null;
+  const shouldDisplayUnranked =
+    battleMatchCount !== null &&
+    firstSolvedProblemCount !== null &&
+    battleMatchCount === 0 &&
+    firstSolvedProblemCount === 0;
+  const displayTier = ratingProgress?.current.displayTier ?? (shouldDisplayUnranked ? "UNRANKED" : (myInfo?.tier ?? "-"));
+  const battleRating =
+    ratingProgress?.current.battleRating ??
+    myInfo?.battleRating ??
+    (typeof myInfo?.score === "number" ? myInfo.score : null);
+  const hardBattleRating = ratingProgress?.current.hardBattleRating ?? myInfo?.hardBattleRating ?? null;
+  const firstSolveScore = ratingProgress?.current.activityPoint ?? myInfo?.firstSolveScore ?? null;
+  const tierScore = myInfo?.tierScore ?? battleRating;
+  const nextTier = ratingProgress?.next ?? null;
+  const nextRequirements = nextTier?.requirements ?? [];
+  const satisfiedRequirementCount = nextRequirements.filter((requirement) => requirement.satisfied).length;
 
   return (
     <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
@@ -290,30 +435,173 @@ export default function MyPageScreen() {
             <div className="space-y-5">
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                 <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">닉네임</p>
+                  <p className="text-xs text-app-dim">표시 티어</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
-                    {session.member?.nickname ?? "-"}
+                    {displayTier}
                   </p>
                 </div>
                 <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">이메일</p>
-                  <p className="mt-1 truncate text-base font-semibold text-app-primary">
-                    {session.member?.email ?? "-"}
+                  <p className="text-xs text-app-dim">SR (battleRating)</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {battleRating ?? "-"}
                   </p>
                 </div>
                 <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">역할</p>
+                  <p className="text-xs text-app-dim">Hard SR</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
-                    {formatRoleLabel(session.member?.role)}
+                    {hardBattleRating ?? "-"}
                   </p>
                 </div>
                 <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">해결 / 전체</p>
+                  <p className="text-xs text-app-dim">AP (firstSolveScore)</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
-                    {solvedCount} / {loadedCount}
+                    {firstSolveScore ?? "-"}
                   </p>
                 </div>
               </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">랭킹 표시 점수 (tierScore)</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">{tierScore ?? "-"}</p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">배틀 판수</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {battleMatchCount ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">first solve 문제 수</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {firstSolvedProblemCount ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">닉네임 / 역할</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {myInfo?.nickname ?? session.member?.nickname ?? "-"}
+                  </p>
+                  <p className="mt-0.5 text-xs text-app-muted">
+                    {formatRoleLabel(myInfo?.role ?? session.member?.role)}
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">1400+ 해결</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {ratingProgress?.current.solved1400Plus ?? myInfo?.solved1400Plus ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">1700+ 해결</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {ratingProgress?.current.solved1700Plus ?? myInfo?.solved1700Plus ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">2000+ 해결</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {ratingProgress?.current.solved2000Plus ?? myInfo?.solved2000Plus ?? "-"}
+                  </p>
+                </div>
+                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                  <p className="text-xs text-app-dim">2300+ 해결 / 최근 Top2 비율</p>
+                  <p className="mt-1 text-base font-semibold text-app-primary">
+                    {ratingProgress?.current.solved2300Plus ?? myInfo?.solved2300Plus ?? "-"} /{" "}
+                    {typeof ratingProgress?.current.recentTop2Ratio === "number"
+                      ? `${Math.round(ratingProgress.current.recentTop2Ratio * 100)}%`
+                      : typeof myInfo?.recentTop2Rate === "number"
+                        ? `${Math.round(myInfo.recentTop2Rate * 100)}%`
+                      : "-"}
+                  </p>
+                </div>
+              </div>
+
+              <section className="rounded-md border border-app-border bg-app-elevated p-4">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <h2 className="text-sm font-semibold text-app-primary">다음 티어 진행도</h2>
+                    <p className="mt-1 text-xs text-app-muted">
+                      현재 티어에서 다음 티어로 올라가기 위해 필요한 조건입니다.
+                    </p>
+                  </div>
+                  {nextTier ? (
+                    <span className="inline-flex h-7 items-center rounded-full border border-app-border-strong bg-app-base px-3 text-xs font-semibold text-app-primary">
+                      {displayTier} → {nextTier.tier}
+                    </span>
+                  ) : (
+                    <span className="inline-flex h-7 items-center rounded-full border border-app-border-strong bg-app-base px-3 text-xs font-semibold text-app-primary">
+                      최상위 티어
+                    </span>
+                  )}
+                </div>
+
+                {ratingProgressError ? (
+                  <p className="text-sm text-app-warn">{ratingProgressError}</p>
+                ) : !ratingProgress ? (
+                  <p className="text-sm text-app-muted">티어 진행도를 불러오는 중입니다.</p>
+                ) : !nextTier ? (
+                  <p className="text-sm text-app-success">현재 GOD 티어입니다. 더 높은 티어는 없습니다.</p>
+                ) : (
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                      <p className="text-app-secondary">{nextTier.message}</p>
+                      <p className="text-app-dim">
+                        충족 {satisfiedRequirementCount}/{nextRequirements.length}
+                      </p>
+                    </div>
+
+                    {nextRequirements.map((requirement) => {
+                      const progressPercent =
+                        requirement.comparison === "AT_LEAST"
+                          ? Math.min(100, Math.round((requirement.current / Math.max(requirement.required, 1)) * 100))
+                          : requirement.satisfied
+                            ? 100
+                            : 0;
+
+                      return (
+                        <div
+                          key={requirement.key}
+                          className="rounded-md border border-app-border bg-app-base px-3 py-2"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="text-sm font-medium text-app-primary">{requirement.label}</p>
+                            <p
+                              className={`text-xs font-semibold ${
+                                requirement.satisfied ? "text-app-success" : "text-app-warn"
+                              }`}
+                            >
+                              {requirement.satisfied ? "충족" : "미충족"}
+                            </p>
+                          </div>
+                          <p className="mt-1 text-xs text-app-muted">
+                            현재 {formatRequirementValue(requirement, requirement.current)} / 목표{" "}
+                            {formatRequirementValue(requirement, requirement.required)}
+                            {requirement.satisfied ? "" : ` · 남은 값 ${formatRequirementRemaining(requirement)}`}
+                          </p>
+                          <div className="mt-2 h-1.5 rounded-full bg-app-border">
+                            <div
+                              className={`h-1.5 rounded-full ${
+                                requirement.satisfied ? "bg-app-success" : "bg-app-accent"
+                              }`}
+                              style={{ width: `${progressPercent}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+
+              {myInfoError ? (
+                <div className="rounded-md border border-app-warn/60 bg-app-warn/15 px-3 py-2 text-sm text-app-warn">
+                  {myInfoError}
+                </div>
+              ) : null}
 
               {error ? (
                 <div className="rounded-md border border-app-danger/60 bg-app-danger/20 px-3 py-2 text-sm text-app-danger">

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -121,18 +121,94 @@ function formatRequirementRemaining(requirement: RatingRequirementProgress) {
   return `${Math.round(requirement.remaining)}`;
 }
 
+function buildRequirementActionGuide(requirement: RatingRequirementProgress) {
+  if (requirement.satisfied) {
+    return "현재 조건을 충족했습니다. 다음 조건을 계속 채우면 승급에 가까워집니다.";
+  }
+
+  if (requirement.key === "battleRating") {
+    const remaining = Math.max(0, requirement.required - requirement.current);
+    const realisticFast = Math.max(1, Math.ceil(remaining / 15));
+    const realisticSafe = Math.max(1, Math.ceil(remaining / 8));
+    const optimistic = Math.max(1, Math.ceil(remaining / 25));
+    const absoluteMin = Math.max(1, Math.ceil(remaining / 35));
+    return `배틀 SR 조건입니다. 동급 매칭 체감 기준(+8~15)으로 약 ${realisticFast}~${realisticSafe}판, 초반 K 구간(+15~25) 기준 약 ${optimistic}판이 필요합니다. (+35는 상한이라 이론 최소 ${absoluteMin}판)`;
+  }
+
+  if (requirement.key === "hardBattleRating") {
+    const remaining = Math.max(0, requirement.required - requirement.current);
+    const realisticFast = Math.max(1, Math.ceil(remaining / 15));
+    const realisticSafe = Math.max(1, Math.ceil(remaining / 8));
+    const optimistic = Math.max(1, Math.ceil(remaining / 25));
+    const absoluteMin = Math.max(1, Math.ceil(remaining / 35));
+    return `Hard SR은 난이도 2000+ 배틀에서만 반영됩니다. 동급 매칭 체감 기준(+8~15)으로 약 ${realisticFast}~${realisticSafe}판, 초반 K 구간(+15~25) 기준 약 ${optimistic}판이 필요합니다. (+35는 상한이라 이론 최소 ${absoluteMin}판)`;
+  }
+
+  if (requirement.key === "activityPoint" || requirement.key === "firstSolveScore") {
+    const remaining = Math.max(0, requirement.required - requirement.current);
+    const fastTrack = Math.max(1, Math.ceil(remaining / 20));
+    const safeTrack = Math.max(1, Math.ceil(remaining / 10));
+    if (fastTrack === safeTrack) {
+      return `문제 first solve(문제당 +10~20 AP) 기준으로 약 ${fastTrack}문제 추가 해결이 필요합니다.`;
+    }
+    return `문제 first solve(문제당 +10~20 AP) 기준으로 약 ${fastTrack}~${safeTrack}문제 추가 해결이 필요합니다.`;
+  }
+
+  if (requirement.key === "solved1400Plus") {
+    const remaining = Math.max(1, Math.ceil(requirement.required - requirement.current));
+    return `1400+ 난이도 문제를 first solve로 ${remaining}개 더 달성하면 조건을 채울 수 있습니다.`;
+  }
+
+  if (requirement.key === "solved1700Plus") {
+    const remaining = Math.max(1, Math.ceil(requirement.required - requirement.current));
+    return `1700+ 난이도 문제를 first solve로 ${remaining}개 더 달성하면 조건을 채울 수 있습니다.`;
+  }
+
+  if (requirement.key === "solved2000Plus") {
+    const remaining = Math.max(1, Math.ceil(requirement.required - requirement.current));
+    return `2000+ 난이도 문제를 first solve로 ${remaining}개 더 달성하면 조건을 채울 수 있습니다.`;
+  }
+
+  if (requirement.key === "solved2300Plus") {
+    const remaining = Math.max(1, Math.ceil(requirement.required - requirement.current));
+    return `2300+ 난이도 문제를 first solve로 ${remaining}개 더 달성하면 조건을 채울 수 있습니다.`;
+  }
+
+  if (requirement.key === "recentTop2Ratio") {
+    const currentTop2Wins = Math.round(requirement.current * 20);
+    const targetTop2Wins = Math.ceil(requirement.required * 20);
+    const neededTop2Wins = Math.max(1, targetTop2Wins - currentTop2Wins);
+    return `최근 20판 기준 Top2 비율 조건입니다. 현재 약 ${currentTop2Wins}/20, 목표 ${targetTop2Wins}/20으로 최소 ${neededTop2Wins}회 추가 Top2가 필요합니다.`;
+  }
+
+  if (requirement.key === "godSeatRank") {
+    const currentRank = Math.max(1, Math.round(requirement.current));
+    const targetRank = Math.max(1, Math.round(requirement.required));
+    const rankGap = Math.max(1, currentRank - targetRank);
+    return `GOD는 좌석제입니다. 현재 ${currentRank}위에서 ${targetRank}위 이내로 올라야 하며, 최소 ${rankGap}계단 상승이 필요합니다.`;
+  }
+
+  return "이 조건은 누적 성과가 반영되면 자동으로 갱신됩니다.";
+}
+
+const statCardClass =
+  "rounded-xl border border-app-border bg-app-surface px-3 py-2 shadow-[0_10px_22px_rgba(0,0,0,0.18)]";
+const infoCardClass = "rounded-xl border border-app-border bg-app-elevated px-3 py-2";
+
 function ResultCard({ item }: { item: MyBattleResultItem }) {
   return (
     <Link
       href={`/battle/results/${item.roomId}`}
-      className="block rounded-md border border-app-border bg-app-elevated p-4 transition hover:bg-app-elevated/90"
+      className="group block rounded-2xl border border-app-border bg-app-surface p-4 shadow-[0_10px_24px_rgba(0,0,0,0.2)] transition hover:border-app-border-strong hover:bg-app-elevated"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
           <p className="text-xs text-app-dim">
             roomId {item.roomId} · problemId {item.problemId}
           </p>
-          <h3 className="mt-1 text-base font-semibold text-app-primary">{item.problemTitle}</h3>
+          <h3 className="mt-1 text-base font-semibold text-app-primary group-hover:text-app-accent-soft">
+            {item.problemTitle}
+          </h3>
           <p className="mt-1 text-xs text-app-muted">{formatDateTime(item.playedAt)} 플레이</p>
         </div>
         <div className="flex items-center gap-2 text-xs">
@@ -152,17 +228,17 @@ function ResultCard({ item }: { item: MyBattleResultItem }) {
       </div>
 
       <div className="mt-4 grid gap-2 text-sm sm:grid-cols-3">
-        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+        <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
           <p className="text-xs text-app-dim">최종 순위</p>
           <p className="mt-1 font-semibold text-app-primary">{formatRank(item.finalRank)}</p>
         </div>
-        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+        <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
           <p className="text-xs text-app-dim">점수 변화</p>
           <p className={`mt-1 font-semibold ${toneForScore(item.scoreDelta)}`}>
             {formatScoreDelta(item.scoreDelta)}
           </p>
         </div>
-        <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+        <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
           <p className="text-xs text-app-dim">정답 처리 시각</p>
           <p className="mt-1 font-medium text-app-primary">
             {item.finishTime ? formatDateTime(item.finishTime) : "기록 없음"}
@@ -179,15 +255,15 @@ function LoadingRows() {
       {Array.from({ length: 3 }).map((_, index) => (
         <div
           key={index}
-          className="animate-pulse rounded-md border border-app-border bg-app-elevated p-4"
+          className="animate-pulse rounded-2xl border border-app-border bg-app-surface p-4"
         >
-          <div className="h-3 w-36 rounded bg-app-elevated" />
-          <div className="mt-3 h-4 w-2/3 rounded bg-app-elevated" />
-          <div className="mt-1 h-3 w-40 rounded bg-app-elevated" />
+          <div className="h-3 w-36 rounded bg-app-base" />
+          <div className="mt-3 h-4 w-2/3 rounded bg-app-base" />
+          <div className="mt-1 h-3 w-40 rounded bg-app-base" />
           <div className="mt-4 grid gap-2 sm:grid-cols-3">
-            <div className="h-14 rounded-md bg-app-elevated" />
-            <div className="h-14 rounded-md bg-app-elevated" />
-            <div className="h-14 rounded-md bg-app-elevated" />
+            <div className="h-14 rounded-xl bg-app-base" />
+            <div className="h-14 rounded-xl bg-app-base" />
+            <div className="h-14 rounded-xl bg-app-base" />
           </div>
         </div>
       ))}
@@ -207,6 +283,7 @@ export default function MyPageScreen() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [showAdvancedStats, setShowAdvancedStats] = useState(false);
 
   useEffect(() => {
     if (!sessionLoaded) {
@@ -370,6 +447,12 @@ export default function MyPageScreen() {
   const hardBattleRating = ratingProgress?.current.hardBattleRating ?? myInfo?.hardBattleRating ?? null;
   const firstSolveScore = ratingProgress?.current.activityPoint ?? myInfo?.firstSolveScore ?? null;
   const tierScore = myInfo?.tierScore ?? battleRating;
+  const recentTop2Ratio =
+    typeof ratingProgress?.current.recentTop2Ratio === "number"
+      ? ratingProgress.current.recentTop2Ratio
+      : typeof myInfo?.recentTop2Rate === "number"
+        ? myInfo.recentTop2Rate
+        : null;
   const nextTier = ratingProgress?.next ?? null;
   const nextRequirements = nextTier?.requirements ?? [];
   const satisfiedRequirementCount = nextRequirements.filter((requirement) => requirement.satisfied).length;
@@ -397,24 +480,37 @@ export default function MyPageScreen() {
 
       <div className="flex-1 overflow-auto bg-app-base">
         <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
-          <div className="mb-5 flex flex-wrap items-end justify-between gap-2 border-b border-app-border/70 pb-3">
-            <div>
-              <h1 className="text-xl font-semibold text-app-primary">마이페이지</h1>
-              <p className="mt-1 text-sm text-app-muted">
-                내 계정 정보와 최근 배틀 전적을 확인합니다.
-              </p>
+          <section className="mb-5 rounded-2xl border border-app-border bg-gradient-to-r from-app-surface to-app-elevated px-4 py-4 shadow-[0_14px_32px_rgba(0,0,0,0.22)]">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.22em] text-app-dim">my-page.json</p>
+                <h1 className="mt-2 text-xl font-semibold text-app-primary">마이페이지</h1>
+                <p className="mt-1 text-sm text-app-muted">
+                  내 계정 정보와 최근 배틀 전적을 확인합니다.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <span className="inline-flex h-7 items-center rounded-full border border-app-border bg-app-base px-3 text-xs font-semibold text-app-secondary">
+                  PROFILE
+                </span>
+                <span className="inline-flex h-7 items-center rounded-full border border-app-border bg-app-base px-3 text-xs font-semibold text-app-secondary">
+                  HISTORY
+                </span>
+              </div>
             </div>
             {session.authenticated ? (
-              <p className="text-xs text-app-dim">
+              <p className="mt-3 text-xs text-app-dim">
                 {pageInfo.totalElements > 0
                   ? `총 ${pageInfo.totalElements}개 · ${currentPage}/${pageInfo.totalPages} 페이지`
                   : "전적 데이터 준비 중"}
               </p>
-            ) : null}
-          </div>
+            ) : (
+              <p className="mt-3 text-xs text-app-dim">로그인 후 내 전적을 확인할 수 있습니다.</p>
+            )}
+          </section>
 
           {!session.authenticated ? (
-            <div className="space-y-4 rounded-md border border-app-border bg-app-elevated px-4 py-4">
+            <div className="space-y-4 rounded-2xl border border-app-border bg-app-surface px-4 py-4">
               <p className="text-sm text-app-secondary">{message}</p>
               <div className="flex flex-wrap gap-2">
                 <Link
@@ -433,94 +529,108 @@ export default function MyPageScreen() {
             </div>
           ) : (
             <div className="space-y-5">
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                <div className={statCardClass}>
                   <p className="text-xs text-app-dim">표시 티어</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
                     {displayTier}
                   </p>
                 </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <div className={statCardClass}>
                   <p className="text-xs text-app-dim">SR (battleRating)</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
                     {battleRating ?? "-"}
                   </p>
                 </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">Hard SR</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">
-                    {hardBattleRating ?? "-"}
-                  </p>
-                </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <div className={statCardClass}>
                   <p className="text-xs text-app-dim">AP (firstSolveScore)</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
                     {firstSolveScore ?? "-"}
                   </p>
                 </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">랭킹 표시 점수 (tierScore)</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">{tierScore ?? "-"}</p>
-                </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <div className={statCardClass}>
                   <p className="text-xs text-app-dim">배틀 판수</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
                     {battleMatchCount ?? "-"}
                   </p>
                 </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <div className={infoCardClass}>
                   <p className="text-xs text-app-dim">first solve 문제 수</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
                     {firstSolvedProblemCount ?? "-"}
                   </p>
                 </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">닉네임 / 역할</p>
+                <div className={infoCardClass}>
+                  <p className="text-xs text-app-dim">최근 Top2 비율</p>
                   <p className="mt-1 text-base font-semibold text-app-primary">
-                    {myInfo?.nickname ?? session.member?.nickname ?? "-"}
-                  </p>
-                  <p className="mt-0.5 text-xs text-app-muted">
-                    {formatRoleLabel(myInfo?.role ?? session.member?.role)}
+                    {recentTop2Ratio !== null ? `${Math.round(recentTop2Ratio * 100)}%` : "-"}
                   </p>
                 </div>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">1400+ 해결</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">
-                    {ratingProgress?.current.solved1400Plus ?? myInfo?.solved1400Plus ?? "-"}
-                  </p>
-                </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">1700+ 해결</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">
-                    {ratingProgress?.current.solved1700Plus ?? myInfo?.solved1700Plus ?? "-"}
-                  </p>
-                </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">2000+ 해결</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">
-                    {ratingProgress?.current.solved2000Plus ?? myInfo?.solved2000Plus ?? "-"}
-                  </p>
-                </div>
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                  <p className="text-xs text-app-dim">2300+ 해결 / 최근 Top2 비율</p>
-                  <p className="mt-1 text-base font-semibold text-app-primary">
-                    {ratingProgress?.current.solved2300Plus ?? myInfo?.solved2300Plus ?? "-"} /{" "}
-                    {typeof ratingProgress?.current.recentTop2Ratio === "number"
-                      ? `${Math.round(ratingProgress.current.recentTop2Ratio * 100)}%`
-                      : typeof myInfo?.recentTop2Rate === "number"
-                        ? `${Math.round(myInfo.recentTop2Rate * 100)}%`
-                      : "-"}
-                  </p>
-                </div>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => setShowAdvancedStats((prev) => !prev)}
+                  className="inline-flex h-9 items-center justify-center rounded-md border border-app-border bg-app-elevated px-3 text-xs font-medium text-app-secondary transition hover:border-app-border-strong hover:bg-app-surface hover:text-app-primary"
+                >
+                  {showAdvancedStats ? "고급 지표 숨기기" : "고급 지표 보기"}
+                </button>
               </div>
 
-              <section className="rounded-md border border-app-border bg-app-elevated p-4">
+              {showAdvancedStats ? (
+                <div className="space-y-3">
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">Hard SR</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {hardBattleRating ?? "-"}
+                      </p>
+                    </div>
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">랭킹 표시 점수 (tierScore)</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">{tierScore ?? "-"}</p>
+                    </div>
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">닉네임 / 역할</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {myInfo?.nickname ?? session.member?.nickname ?? "-"}
+                      </p>
+                      <p className="mt-0.5 text-xs text-app-muted">
+                        {formatRoleLabel(myInfo?.role ?? session.member?.role)}
+                      </p>
+                    </div>
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">2300+ 해결</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {ratingProgress?.current.solved2300Plus ?? myInfo?.solved2300Plus ?? "-"}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">1400+ 해결</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {ratingProgress?.current.solved1400Plus ?? myInfo?.solved1400Plus ?? "-"}
+                      </p>
+                    </div>
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">1700+ 해결</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {ratingProgress?.current.solved1700Plus ?? myInfo?.solved1700Plus ?? "-"}
+                      </p>
+                    </div>
+                    <div className={infoCardClass}>
+                      <p className="text-xs text-app-dim">2000+ 해결</p>
+                      <p className="mt-1 text-base font-semibold text-app-primary">
+                        {ratingProgress?.current.solved2000Plus ?? myInfo?.solved2000Plus ?? "-"}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              <section className="rounded-2xl border border-app-border bg-app-surface p-4 shadow-[0_10px_24px_rgba(0,0,0,0.2)]">
                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                   <div>
                     <h2 className="text-sm font-semibold text-app-primary">다음 티어 진행도</h2>
@@ -561,11 +671,12 @@ export default function MyPageScreen() {
                           : requirement.satisfied
                             ? 100
                             : 0;
+                      const actionGuide = buildRequirementActionGuide(requirement);
 
                       return (
                         <div
                           key={requirement.key}
-                          className="rounded-md border border-app-border bg-app-base px-3 py-2"
+                          className="rounded-xl border border-app-border bg-app-base px-3 py-2"
                         >
                           <div className="flex flex-wrap items-center justify-between gap-2">
                             <p className="text-sm font-medium text-app-primary">{requirement.label}</p>
@@ -590,6 +701,7 @@ export default function MyPageScreen() {
                               style={{ width: `${progressPercent}%` }}
                             />
                           </div>
+                          <p className="mt-2 text-xs text-app-secondary">{actionGuide}</p>
                         </div>
                       );
                     })}
@@ -598,17 +710,17 @@ export default function MyPageScreen() {
               </section>
 
               {myInfoError ? (
-                <div className="rounded-md border border-app-warn/60 bg-app-warn/15 px-3 py-2 text-sm text-app-warn">
+                <div className="rounded-xl border border-app-warn/60 bg-app-warn/15 px-3 py-2 text-sm text-app-warn">
                   {myInfoError}
                 </div>
               ) : null}
 
               {error ? (
-                <div className="rounded-md border border-app-danger/60 bg-app-danger/20 px-3 py-2 text-sm text-app-danger">
+                <div className="rounded-xl border border-app-danger/60 bg-app-danger/20 px-3 py-2 text-sm text-app-danger">
                   {error}
                 </div>
               ) : (
-                <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2 text-sm text-app-secondary">
+                <div className="rounded-xl border border-app-border bg-app-surface px-3 py-2 text-sm text-app-secondary">
                   {message}
                 </div>
               )}
@@ -616,7 +728,7 @@ export default function MyPageScreen() {
               {isLoading ? (
                 <LoadingRows />
               ) : battleResults.length === 0 ? (
-                <div className="rounded-md border border-app-border bg-app-elevated px-4 py-6 text-center text-sm text-app-muted">
+                <div className="rounded-xl border border-app-border bg-app-surface px-4 py-6 text-center text-sm text-app-muted">
                   아직 전적이 없습니다. 배틀을 완료하면 이곳에서 확인할 수 있습니다.
                 </div>
               ) : (
@@ -642,7 +754,7 @@ export default function MyPageScreen() {
                       {isLoadingMore ? "불러오는 중..." : "다음 전적 더 보기"}
                     </button>
                   ) : (
-                    <div className="inline-flex h-10 items-center rounded-md border border-app-border bg-app-elevated px-4 text-sm text-app-muted">
+                    <div className="inline-flex h-10 items-center rounded-md border border-app-border bg-app-surface px-4 text-sm text-app-muted">
                       마지막 페이지입니다.
                     </div>
                   )}

--- a/src/shared/api/backend.ts
+++ b/src/shared/api/backend.ts
@@ -21,8 +21,14 @@ interface CookieStore {
 
 const DEFAULT_BACKEND_BASE_URL = "http://localhost:8080";
 
+function normalizeBackendBaseUrl(url: string) {
+  return url.trim().replace(/\/+$/, "");
+}
+
 export function getBackendBaseUrl() {
-  return process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_BACKEND_BASE_URL;
+  return normalizeBackendBaseUrl(
+    process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_BACKEND_BASE_URL,
+  );
 }
 
 export function buildBackendUrl(

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -38,6 +38,68 @@ export interface AuthMutationResponse extends SessionResponse {
   message: string;
 }
 
+export interface MyInfoResponse {
+  memberId: number;
+  nickname: string;
+  email: string;
+  score: number;
+  tier: string;
+  role: string;
+  battleRating?: number | null;
+  hardBattleRating?: number | null;
+  firstSolveScore?: number | null;
+  tierScore?: number | null;
+  battleMatchCount?: number | null;
+  firstSolvedProblemCount?: number | null;
+  solved1400Plus?: number | null;
+  solved1700Plus?: number | null;
+  solved2000Plus?: number | null;
+  solved2300Plus?: number | null;
+  recentTop2Rate?: number | null;
+}
+
+export type MyInfoApiResponse = RsData<MyInfoResponse | null>;
+
+export interface RatingRequirementProgress {
+  key: string;
+  label: string;
+  comparison: "AT_LEAST" | "AT_MOST";
+  current: number;
+  required: number;
+  remaining: number;
+  satisfied: boolean;
+}
+
+export interface NextTierProgress {
+  tier: string;
+  eligibleNow: boolean;
+  message: string;
+  seatRank?: number | null;
+  requirements: RatingRequirementProgress[];
+}
+
+export interface CurrentTierProgress {
+  displayTier: string;
+  tier: string;
+  battleRating: number;
+  hardBattleRating: number;
+  activityPoint: number;
+  battleMatchCount: number;
+  firstSolvedProblemCount: number;
+  solved1400Plus: number;
+  solved1700Plus: number;
+  solved2000Plus: number;
+  solved2300Plus: number;
+  recentTop2Ratio: number;
+}
+
+export interface RatingProgressResponse {
+  current: CurrentTierProgress;
+  next: NextTierProgress | null;
+}
+
+export type RatingProgressApiResponse = RsData<RatingProgressResponse | null>;
+
 export interface QueueJoinRequest {
   category: string;
   difficulty: Difficulty;


### PR DESCRIPTION
## 작업 개요

- 마이페이지에서 티어 진행도 정보를 더 이해하기 쉽게 만들고, 배틀 결과 상세 화면의 정보 구조를 정리했습니다.
- 기존에는 조건 값만 보여서 "어떤 행동을 해야 승급되는지"가 불명확했기 때문에, 조건별 행동 가이드를 추가했습니다.

## 영향 범위

- route: `/mypage`, `/battle/results/[roomId]`
- feature: 마이페이지 티어 진행도 가이드, 배틀 결과 상세 UI 구조 개선
- api/bff: 변경 없음 (기존 API 응답 사용)

## 작업 내용

- [x] 마이페이지 티어 진행도 카드에 조건별 행동 가이드 추가
- [x] SR/Hard SR/AP/난이도 해결수/Top2/GOD 좌석 조건별 안내 문구 분기 적용
- [x] 배틀 결과 상세 화면을 현재 앱 톤에 맞게 재구성
- [x] 마이페이지에서 핵심 지표 우선 노출 + 고급 지표 토글 구성

## 변경 사항

- `src/features/my-page/screen.tsx`
  - `다음 티어 진행도`에 "무엇을 하면 몇 점(또는 몇 개) 채워지는지" 안내 문구 추가
  - SR 조건 안내를 현실 기준으로 보강
    - 동급 매칭 체감치(+8~15), 초반 구간(+15~25), 상한(+35) 분리 표기
  - 핵심 지표/고급 지표 분리로 가독성 개선
- `src/features/battle-result/screen.tsx`
  - 결과 상세 화면 레이아웃/카드 구조 정리
  - 현재 서비스 디자인 톤에 맞춘 시각 계층 개선

## 테스트 및 확인

- [ ] `npm run lint` (현재 레포 ESLint 설정 이슈로 실패)
- [x] `npx tsc --noEmit`
- [x] 주요 라우트 수동 확인 (`/mypage`, `/battle/results/[roomId]`)
- [x] API/BFF 연동 확인 (응답 데이터 렌더링 기준)

## 관련 이슈

- close #

## 스크린샷 / 영상

- UI 변경사항은 필요 시 코멘트로 추가 첨부하겠습니다.

## 참고 자료

- 티어 정책/요구조건 키: 백엔드 `rating-progress` 응답 계약 기준
