### PR TITLE
[fix] 관전 화면 초기 코드 미수신 race condition 수정

### DIFF
--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -129,6 +129,20 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
     };
   }, [refreshSession, roomId, session.authenticated, sessionLoaded]);
 
+  // room이 로드됐을 때 WebSocket이 이미 연결된 경우 sync 요청 (race condition 보완)
+  useEffect(() => {
+    if (!room || !stompClientRef.current?.connected) return;
+    if (roomStatusRef.current === "FINISHED") return;
+
+    for (const participant of room.participants) {
+      stompClientRef.current.publish({
+        destination: `/app/room/${roomId}/code/sync`,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ targetUserId: participant.userId }),
+      });
+    }
+  }, [room, roomId]);
+
   // WebSocket: /topic/room/{roomId}/spectate 구독
   useEffect(() => {
     if (!session.authenticated) return;


### PR DESCRIPTION
## 작업 개요

- `useEffect 1`: 방 정보 로드 (비동기) → `participantsRef` 채움                                                                     
  - `useEffect 2`: WebSocket 연결 → `onConnect`에서 sync 요청                                                                         
                                                                                                                                      
  WebSocket이 방 정보보다 먼저 연결되면 `participantsRef.current`가 아직 `[]`이라                                                     
  sync 요청이 아무에게도 전송되지 않아 초기 코드를 받지 못했습니다.                                                                   
  이후 참여자가 타이핑해야만 `CODE_UPDATE`로 코드가 수신되는 상태였습니다.

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- [ ] 작업 1
- [ ] 작업 2

## 변경 사항

`room` 상태가 로드됐을 때 WebSocket이 이미 연결된 경우 sync를 추가로 요청하는                                                       
  `useEffect`를 추가했습니다.                                                                                                         
   
  기존 `onConnect` 안의 sync 루프는 그대로 유지하여,                                                                                  
  어느 쪽이 먼저 완료되든 모두 커버합니다.

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #57 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
