### PR TITLE
[feat] 백엔드 배틀 상태 변경 및 신규 기능 연동

### DIFF
--- a/src/app/api/battle/result/[roomId]/check/route.ts
+++ b/src/app/api/battle/result/[roomId]/check/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import { fetchBackendWithReissue, getErrorMessage } from "@/shared/api/backend";
+
+export async function POST(
+  _request: Request,
+  context: RouteContext<"/api/battle/result/[roomId]/check">,
+) {
+  const { roomId } = await context.params;
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      `/api/v1/battle/result/${roomId}/check`,
+      { method: "POST" },
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { message: "배틀 결과 확인 처리에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/battle/result/unchecked/route.ts
+++ b/src/app/api/battle/result/unchecked/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { UncheckedBattleResult } from "@/shared/api/contracts";
+import { fetchBackendWithReissue, getErrorMessage, readJsonBody } from "@/shared/api/backend";
+
+export async function GET() {
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue("/api/v1/battle/result/unchecked", {}, cookieStore);
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    const body = await readJsonBody<UncheckedBattleResult | null>(response);
+    return NextResponse.json(body);
+  } catch {
+    return NextResponse.json(
+      { message: "미확인 배틀 결과를 가져오지 못했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/battle-result/screen.tsx
+++ b/src/features/battle-result/screen.tsx
@@ -57,6 +57,12 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
       setResult((await response.json()) as BattleResultResponse);
       setSource("api");
       setMessage("실제 API 기반 결과를 표시합니다.");
+
+      // 미확인 결과 확인 처리 (다음 접속 시 결과 화면으로 재유도 방지)
+      await fetch(`/api/battle/result/${roomId}/check`, {
+        method: "POST",
+        credentials: "include",
+      }).catch(() => undefined);
     })();
   }, [roomId]);
 

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -510,7 +510,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       !hasAttemptedJoinRef.current;
     const shouldRejoinFromPlaying =
       room.status === "PLAYING" &&
-      (participant?.status === "ABANDONED" || participant?.status === "EXIT");
+      (participant?.status === "ABANDONED" || participant?.status === "SOLVED");
 
     if (!shouldJoinFromWaiting && !shouldRejoinFromPlaying) {
       return;

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -2,12 +2,16 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
 
 import type {
+  BattleResultWsMessage,
   MyBattleResultItem,
   MyBattleResultsResponse,
   RoomResponse,
   SessionResponse,
+  UncheckedBattleResult,
 } from "@/shared/api/contracts";
 
 import ProfilePane from "@/features/home/components/profile-pane";
@@ -265,6 +269,79 @@ export default function IdeShell({
       active = false;
     };
   }, [refreshSession, session.authenticated]);
+
+  // 로그인 시 미확인 배틀 결과 조회 → 있으면 결과 화면으로 이동
+  useEffect(() => {
+    if (!session.authenticated) return;
+
+    void (async () => {
+      try {
+        const response = await fetch("/api/battle/result/unchecked", {
+          cache: "no-store",
+          credentials: "include",
+        });
+
+        if (!response.ok) return;
+
+        const result = (await response.json()) as UncheckedBattleResult | null;
+        if (result?.roomId) {
+          router.push(`/battle/results/${result.roomId}`);
+        }
+      } catch {
+        // 미확인 결과 조회 실패는 무시
+      }
+    })();
+  }, [router, session.authenticated]);
+
+  // 전역 WebSocket: /topic/user/{myId}/battle 구독 (배틀 결과 실시간 수신)
+  useEffect(() => {
+    if (!session.authenticated || !session.member) return;
+
+    const myId = session.member.memberId;
+    const client = new Client({
+      webSocketFactory: () =>
+        new SockJS(`${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`),
+      reconnectDelay: 3000,
+      beforeConnect: async () => {
+        client.connectHeaders = {};
+        try {
+          const res = await fetch("/api/v1/ws/token", { method: "POST" });
+          if (res.ok) {
+            const data = (await res.json()) as { token: string };
+            client.connectHeaders = { "X-WS-Token": data.token };
+          }
+        } catch {
+          // 쿠키 기반 인증으로 폴백
+        }
+      },
+      onConnect: () => {
+        client.subscribe(`/topic/user/${myId}/battle`, (frame) => {
+          let payload: unknown;
+          try {
+            payload = JSON.parse(frame.body) as unknown;
+          } catch {
+            return;
+          }
+
+          if (
+            typeof payload === "object" &&
+            payload !== null &&
+            "type" in payload &&
+            (payload as { type: unknown }).type === "BATTLE_RESULT"
+          ) {
+            const msg = payload as BattleResultWsMessage;
+            router.push(`/battle/results/${msg.roomId}`);
+          }
+        });
+      },
+    });
+
+    client.activate();
+
+    return () => {
+      void client.deactivate();
+    };
+  }, [router, session.authenticated, session.member]);
 
   async function handleLogout() {
     setIsLoggingOut(true);

--- a/src/features/spectate-room/data.ts
+++ b/src/features/spectate-room/data.ts
@@ -1,7 +1,7 @@
 export interface ParticipantInfo {
   userId: number;
   nickname: string;
-  status: "READY" | "PLAYING" | "EXIT";
+  status: "READY" | "PLAYING" | "SOLVED";
 }
 
 export interface SpectatorCodePanel {

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -194,7 +194,7 @@ export type MatchingWsMessage =
 export interface ParticipantInfo {
   userId: number;
   nickname: string;
-  status: "READY" | "PLAYING" | "EXIT" | "ABANDONED";
+  status: "READY" | "PLAYING" | "SOLVED" | "ABANDONED" | "TIMEOUT" | "QUIT";
 }
 
 export interface RoomResponse {
@@ -403,4 +403,18 @@ export interface RoomListResponse {
   problemTitle: string;
   currentPlayers: number;
   maxPlayers: number;
+}
+
+export interface BattleResultWsMessage {
+  type: "BATTLE_RESULT";
+  roomId: number;
+  rank: number;
+  scoreDelta: number;
+}
+
+export interface UncheckedBattleResult {
+  roomId: number;
+  rank: number;
+  scoreDelta: number;
+  problemTitle: string;
 }


### PR DESCRIPTION
## 작업 개요

- 이 PR에서 무엇을 왜 바꾸는지 간단히 작성해주세요.

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- ParticipantInfo.status EXIT → SOLVED 리네임, TIMEOUT/QUIT 추가                                                                    
- 미확인 배틀 결과 조회 및 확인 처리 API 연동
- 전역 WebSocket으로 /topic/user/{id}/battle 구독하여 배틀 결과 실시간 수신    

## 변경 사항

## 테스트 및 확인


## 관련 이슈

- close #59 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
