### PR TITLE
fix: 홈 매칭 쪽 direct backend WebSocket + X-WS-Token 방식 바꿈

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,6 @@
 import type { NextConfig } from "next";
 
-const DEFAULT_BACKEND_BASE_URL = "http://localhost:8080";
-
-function normalizeBackendBaseUrl(url: string) {
-  return url.trim().replace(/\/+$/, "");
-}
-
-const BACKEND_BASE_URL = normalizeBackendBaseUrl(
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_BACKEND_BASE_URL,
-);
+const BACKEND_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 
 const nextConfig: NextConfig = {
   async rewrites() {

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -491,8 +491,30 @@ export default function HomeScreen() {
     }
 
     const client = new Client({
-      webSocketFactory: () => new SockJS("/ws"),
+      webSocketFactory: () =>
+        new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
       reconnectDelay: 3000,
+      beforeConnect: async () => {
+        client.connectHeaders = {};
+
+        const res = await fetch("/api/v1/ws/token", {
+          method: "POST",
+          cache: "no-store",
+          credentials: "include",
+        });
+
+        if (!res.ok) {
+          throw new Error(`WS token request failed (${res.status})`);
+        }
+
+        const data = (await res.json()) as { token?: string };
+
+        if (!data.token) {
+          throw new Error("WS token response missing token");
+        }
+
+        client.connectHeaders = { "X-WS-Token": data.token };
+      },
       onConnect: () => {
         logMatchingDebug("ws connected");
         personalSubscriptionRef.current?.unsubscribe();


### PR DESCRIPTION
## 작업 개요

- 홈 매칭 쪽 direct backend WebSocket + X-WS-Token 방식 바꿈

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- [ ] 작업 1
- [ ] 작업 2

## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #55 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
