### PR TITLE
[Feat] 관전기능 인가처리

### DIFF
--- a/src/app/api/battle/rooms/[roomId]/exit/route.ts
+++ b/src/app/api/battle/rooms/[roomId]/exit/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import { fetchBackendWithReissue, getErrorMessage } from "@/shared/api/backend";
+
+export async function POST(
+  _request: Request,
+  context: RouteContext<"/api/battle/rooms/[roomId]/exit">,
+) {
+  const { roomId } = await context.params;
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      `/api/v1/battle/rooms/${roomId}/exit`,
+      { method: "POST" },
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { message: "방 포기 처리에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/battle/rooms/me/active/route.ts
+++ b/src/app/api/battle/rooms/me/active/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { ActiveRoomResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET() {
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      "/api/v1/battle/rooms/me/active",
+      {},
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    const body = await readJsonBody<ActiveRoomResponse | null>(response);
+    return NextResponse.json(body);
+  } catch {
+    return NextResponse.json(
+      { message: "활성 방 정보를 가져오지 못했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -1138,9 +1138,12 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         title="문제를 풀었습니다!"
         description="다른 참여자들의 풀이를 관전하시겠습니까?"
         confirmLabel="관전하기"
-        cancelLabel="계속 있기"
-        onConfirm={() => router.push(`/spectate/rooms/${roomId}`)}
-        onCancel={() => setShowSpectateDialog(false)}
+        cancelLabel="나가기"
+        onConfirm={() => {
+          sessionStorage.setItem("spectate-from-hub", "1");
+          router.push(`/spectate/rooms/${roomId}`);
+        }}
+        onCancel={() => router.push("/")}
       />
 
       <ConfirmDialog

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
@@ -18,7 +19,7 @@ import type {
   SubmissionWsMessage,
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
-import { DefinitionGrid, MathText, Panel, StatusPill } from "@/shared/ui";
+import { ConfirmDialog, DefinitionGrid, MathText, Panel, StatusPill } from "@/shared/ui";
 import {
   readPreferredEditorLanguage,
   writePreferredEditorLanguage,
@@ -251,7 +252,12 @@ function getSubmitHeadline(isSubmitting: boolean, result: string | null | undefi
 }
 
 export default function BattleRoomScreen({ roomId }: { roomId: string }) {
+  const router = useRouter();
   const { session, sessionLoaded, refreshSession } = useAppSession();
+  const [showSpectateDialog, setShowSpectateDialog] = useState(false);
+  const [showExitDialog, setShowExitDialog] = useState(false);
+  const pendingNavRef = useRef<(() => void) | null>(null);
+  const bypassGuardRef = useRef(false);
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [latestSubmission, setLatestSubmission] =
@@ -289,6 +295,45 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const rightTopPaneRatioRef = useRef(rightTopPaneRatio);
   const sampleCasesRef = useRef(problem?.sampleCases ?? []);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const myParticipantStatus = room?.participants.find(
+    (p) => p.userId === session.member?.memberId,
+  )?.status;
+  const shouldGuard =
+    room?.status === "PLAYING" &&
+    (myParticipantStatus === "PLAYING" || myParticipantStatus === "ABANDONED");
+
+  // 탭 닫기 / 새로고침 가드
+  useEffect(() => {
+    if (!shouldGuard) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [shouldGuard]);
+
+  // 뒤로가기 가드 — 히스토리 스택에 더미 엔트리를 쌓아 popstate를 가로챔
+  useEffect(() => {
+    if (!shouldGuard) return;
+
+    window.history.pushState(null, "", window.location.href);
+
+    const handler = () => {
+      if (bypassGuardRef.current) return;
+      window.history.pushState(null, "", window.location.href);
+      pendingNavRef.current = () => {
+        bypassGuardRef.current = true;
+        window.history.go(-2);
+      };
+      setShowExitDialog(true);
+    };
+
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  }, [router, shouldGuard]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
@@ -669,6 +714,11 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
               );
               setIsSubmitting(false);
               setMessage(`채점 완료: ${msg.result} (${msg.passedCount}/${msg.totalCount})`);
+
+              const normalizedResult = normalizeVerdict(msg.result);
+              if (normalizedResult === "AC" || normalizedResult === "ACCEPTED") {
+                setShowSpectateDialog(true);
+              }
             }
           }
         });
@@ -1035,6 +1085,14 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
   const activeRunCasePass = isPassVerdict(activeRunCase?.status);
   const activeRunCaseWrongAnswer = isWrongAnswerVerdict(activeRunCase?.status);
   const isPlayable = room.status === "PLAYING";
+
+  async function handleExitConfirm() {
+    bypassGuardRef.current = true;
+    await fetch(`/api/battle/rooms/${roomId}/exit`, { method: "POST" });
+    setShowExitDialog(false);
+    pendingNavRef.current?.();
+  }
+
   const latestResultCode = normalizeVerdict(latestSubmission?.result ?? undefined);
   const submitHeadline = getSubmitHeadline(isSubmitting, latestSubmission?.result);
   const submitIsAccepted = latestResultCode === "AC" || latestResultCode === "ACCEPTED";
@@ -1075,6 +1133,27 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
   return (
     <div className="h-full space-y-6 lg:space-y-0">
+      <ConfirmDialog
+        open={showSpectateDialog}
+        title="문제를 풀었습니다!"
+        description="다른 참여자들의 풀이를 관전하시겠습니까?"
+        confirmLabel="관전하기"
+        cancelLabel="계속 있기"
+        onConfirm={() => router.push(`/spectate/rooms/${roomId}`)}
+        onCancel={() => setShowSpectateDialog(false)}
+      />
+
+      <ConfirmDialog
+        open={showExitDialog}
+        title="배틀을 포기하시겠습니까?"
+        description="지금 나가면 최하위 처리되며 다시 참여할 수 없습니다."
+        confirmLabel="포기하고 나가기"
+        cancelLabel="계속 풀기"
+        confirmTone="danger"
+        onConfirm={() => void handleExitConfirm()}
+        onCancel={() => setShowExitDialog(false)}
+      />
+
       {error && (
         <div
           className="rounded-2xl border border-app-danger/35 bg-app-danger/10 px-4 py-3 text-sm text-app-danger"
@@ -1830,18 +1909,44 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         </section>
 
         <div className="flex flex-wrap gap-3">
-          <Link
-            href={`/battle/results/${room.roomId}`}
-            className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
-          >
-            결과 화면 보기
-          </Link>
-          <Link
-            href="/"
-            className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
-          >
-            메인으로 돌아가기
-          </Link>
+          {shouldGuard ? (
+            <button
+              type="button"
+              onClick={() => {
+                pendingNavRef.current = () => router.push(`/battle/results/${room.roomId}`);
+                setShowExitDialog(true);
+              }}
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
+            >
+              결과 화면 보기
+            </button>
+          ) : (
+            <Link
+              href={`/battle/results/${room.roomId}`}
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
+            >
+              결과 화면 보기
+            </Link>
+          )}
+          {shouldGuard ? (
+            <button
+              type="button"
+              onClick={() => {
+                pendingNavRef.current = () => router.push("/");
+                setShowExitDialog(true);
+              }}
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
+            >
+              메인으로 돌아가기
+            </button>
+          ) : (
+            <Link
+              href="/"
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
+            >
+              메인으로 돌아가기
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -6,6 +6,7 @@ import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
 import type {
+  ActiveRoomResponse,
   ApiErrorResponse,
   Difficulty,
   MatchStateResponse,
@@ -14,6 +15,7 @@ import type {
   QueueStatusResponse,
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
+import { ConfirmDialog } from "@/shared/ui";
 
 import {
   DEFAULT_REQUIRED_COUNT,
@@ -262,6 +264,8 @@ export default function HomeScreen() {
   const [pollStage, setPollStage] = useState<PollStage>("IDLE");
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
   const [now, setNow] = useState(Date.now());
+  const [pendingActiveRoomId, setPendingActiveRoomId] = useState<number | null>(null);
+  const [confirmingForfeit, setConfirmingForfeit] = useState(false);
 
   const joiningRoomIdRef = useRef<number | null>(null);
   const stompClientRef = useRef<Client | null>(null);
@@ -903,22 +907,7 @@ export default function HomeScreen() {
     void attemptRoomEntry(roomId);
   }, [attemptRoomEntry, matchState.room?.roomId, modalMode, session.authenticated]);
 
-  async function handleStartMatch() {
-    if (!session.authenticated) {
-      router.push("/login?next=/");
-      return;
-    }
-
-    if (category === "RANDOM") {
-      setError("현재는 구체적인 카테고리만 매칭할 수 있습니다.");
-      return;
-    }
-
-    if (modalMode && modalMode !== "TERMINAL") {
-      setError("이미 진행 중인 매칭 흐름이 있습니다.");
-      return;
-    }
-
+  async function joinQueue() {
     setBusyAction("start");
     setError(null);
     setTerminalMessage(null);
@@ -962,6 +951,55 @@ export default function HomeScreen() {
     } finally {
       setBusyAction(null);
     }
+  }
+
+  async function handleStartMatch() {
+    if (!session.authenticated) {
+      router.push("/login?next=/");
+      return;
+    }
+
+    if (category === "RANDOM") {
+      setError("현재는 구체적인 카테고리만 매칭할 수 있습니다.");
+      return;
+    }
+
+    if (modalMode && modalMode !== "TERMINAL") {
+      setError("이미 진행 중인 매칭 흐름이 있습니다.");
+      return;
+    }
+
+    setBusyAction("start");
+    setError(null);
+
+    try {
+      const activeRes = await fetch("/api/battle/rooms/me/active", { cache: "no-store" });
+      if (activeRes.ok) {
+        const body = (await activeRes.json()) as ActiveRoomResponse | null;
+        if (body?.roomId != null) {
+          setPendingActiveRoomId(body.roomId);
+          return;
+        }
+      }
+    } finally {
+      setBusyAction(null);
+    }
+
+    await joinQueue();
+  }
+
+  function handleRejoin() {
+    if (pendingActiveRoomId === null) return;
+    router.push(`/battle/rooms/${pendingActiveRoomId}`);
+    setPendingActiveRoomId(null);
+  }
+
+  async function handleForfeitAndMatch() {
+    if (pendingActiveRoomId === null) return;
+    await fetch(`/api/battle/rooms/${pendingActiveRoomId}/exit`, { method: "POST" });
+    setPendingActiveRoomId(null);
+    setConfirmingForfeit(false);
+    await joinQueue();
   }
 
   async function handleCancelMatch() {
@@ -1081,6 +1119,26 @@ export default function HomeScreen() {
 
   return (
     <div className="relative h-full min-h-0">
+      <ConfirmDialog
+        open={pendingActiveRoomId !== null && !confirmingForfeit}
+        title="현재 진행 중인 배틀이 있습니다."
+        confirmLabel="재참여하기"
+        cancelLabel="포기하고 매칭 시작"
+        onConfirm={handleRejoin}
+        onCancel={() => setConfirmingForfeit(true)}
+      />
+
+      <ConfirmDialog
+        open={confirmingForfeit}
+        title="배틀을 포기하시겠습니까?"
+        description="포기하면 최하위 처리되며 다시 참여할 수 없습니다."
+        confirmLabel="포기 확인"
+        cancelLabel="취소"
+        confirmTone="danger"
+        onConfirm={() => void handleForfeitAndMatch()}
+        onCancel={() => setConfirmingForfeit(false)}
+      />
+
       <QueueEditorPane
         editorPaneRef={editorPaneRef}
         editorContentStyle={editorContentStyle}

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -33,6 +33,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
   const router = useRouter();
   const { session, sessionLoaded, refreshSession } = useAppSession();
   const [accessGranted, setAccessGranted] = useState(false);
+  const accessCheckedRef = useRef(false);
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [message, setMessage] = useState("관전 정보를 불러오는 중입니다.");
@@ -47,6 +48,9 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
 
   // 허브를 통한 정상 진입 여부 확인 — 직접 URL 접근 차단
   useEffect(() => {
+    if (accessCheckedRef.current) return;
+    accessCheckedRef.current = true;
+
     const token = sessionStorage.getItem(SPECTATE_ACCESS_KEY);
     if (!token) {
       router.replace("/spectate");

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -27,9 +27,12 @@ import {
 
 import { getSpectateRoom } from "./data";
 
+const SPECTATE_ACCESS_KEY = "spectate-from-hub";
+
 export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
   const router = useRouter();
   const { session, sessionLoaded, refreshSession } = useAppSession();
+  const [accessGranted, setAccessGranted] = useState(false);
   const [room, setRoom] = useState<RoomResponse | null>(null);
   const [problem, setProblem] = useState<ProblemDetailResponse | null>(null);
   const [message, setMessage] = useState("관전 정보를 불러오는 중입니다.");
@@ -42,9 +45,20 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
   const participantsRef = useRef<RoomResponse["participants"]>([]);
   const roomStatusRef = useRef<RoomResponse["status"] | null>(null);
 
+  // 허브를 통한 정상 진입 여부 확인 — 직접 URL 접근 차단
+  useEffect(() => {
+    const token = sessionStorage.getItem(SPECTATE_ACCESS_KEY);
+    if (!token) {
+      router.replace("/spectate");
+      return;
+    }
+    sessionStorage.removeItem(SPECTATE_ACCESS_KEY);
+    setAccessGranted(true);
+  }, [router]);
+
   // 세션 및 방 정보 로드
   useEffect(() => {
-    if (!sessionLoaded) {
+    if (!accessGranted || !sessionLoaded) {
       return;
     }
 
@@ -127,7 +141,7 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
     return () => {
       active = false;
     };
-  }, [refreshSession, roomId, session.authenticated, sessionLoaded]);
+  }, [accessGranted, refreshSession, roomId, session.authenticated, sessionLoaded]);
 
   // room이 로드됐을 때 WebSocket이 이미 연결된 경우 sync 요청 (race condition 보완)
   useEffect(() => {

--- a/src/features/spectate/screen.tsx
+++ b/src/features/spectate/screen.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-import type { ApiErrorResponse, RoomListResponse } from "@/shared/api/contracts";
+import type { ActiveRoomResponse, ApiErrorResponse, RoomListResponse } from "@/shared/api/contracts";
 import {
   ApiCallout,
   MetricCard,
@@ -12,49 +13,119 @@ import {
   Panel,
   StatusPill,
 } from "@/shared/ui";
+import { useAppSession } from "@/features/layout/session-context";
 
 import { roomList as fallbackRoomList } from "./data";
 
-export default function SpectateScreen() {
-  const [rooms, setRooms] = useState<RoomListResponse[]>([]);
-  const [message, setMessage] = useState("진행 중인 방 목록을 불러오는 중입니다.");
-  const [error, setError] = useState<string | null>(null);
-  const [source, setSource] = useState<"api" | "fallback">("api");
-  const [requiresLogin, setRequiresLogin] = useState(false);
+type ActiveRoomState =
+  | { status: "loading" }
+  | { status: "none" }
+  | { status: "found"; roomId: number };
 
+export default function SpectateScreen() {
+  const router = useRouter();
+  const { session, sessionLoaded } = useAppSession();
+
+  const [activeRoom, setActiveRoom] = useState<ActiveRoomState>({ status: "loading" });
+  const [confirmingExit, setConfirmingExit] = useState(false);
+  const [exitLoading, setExitLoading] = useState(false);
+  const [exitError, setExitError] = useState<string | null>(null);
+
+  const [rooms, setRooms] = useState<RoomListResponse[]>([]);
+  const [roomsMessage, setRoomsMessage] = useState("진행 중인 방 목록을 불러오는 중입니다.");
+  const [roomsError, setRoomsError] = useState<string | null>(null);
+  const [roomsSource, setRoomsSource] = useState<"api" | "fallback">("api");
+
+  // 로그인 확인 후 active room 조회
   useEffect(() => {
+    if (!sessionLoaded) return;
+    if (!session.authenticated) return;
+
     void (async () => {
-      const response = await fetch("/api/battle/rooms", {
+      setActiveRoom({ status: "loading" });
+
+      const response = await fetch("/api/battle/rooms/me/active", {
         cache: "no-store",
       });
 
-      if (response.status === 401) {
-        setRequiresLogin(true);
-        setMessage("관전 허브는 로그인 후 접근할 수 있습니다.");
+      if (!response.ok) {
+        // 오류가 나도 방 목록은 보여줌 (active room 없는 것으로 처리)
+        setActiveRoom({ status: "none" });
         return;
       }
 
+      const body = (await response.json()) as ActiveRoomResponse | null;
+      if (body?.roomId != null) {
+        setActiveRoom({ status: "found", roomId: body.roomId });
+      } else {
+        setActiveRoom({ status: "none" });
+      }
+    })();
+  }, [sessionLoaded, session.authenticated]);
+
+  // active room 없을 때 방 목록 조회
+  useEffect(() => {
+    if (activeRoom.status !== "none") return;
+
+    void (async () => {
+      const response = await fetch("/api/battle/rooms", { cache: "no-store" });
+
       if (!response.ok) {
         setRooms(fallbackRoomList);
-        setSource("fallback");
+        setRoomsSource("fallback");
         const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
-        setError(payload?.message ?? "방 목록 조회에 실패해 샘플 목록을 표시합니다.");
+        setRoomsError(payload?.message ?? "방 목록 조회에 실패해 샘플 목록을 표시합니다.");
         return;
       }
 
       setRooms((await response.json()) as RoomListResponse[]);
-      setSource("api");
-      setMessage("실제 API 기반 진행 중 방 목록을 표시합니다.");
+      setRoomsSource("api");
+      setRoomsMessage("실제 API 기반 진행 중 방 목록을 표시합니다.");
     })();
-  }, []);
+  }, [activeRoom.status]);
 
-  if (requiresLogin) {
+  // 포기 처리
+  async function handleExit(roomId: number) {
+    setExitLoading(true);
+    setExitError(null);
+
+    const response = await fetch(`/api/battle/rooms/${roomId}/exit`, {
+      method: "POST",
+    });
+
+    setExitLoading(false);
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+      setExitError(payload?.message ?? "포기 처리에 실패했습니다. 다시 시도해 주세요.");
+      return;
+    }
+
+    setConfirmingExit(false);
+    setActiveRoom({ status: "none" });
+  }
+
+  // 세션 로딩 중
+  if (!sessionLoaded) {
+    return (
+      <div className="space-y-8">
+        <PageHero
+          eyebrow="Spectate"
+          title="로딩 중..."
+          description="세션 정보를 확인하고 있습니다."
+        />
+      </div>
+    );
+  }
+
+  // 미로그인
+  if (!session.authenticated) {
     return (
       <div className="space-y-8">
         <PageHero
           eyebrow="Spectate"
           title="로그인 후 관전 목록을 볼 수 있습니다."
-          description="현재 배틀 관련 API는 모두 보호된 상태입니다."
+          description="관전 기능은 로그인한 사용자만 이용할 수 있습니다."
           actions={<StatusPill tone="warn">로그인 필요</StatusPill>}
         />
         <Panel title="이동" description="보호 화면 진입 전 처리">
@@ -77,6 +148,88 @@ export default function SpectateScreen() {
     );
   }
 
+  // active room 조회 중
+  if (activeRoom.status === "loading") {
+    return (
+      <div className="space-y-8">
+        <PageHero
+          eyebrow="Spectate"
+          title="로딩 중..."
+          description="참여 중인 방 정보를 확인하고 있습니다."
+        />
+      </div>
+    );
+  }
+
+  // 플레이중인 방 있음
+  if (activeRoom.status === "found") {
+    return (
+      <div className="space-y-8">
+        <PageHero
+          eyebrow="Spectate"
+          title="플레이중인 방이 있습니다."
+          description="현재 진행 중인 배틀에 참여하고 있습니다. 재참여하거나 포기한 후 관전할 수 있습니다."
+          actions={<StatusPill tone="warn">배틀 진행 중</StatusPill>}
+        />
+
+        <Panel
+          title={`Room #${activeRoom.roomId}`}
+          description="현재 참여 중인 배틀방입니다."
+        >
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => router.push(`/battle/rooms/${activeRoom.roomId}`)}
+              className="rounded-2xl bg-app-base px-4 py-3 text-sm font-medium text-white"
+            >
+              재참여하기
+            </button>
+            <button
+              type="button"
+              onClick={() => { setConfirmingExit(true); setExitError(null); }}
+              className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm font-medium text-app-primary"
+            >
+              포기하고 관전하기
+            </button>
+          </div>
+
+          {confirmingExit && (
+            <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-5">
+              <p className="text-sm font-semibold text-red-400">
+                정말 포기하시겠습니까?
+              </p>
+              <p className="mt-1 text-sm text-app-secondary">
+                포기하면 최하위 처리되며 다시 참여할 수 없습니다.
+              </p>
+              {exitError && (
+                <p className="mt-2 text-sm text-red-400">{exitError}</p>
+              )}
+              <div className="mt-4 flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  disabled={exitLoading}
+                  onClick={() => void handleExit(activeRoom.roomId)}
+                  className="rounded-2xl bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  {exitLoading ? "처리 중..." : "포기 확인"}
+                </button>
+                <button
+                  type="button"
+                  disabled={exitLoading}
+                  onClick={() => { setConfirmingExit(false); setExitError(null); }}
+                  className="rounded-2xl border border-app-border bg-app-surface px-4 py-2 text-sm font-medium text-app-primary disabled:opacity-50"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          )}
+        </Panel>
+      </div>
+    );
+  }
+
+  // 플레이중인 방 없음 — 방 목록 표시
   return (
     <div className="space-y-8">
       <PageHero
@@ -86,13 +239,13 @@ export default function SpectateScreen() {
         actions={
           <>
             <StatusPill tone="success">PLAYING rooms</StatusPill>
-            <StatusPill>{source === "api" ? "API" : "Fallback"}</StatusPill>
+            <StatusPill>{roomsSource === "api" ? "API" : "Fallback"}</StatusPill>
           </>
         }
       />
 
       <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3 text-sm text-app-secondary">
-        {error ?? message}
+        {roomsError ?? roomsMessage}
       </div>
 
       <MetricGrid>
@@ -100,7 +253,7 @@ export default function SpectateScreen() {
         <MetricCard
           label="Socket Endpoint"
           value="/ws"
-          hint="SockJS handshake endpoint"
+          hint="SockJS 핸드셰이크 엔드포인트"
         />
         <MetricCard label="Broker Prefix" value="/topic" />
         <MetricCard label="Publish Prefix" value="/app" />

--- a/src/features/spectate/screen.tsx
+++ b/src/features/spectate/screen.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
+const SPECTATE_ACCESS_KEY = "spectate-from-hub";
+
 import type { ActiveRoomResponse, ApiErrorResponse, RoomListResponse } from "@/shared/api/contracts";
 import {
   ApiCallout,
@@ -261,10 +263,14 @@ export default function SpectateScreen() {
 
       <section className="grid gap-6 lg:grid-cols-2">
         {rooms.map((room) => (
-          <Link
+          <button
             key={room.roomId}
-            href={`/spectate/rooms/${room.roomId}`}
-            className="rounded-2xl border border-app-border bg-app-surface p-5 shadow-sm transition hover:border-app-border-strong"
+            type="button"
+            onClick={() => {
+              sessionStorage.setItem(SPECTATE_ACCESS_KEY, "1");
+              router.push(`/spectate/rooms/${room.roomId}`);
+            }}
+            className="rounded-2xl border border-app-border bg-app-surface p-5 shadow-sm transition hover:border-app-border-strong text-left w-full"
           >
             <div className="flex items-center justify-between gap-3">
               <div>
@@ -293,7 +299,7 @@ export default function SpectateScreen() {
                 </p>
               </div>
             </div>
-          </Link>
+          </button>
         ))}
       </section>
 

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -1,5 +1,9 @@
 export type Difficulty = "EASY" | "MEDIUM" | "HARD";
 
+export interface ActiveRoomResponse {
+  roomId: number;
+}
+
 export interface RsData<T> {
   resultCode: string;
   msg: string;


### PR DESCRIPTION
## 작업 개요
사용자가 배틀 중 비정상적으로 이탈하는 것을 방지하고, 관전 상세 페이지로의 부적절한 직접 접근을 차단했습니다. 또한, 홈과 관전 허브 등 주요 진입점에서 활성 배틀 유무를 체크하여 사용자 흐름을 최적화했습니다.

## 영향 범위
route: /, /battle/rooms/[id], /spectate, /spectate/[id] (관전 상세)

feature: 매칭 시스템, 배틀 이탈 방지 가드, 관전 접근 제어

api/bff:

GET /api/v1/battle/rooms/me/active

POST /api/v1/battle/rooms/{roomId}/exit

## 작업 내용
[x] 관전 상세 페이지 URL 직접 접근 차단 (sessionStorage 활용)

[x] 관전 허브 내 매칭 시작 전 활성 방(active room) 체크 로직 추가

[x] 배틀 진행 중 이탈 방지 가드 및 beforeunload 이벤트 처리

[x] 로그인 상태 및 진행 중인 방 유무에 따른 접근 제어 레이어 구현

[x] AC 수신 시 관전 유도 및 모바일 대응을 위한 다이얼로그 위치 조정

## 변경 사항
1. 관전 시스템 보안 및 흐름 개선
상세 페이지 보호: 관전 허브에서 방 클릭 시에만 sessionStorage에 토큰을 설정하며, 상세 페이지 마운트 시 토큰이 없으면 /spectate로 리다이렉트 처리하여 직접 URL 접근을 차단했습니다.

관전 허브 내 매칭: 관전 허브에서도 매칭 시작 시 활성 방 존재 여부를 체크하여, 참여 중인 방이 있다면 재참여/포기 선택 다이얼로그를 표시합니다.

2. 배틀 이탈 방지 및 페이지 가드
강력한 이탈 방지: PLAYING/ABANDONED 상태에서 브라우저 닫기, 새로고침, popstate(뒤로가기)를 차단하고 가드 로직을 통해 의도치 않은 이탈을 막았습니다.

포기 로직: 사용자가 명시적으로 '포기'를 선택한 경우에만 /exit API를 호출하고 다음 단계(큐 참가 등)로 이동합니다.

3. 사용자 경험(UX) 최적화
홈/관전 공통 로직: 어느 페이지에서든 매칭 진입 전 기존 배틀 유무를 확인하도록 로직을 강화했습니다.

UI 노출 최적화: 배틀 결과에 따른 관전 유도 ConfirmDialog가 모바일 환경에서도 가려지지 않도록 최상단 레이어로 배치했습니다.

코드 재사용: 큐 참가 로직을 joinQueue()로 모듈화하여 관리 효율성을 높였습니다.

## 테스트 및 확인


## 관련 이슈

- close #67 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
