### PR TITLE
[fix] 마지막 참가자 ready-check handoff race condition 수정

### DIFF
--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -272,11 +272,32 @@ export default function HomeScreen() {
   const personalSubscriptionRef = useRef<SubscriptionHandle | null>(null);
   const queueTopicSubscriptionRef = useRef<SubscriptionHandle | null>(null);
   const queueTopicDestinationRef = useRef<string | null>(null);
+  const matchStateRef = useRef(defaultMatchState);
+  const modalModeRef = useRef<ModalMode>(null);
   const hasConnectedOnceRef = useRef(false);
   const editorPaneRef = useRef<HTMLDivElement | null>(null);
   const [editorLineCount, setEditorLineCount] = useState(28);
   const [editorLineHeight, setEditorLineHeight] = useState(32);
   const [editorFontSize, setEditorFontSize] = useState(13);
+
+  const applyMatchState = useCallback((nextMatchState: MatchStateResponse) => {
+    matchStateRef.current = nextMatchState;
+    setMatchState(nextMatchState);
+  }, []);
+
+  const applyModalMode = useCallback((nextModalMode: ModalMode) => {
+    modalModeRef.current = nextModalMode;
+    setModalMode(nextModalMode);
+  }, []);
+
+  const isMatchStageActive = useCallback(() => {
+    return (
+      matchStateRef.current.status !== "IDLE" ||
+      modalModeRef.current === "READY_CHECK" ||
+      modalModeRef.current === "ROOM_READY" ||
+      modalModeRef.current === "TERMINAL"
+    );
+  }, []);
 
   const clearQueueTopicSubscription = useCallback(() => {
     queueTopicSubscriptionRef.current?.unsubscribe();
@@ -286,25 +307,25 @@ export default function HomeScreen() {
 
   const resetFlow = useCallback((nextFeedback = DEFAULT_FEEDBACK) => {
     setQueueState(defaultQueueState);
-    setMatchState(defaultMatchState);
+    applyMatchState(defaultMatchState);
     setQueueStartedAt(null);
     setTerminalMessage(null);
-    setModalMode(null);
+    applyModalMode(null);
     setPollStage("IDLE");
     setError(null);
     setFeedback(nextFeedback);
     joiningRoomIdRef.current = null;
-  }, []);
+  }, [applyMatchState, applyModalMode]);
 
   const applyMatchSnapshot = useCallback((nextMatchState: MatchStateResponse) => {
-    setMatchState(nextMatchState);
+    applyMatchState(nextMatchState);
     setQueueState(defaultQueueState);
     setQueueStartedAt(null);
     setError(null);
 
     if (nextMatchState.status === "ACCEPT_PENDING") {
       setTerminalMessage(null);
-      setModalMode("READY_CHECK");
+      applyModalMode("READY_CHECK");
       setPollStage("MATCH");
       setFeedback(nextMatchState.message ?? "매칭이 성사되었습니다. 수락 여부를 선택해주세요.");
       return;
@@ -312,7 +333,7 @@ export default function HomeScreen() {
 
     if (nextMatchState.status === "ROOM_READY") {
       setTerminalMessage(null);
-      setModalMode("ROOM_READY");
+      applyModalMode("ROOM_READY");
       setPollStage("IDLE");
       setFeedback(nextMatchState.message ?? "전원이 수락했습니다. 배틀룸으로 입장합니다.");
       return;
@@ -326,17 +347,17 @@ export default function HomeScreen() {
           : "다른 참가자가 매칭을 거절했습니다.");
 
       setTerminalMessage(nextMessage);
-      setModalMode("TERMINAL");
+      applyModalMode("TERMINAL");
       setPollStage("IDLE");
       setFeedback(nextMessage);
       return;
     }
 
     setTerminalMessage(null);
-    setModalMode(null);
+    applyModalMode(null);
     setPollStage("IDLE");
     setFeedback(DEFAULT_FEEDBACK);
-  }, []);
+  }, [applyMatchState, applyModalMode]);
 
   const attemptRoomEntry = useCallback(
     async (roomId: number) => {
@@ -406,12 +427,12 @@ export default function HomeScreen() {
         return;
       }
 
-      setMatchState(defaultMatchState);
-      setModalMode("READY_CHECK");
+      applyMatchState(defaultMatchState);
+      applyModalMode("READY_CHECK");
       setPollStage("MATCH");
       setFeedback("ready-check 세션을 확인하는 중입니다.");
     },
-    [applyMatchSnapshot, clearQueueTopicSubscription],
+    [applyMatchSnapshot, applyMatchState, applyModalMode, clearQueueTopicSubscription],
   );
 
   const handleMatchStateEvent = useCallback(
@@ -590,10 +611,10 @@ export default function HomeScreen() {
               ...restoredQueueState,
               requiredCount: restoredQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
             });
-            setMatchState(defaultMatchState);
+            applyMatchState(defaultMatchState);
             setQueueStartedAt((current) => current ?? new Date().toISOString());
             setTerminalMessage(null);
-            setModalMode("SEARCHING");
+            applyModalMode("SEARCHING");
             setPollStage("QUEUE");
             setError(null);
             setFeedback("?湲곗뿴?먯꽌 ?곷?瑜?李얘퀬 ?덉뒿?덈떎.");
@@ -627,6 +648,8 @@ export default function HomeScreen() {
     };
   }, [
     applyMatchSnapshot,
+    applyMatchState,
+    applyModalMode,
     clearQueueTopicSubscription,
     handleMatchStateEvent,
     handleQueueStateChangedEvent,
@@ -739,10 +762,10 @@ export default function HomeScreen() {
           requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
         });
         logMatchingDebug("initial restore queue/me inQueue=true", nextQueueState);
-        setMatchState(defaultMatchState);
+        applyMatchState(defaultMatchState);
         setQueueStartedAt((current) => current ?? new Date().toISOString());
         setTerminalMessage(null);
-        setModalMode("SEARCHING");
+        applyModalMode("SEARCHING");
         setPollStage("QUEUE");
         setError(null);
         setFeedback("대기열에서 상대를 찾고 있습니다.");
@@ -761,7 +784,7 @@ export default function HomeScreen() {
     return () => {
       active = false;
     };
-  }, [applyMatchSnapshot, resetFlow, session.authenticated, sessionLoaded]);
+  }, [applyMatchSnapshot, applyMatchState, applyModalMode, resetFlow, session.authenticated, sessionLoaded]);
 
   useEffect(() => {
     if (
@@ -809,7 +832,7 @@ export default function HomeScreen() {
           ...nextQueueState,
           requiredCount: nextQueueState.requiredCount ?? DEFAULT_REQUIRED_COUNT,
         });
-        setModalMode("SEARCHING");
+        applyModalMode("SEARCHING");
         setError(null);
         setFeedback("대기열에서 상대를 찾고 있습니다.");
         return;
@@ -819,7 +842,7 @@ export default function HomeScreen() {
       logMatchingDebug("poll queue/me inQueue=false -> switch to matches/me", nextQueueState);
       setQueueState(nextQueueState);
       setQueueStartedAt(null);
-      setModalMode("READY_CHECK");
+      applyModalMode("READY_CHECK");
       setPollStage("MATCH");
       setError(null);
       setFeedback("ready-check 세션을 확인하는 중입니다.");
@@ -853,6 +876,7 @@ export default function HomeScreen() {
     };
   }, [
     applyMatchSnapshot,
+    applyModalMode,
     clearQueueTopicSubscription,
     pollStage,
     resetFlow,
@@ -931,6 +955,16 @@ export default function HomeScreen() {
         | null;
 
       if ((response.ok || response.status === 409) && isQueueStatusResponse(payload)) {
+        if (isMatchStageActive()) {
+          logMatchingDebug("ignored queue/join success because match stage is already active", {
+            modalMode: modalModeRef.current,
+            matchStatus: matchStateRef.current.status,
+            queueStatus: payload,
+          });
+          return;
+        }
+
+        logMatchingDebug("applied queue/join success -> SEARCHING", payload);
         setQueueState({
           inQueue: true,
           category: payload.category,
@@ -938,9 +972,9 @@ export default function HomeScreen() {
           waitingCount: payload.waitingCount,
           requiredCount: payload.requiredCount ?? DEFAULT_REQUIRED_COUNT,
         });
-        setMatchState(defaultMatchState);
+        applyMatchState(defaultMatchState);
         setQueueStartedAt(new Date().toISOString());
-        setModalMode("SEARCHING");
+        applyModalMode("SEARCHING");
         setPollStage("QUEUE");
         setFeedback(payload.message);
         syncQueueTopicSubscription(payload.category, payload.difficulty);


### PR DESCRIPTION
refs #45
closes #45

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 4인 매칭 성사 시 <strong>마지막 참가자만 ready-check 화면으로 즉시 전환되지 않고 SEARCHING 화면에 남는 race condition</strong>을 수정한 작업입니다.
</p>

<p>
원인은 마지막 참가자가 <code>READY_CHECK_STARTED</code> WebSocket 이벤트를 먼저 받아 ready-check 상태로 전환된 뒤,
늦게 도착한 <code>queue/join</code> HTTP 성공 응답이 다시 SEARCHING 상태를 세팅하면서 화면을 덮어쓰는 흐름이었습니다.
</p>

<hr />

<h3>1) 최신 매칭 단계 참조용 ref 추가</h3>
<p>
비동기 함수 안에서 오래된 렌더 클로저의 상태를 보지 않도록,
현재 매칭 상태와 모달 상태를 ref로 함께 관리하도록 했습니다.
</p>

<ul>
  <li><code>matchStateRef</code>: 최신 <code>MatchStateResponse</code> 보관</li>
  <li><code>modalModeRef</code>: 최신 모달 단계 보관</li>
</ul>

<p>
이를 위해 <code>applyMatchState()</code>, <code>applyModalMode()</code> helper를 추가해
React state와 ref를 동시에 갱신하도록 정리했습니다.
</p>

<hr />

<h3>2) 늦게 도착한 queue/join 성공 응답 무시 가드 추가</h3>
<p>
<code>queue/join</code> 성공 응답 처리 시점에 이미 match 단계가 활성화되어 있다면,
SEARCHING 상태를 다시 세팅하지 않도록 가드를 추가했습니다.
</p>

<p>
아래 조건 중 하나라도 만족하면 late response로 보고 무시합니다.
</p>

<ul>
  <li><code>matchState.status !== "IDLE"</code></li>
  <li><code>modalMode === "READY_CHECK"</code></li>
  <li><code>modalMode === "ROOM_READY"</code></li>
  <li><code>modalMode === "TERMINAL"</code></li>
</ul>

<pre><code class="language-ts">if (isMatchStageActive()) {
  logMatchingDebug("ignored queue/join success because match stage is already active", {
    modalMode: modalModeRef.current,
    matchStatus: matchStateRef.current.status,
    queueStatus: payload,
  });
  return;
}</code></pre>

<p>
이제 <code>READY_CHECK_STARTED</code>가 먼저 적용된 뒤 <code>queue/join</code> 응답이 늦게 도착하더라도,
화면이 SEARCHING으로 롤백되지 않습니다.
</p>

<hr />

<h3>3) 기존 ready-check handoff 흐름 유지</h3>
<p>
이번 수정은 상태 적용 우선순위만 보강한 작업입니다.
따라서 기존 WebSocket / HTTP 계약은 변경하지 않았습니다.
</p>

<ul>
  <li><code>READY_CHECK_STARTED</code> 수신 후 queue topic 구독 해제 흐름 유지</li>
  <li>ready-check snapshot 적용 흐름 유지</li>
  <li><code>queue/me</code>, <code>matches/me</code> 주기 polling 제거 상태 유지</li>
  <li>matching WebSocket 이벤트 기반 상태 반영 구조 유지</li>
</ul>

<hr />

<h3>4) 디버그 로그 추가</h3>
<p>
마지막 참가자에서 어떤 순서로 상태가 적용되는지 확인할 수 있도록 matching debug log를 추가했습니다.
</p>

<ul>
  <li><code>applied queue/join success -&gt; SEARCHING</code></li>
  <li><code>ignored queue/join success because match stage is already active</code></li>
</ul>

<p>
이를 통해 <code>READY_CHECK_STARTED</code>가 먼저 적용된 뒤 늦은 <code>queue/join</code> 응답이 무시되는지 콘솔에서 바로 확인할 수 있습니다.
</p>

<hr />

<h3>5) 변경 파일</h3>
<ul>
  <li><code>src/features/home/screen.tsx</code></li>
</ul>

<hr />

<h3>테스트 / 확인 포인트</h3>
<ol>
  <li>4인 매칭에서 마지막 참가자 콘솔에 <code>ws READY_CHECK_STARTED</code>가 먼저 찍힌 뒤 <code>queue/join</code> 성공 응답이 와도 SEARCHING으로 롤백되지 않는지 확인</li>
  <li>같은 서버 실행 상태에서 두 번째, 세 번째 매칭을 반복해도 마지막 참가자가 READY_CHECK 화면으로 즉시 진입하는지 확인</li>
  <li>다른 참가자가 추가로 수락하지 않아도 마지막 참가자가 <code>READY_CHECK_STARTED</code>만으로 ready-check 화면을 볼 수 있는지 확인</li>
  <li><code>READY_DECISION_CHANGED</code>, <code>MATCH_CANCELLED</code>, <code>MATCH_EXPIRED</code>, <code>ROOM_READY</code> 이벤트 반영이 기존처럼 동작하는지 확인</li>
  <li>새로고침 시 <code>matches/me = ACCEPT_PENDING</code>이면 ready-check가 기존처럼 복구되는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx.cmd tsc --noEmit</code> 기준으로 통과했습니다.
</p>
