### PR TITLE
[Feat] 각 페이지 전환 시 대기화면 추가

### DIFF
--- a/src/app/battle/results/[roomId]/loading.tsx
+++ b/src/app/battle/results/[roomId]/loading.tsx
@@ -1,0 +1,64 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function BattleResultLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-28 rounded-full" />
+        <Sk className="h-9 w-1/2" />
+        <Sk className="h-4 w-72" />
+        <div className="flex gap-2">
+          <Sk className="h-6 w-20 rounded-full" />
+        </div>
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* 순위 카드 */}
+      <div className="space-y-4">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-5">
+            <div className="flex items-center gap-4">
+              <Sk className="h-10 w-10 rounded-full shrink-0" />
+              <div className="flex-1 space-y-2">
+                <Sk className="h-5 w-32" />
+                <Sk className="h-4 w-24" />
+              </div>
+              <Sk className="h-6 w-20 rounded-full" />
+              <Sk className="h-8 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 코드 패널 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface overflow-hidden">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-app-border">
+          <Sk className="h-3 w-3 rounded-full" />
+          <Sk className="h-3 w-3 rounded-full" />
+          <Sk className="h-3 w-3 rounded-full" />
+          <Sk className="h-4 w-40 ml-2" />
+        </div>
+        <div className="p-4 space-y-2">
+          {[...Array(8)].map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <Sk className="h-4 w-5 shrink-0" />
+              <Sk className={`h-4 ${i % 3 === 0 ? "w-1/3" : i % 3 === 1 ? "w-3/5" : "w-2/5"}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/battle/rooms/[roomId]/loading.tsx
+++ b/src/app/battle/rooms/[roomId]/loading.tsx
@@ -1,0 +1,76 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function BattleRoomLoading() {
+  return (
+    <div className="flex h-[calc(100vh-var(--app-header-h))] gap-0 overflow-hidden -mx-4 md:-mx-6">
+      {/* 왼쪽: 문제 설명 */}
+      <div className="w-full max-w-[460px] border-r border-app-border bg-app-surface overflow-y-auto p-6 space-y-5 shrink-0">
+        {/* 타이머 + 참여자 */}
+        <div className="flex items-center justify-between">
+          <Sk className="h-8 w-20" />
+          <div className="flex gap-2">
+            <Sk className="h-6 w-24 rounded-full" />
+            <Sk className="h-6 w-16 rounded-full" />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <Sk className="h-7 w-3/4" />
+          <div className="flex gap-2">
+            <Sk className="h-5 w-16 rounded-full" />
+            <Sk className="h-5 w-20 rounded-full" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {[...Array(5)].map((_, i) => (
+            <Sk key={i} className={`h-4 ${i % 4 === 3 ? "w-2/3" : "w-full"}`} />
+          ))}
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-elevated p-4 space-y-2">
+          <Sk className="h-3 w-16" />
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-4/5" />
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-elevated p-4 space-y-2">
+          <Sk className="h-3 w-20" />
+          <Sk className="h-4 w-3/4" />
+        </div>
+      </div>
+
+      {/* 오른쪽: 에디터 */}
+      <div className="flex-1 flex flex-col bg-app-base">
+        {/* 언어 선택 바 */}
+        <div className="flex items-center gap-3 border-b border-app-border px-4 py-2">
+          <Sk className="h-7 w-28 rounded-lg" />
+          <div className="ml-auto flex gap-2">
+            <Sk className="h-6 w-16 rounded-full" />
+          </div>
+        </div>
+
+        {/* 에디터 영역 */}
+        <div className="flex-1 p-4 space-y-2">
+          {[...Array(20)].map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <Sk className="h-4 w-6 shrink-0" />
+              <Sk className={`h-4 ${i % 4 === 0 ? "w-1/4" : i % 4 === 1 ? "w-3/5" : i % 4 === 2 ? "w-1/2" : "w-2/5"}`} />
+            </div>
+          ))}
+        </div>
+
+        {/* 제출 버튼 */}
+        <div className="flex items-center justify-between border-t border-app-border px-4 py-3">
+          <Sk className="h-4 w-32" />
+          <div className="flex gap-2">
+            <Sk className="h-9 w-24 rounded-2xl" />
+            <Sk className="h-9 w-24 rounded-2xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -111,3 +111,19 @@ pre {
   background: var(--app-accent);
   color: #0b0f16;
 }
+
+@keyframes skeleton-shimmer {
+  0% { background-position: -200% center; }
+  100% { background-position: 200% center; }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--app-bg-elevated) 25%,
+    rgba(255, 255, 255, 0.055) 50%,
+    var(--app-bg-elevated) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,60 @@
+// Home (/) 스켈레톤
+
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function HomeLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-20 rounded-full" />
+        <Sk className="h-9 w-2/3" />
+        <div className="space-y-2">
+          <Sk className="h-4 w-full max-w-lg" />
+          <Sk className="h-4 w-4/5 max-w-md" />
+        </div>
+        <div className="flex gap-2 pt-1">
+          <Sk className="h-9 w-36 rounded-2xl" />
+        </div>
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-24" />
+          </div>
+        ))}
+      </div>
+
+      {/* Panel: 매칭 설정 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface p-6 space-y-4">
+        <Sk className="h-5 w-32" />
+        <Sk className="h-3 w-56" />
+        <div className="mt-2 grid gap-3 sm:grid-cols-2">
+          <Sk className="h-10 rounded-xl" />
+          <Sk className="h-10 rounded-xl" />
+        </div>
+        <Sk className="h-10 w-36 rounded-2xl" />
+      </div>
+
+      {/* Panel: 최근 전적 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface p-6 space-y-4">
+        <Sk className="h-5 w-24" />
+        <Sk className="h-3 w-48" />
+        <div className="space-y-3 mt-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="flex items-center gap-4">
+              <Sk className="h-4 w-16" />
+              <Sk className="h-4 flex-1" />
+              <Sk className="h-5 w-14 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/loading.tsx
+++ b/src/app/login/loading.tsx
@@ -1,0 +1,32 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function LoginLoading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-sm space-y-6">
+        {/* 제목 */}
+        <div className="space-y-2 text-center">
+          <Sk className="mx-auto h-7 w-32" />
+          <Sk className="mx-auto h-4 w-48" />
+        </div>
+
+        {/* 폼 */}
+        <div className="rounded-2xl border border-app-border bg-app-surface p-6 space-y-4">
+          <div className="space-y-1">
+            <Sk className="h-3 w-12" />
+            <Sk className="h-10 w-full rounded-xl" />
+          </div>
+          <div className="space-y-1">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-10 w-full rounded-xl" />
+          </div>
+          <Sk className="h-10 w-full rounded-2xl" />
+        </div>
+
+        <Sk className="mx-auto h-4 w-40" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/mypage/loading.tsx
+++ b/src/app/mypage/loading.tsx
@@ -1,0 +1,56 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function MyPageLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-20 rounded-full" />
+        <Sk className="h-9 w-1/3" />
+        <Sk className="h-4 w-64" />
+      </div>
+
+      {/* 프로필 카드 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface p-6">
+        <div className="flex items-center gap-5">
+          <Sk className="h-16 w-16 rounded-full shrink-0" />
+          <div className="space-y-2 flex-1">
+            <Sk className="h-6 w-36" />
+            <Sk className="h-4 w-48" />
+          </div>
+          <Sk className="h-9 w-24 rounded-2xl" />
+        </div>
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* 배틀 히스토리 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface overflow-hidden">
+        <div className="flex gap-4 px-5 py-3 border-b border-app-border">
+          <Sk className="h-3 w-24" />
+          <Sk className="h-3 w-20 ml-auto" />
+          <Sk className="h-3 w-16" />
+          <Sk className="h-3 w-14" />
+        </div>
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="flex items-center gap-4 px-5 py-4 border-b border-app-border last:border-0">
+            <Sk className="h-4 w-32" />
+            <Sk className="h-5 w-16 rounded-full ml-auto" />
+            <Sk className="h-4 w-16" />
+            <Sk className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/problems/[problemId]/loading.tsx
+++ b/src/app/problems/[problemId]/loading.tsx
@@ -1,0 +1,67 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function ProblemSoloLoading() {
+  return (
+    <div className="flex h-[calc(100vh-var(--app-header-h))] gap-0 overflow-hidden -mx-4 md:-mx-6">
+      {/* 왼쪽: 문제 설명 */}
+      <div className="w-full max-w-[480px] border-r border-app-border bg-app-surface overflow-y-auto p-6 space-y-5 shrink-0">
+        <div className="space-y-3">
+          <Sk className="h-5 w-20 rounded-full" />
+          <Sk className="h-7 w-3/4" />
+          <div className="flex gap-2">
+            <Sk className="h-5 w-16 rounded-full" />
+            <Sk className="h-5 w-20 rounded-full" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-5/6" />
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-4/5" />
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-elevated p-4 space-y-2">
+          <Sk className="h-3 w-16" />
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-3/4" />
+        </div>
+
+        <div className="rounded-xl border border-app-border bg-app-elevated p-4 space-y-2">
+          <Sk className="h-3 w-20" />
+          <Sk className="h-4 w-full" />
+          <Sk className="h-4 w-2/3" />
+        </div>
+      </div>
+
+      {/* 오른쪽: 에디터 */}
+      <div className="flex-1 flex flex-col bg-app-base">
+        {/* 언어 선택 바 */}
+        <div className="flex items-center gap-3 border-b border-app-border px-4 py-2">
+          <Sk className="h-7 w-28 rounded-lg" />
+          <Sk className="h-5 w-px" />
+          <Sk className="h-5 w-20" />
+        </div>
+
+        {/* 에디터 영역 */}
+        <div className="flex-1 p-4 space-y-2">
+          {[...Array(18)].map((_, i) => (
+            <div key={i} className="flex gap-4">
+              <Sk className="h-4 w-6 shrink-0" />
+              <Sk className={`h-4 ${i % 3 === 0 ? "w-1/3" : i % 3 === 1 ? "w-2/3" : "w-1/2"}`} />
+            </div>
+          ))}
+        </div>
+
+        {/* 하단 실행 버튼 */}
+        <div className="flex items-center justify-end gap-3 border-t border-app-border px-4 py-3">
+          <Sk className="h-9 w-24 rounded-2xl" />
+          <Sk className="h-9 w-24 rounded-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/problems/loading.tsx
+++ b/src/app/problems/loading.tsx
@@ -1,0 +1,52 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function ProblemsLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-24 rounded-full" />
+        <Sk className="h-9 w-1/2" />
+        <Sk className="h-4 w-full max-w-md" />
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* 검색 / 필터 */}
+      <div className="flex gap-3">
+        <Sk className="h-10 flex-1 rounded-xl" />
+        <Sk className="h-10 w-32 rounded-xl" />
+      </div>
+
+      {/* 문제 목록 테이블 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface overflow-hidden">
+        {/* 헤더 */}
+        <div className="flex gap-4 px-5 py-3 border-b border-app-border">
+          <Sk className="h-3 w-8" />
+          <Sk className="h-3 w-32" />
+          <Sk className="h-3 w-16 ml-auto" />
+          <Sk className="h-3 w-12" />
+        </div>
+        {/* 행 */}
+        {[...Array(8)].map((_, i) => (
+          <div key={i} className="flex items-center gap-4 px-5 py-4 border-b border-app-border last:border-0">
+            <Sk className="h-4 w-8" />
+            <Sk className="h-4 flex-1" />
+            <Sk className="h-5 w-16 rounded-full ml-auto" />
+            <Sk className="h-4 w-12" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/loading.tsx
+++ b/src/app/signup/loading.tsx
@@ -1,0 +1,28 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function SignupLoading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-2 text-center">
+          <Sk className="mx-auto h-7 w-28" />
+          <Sk className="mx-auto h-4 w-52" />
+        </div>
+
+        <div className="rounded-2xl border border-app-border bg-app-surface p-6 space-y-4">
+          {["h-3 w-12", "h-3 w-20", "h-3 w-16", "h-3 w-24"].map((label, i) => (
+            <div key={i} className="space-y-1">
+              <Sk className={label} />
+              <Sk className="h-10 w-full rounded-xl" />
+            </div>
+          ))}
+          <Sk className="h-10 w-full rounded-2xl" />
+        </div>
+
+        <Sk className="mx-auto h-4 w-36" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/spectate/loading.tsx
+++ b/src/app/spectate/loading.tsx
@@ -1,0 +1,55 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function SpectateLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-20 rounded-full" />
+        <Sk className="h-9 w-2/5" />
+        <Sk className="h-4 w-full max-w-lg" />
+        <div className="flex gap-2">
+          <Sk className="h-6 w-24 rounded-full" />
+          <Sk className="h-6 w-16 rounded-full" />
+        </div>
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* 방 목록 그리드 */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-5 space-y-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-2">
+                <Sk className="h-3 w-16" />
+                <Sk className="h-6 w-48" />
+              </div>
+              <Sk className="h-6 w-20 rounded-full shrink-0" />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="rounded-2xl border border-app-border bg-app-elevated p-4 space-y-2">
+                <Sk className="h-3 w-24" />
+                <Sk className="h-6 w-16" />
+              </div>
+              <div className="rounded-2xl border border-app-border bg-app-elevated p-4 space-y-2">
+                <Sk className="h-3 w-20" />
+                <Sk className="h-6 w-28" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/spectate/rooms/[roomId]/loading.tsx
+++ b/src/app/spectate/rooms/[roomId]/loading.tsx
@@ -1,0 +1,68 @@
+function Sk({ className = "" }: { className?: string }) {
+  return <div className={`skeleton rounded ${className}`} />;
+}
+
+export default function SpectateRoomLoading() {
+  return (
+    <div className="space-y-8">
+      {/* PageHero */}
+      <div className="space-y-4 py-2">
+        <Sk className="h-5 w-28 rounded-full" />
+        <Sk className="h-9 w-3/5" />
+        <Sk className="h-4 w-72" />
+        <div className="flex gap-2">
+          <Sk className="h-6 w-16 rounded-full" />
+          <Sk className="h-6 w-20 rounded-full" />
+        </div>
+      </div>
+
+      {/* 상태 메시지 바 */}
+      <div className="rounded-2xl border border-app-border bg-app-surface px-4 py-3">
+        <Sk className="h-4 w-48" />
+      </div>
+
+      {/* MetricGrid */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface p-4 space-y-3">
+            <Sk className="h-3 w-16" />
+            <Sk className="h-7 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* 코드 윈도우 그리드 (참여자별) */}
+      <div className="grid gap-4 xl:grid-cols-2">
+        {[...Array(2)].map((_, i) => (
+          <div key={i} className="rounded-2xl border border-app-border bg-app-surface overflow-hidden">
+            {/* 윈도우 헤더 */}
+            <div className="flex items-center gap-3 border-b border-app-border px-4 py-3 bg-app-elevated">
+              <div className="flex gap-1.5">
+                <Sk className="h-3 w-3 rounded-full" />
+                <Sk className="h-3 w-3 rounded-full" />
+                <Sk className="h-3 w-3 rounded-full" />
+              </div>
+              <Sk className="h-4 w-40" />
+            </div>
+            {/* 코드 라인 */}
+            <div className="p-4 space-y-2">
+              {[...Array(12)].map((_, j) => (
+                <div key={j} className="flex gap-4">
+                  <Sk className="h-4 w-5 shrink-0" />
+                  <Sk className={`h-4 ${j % 4 === 0 ? "w-1/4" : j % 4 === 1 ? "w-3/5" : j % 4 === 2 ? "w-2/5" : "w-1/2"}`} />
+                </div>
+              ))}
+            </div>
+            {/* 윈도우 푸터 */}
+            <div className="border-t border-app-border px-4 py-2">
+              <Sk className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 돌아가기 버튼 */}
+      <Sk className="h-10 w-40 rounded-2xl" />
+    </div>
+  );
+}

--- a/src/features/battle-result/screen.tsx
+++ b/src/features/battle-result/screen.tsx
@@ -17,6 +17,8 @@ import {
 import { formatDateTime } from "@/shared/utils/format-date-time";
 import { useAppSession } from "@/features/layout/session-context";
 
+import BattleResultLoading from "@/app/battle/results/[roomId]/loading";
+
 import { getBattleResult } from "./data";
 
 export default function BattleResultScreen({ roomId }: { roomId: string }) {
@@ -116,6 +118,10 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
     );
   }
 
+  if (!result && !error) {
+    return <BattleResultLoading />;
+  }
+
   if (!result) {
     return (
       <main className="flex h-full min-h-0 flex-col border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
@@ -144,7 +150,7 @@ export default function BattleResultScreen({ roomId }: { roomId: string }) {
                 <h1 className="text-xl font-semibold text-app-danger">결과를 열지 못했습니다.</h1>
                 <StatusPill tone="danger">Load failed</StatusPill>
               </div>
-              <p className="text-sm text-app-secondary">{error ?? message}</p>
+              <p className="text-sm text-app-secondary">{error}</p>
             </section>
           </div>
         </div>

--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -25,6 +25,7 @@ import {
   writePreferredEditorLanguage,
 } from "@/shared/utils/editor-language";
 
+import BattleRoomLoading from "@/app/battle/rooms/[roomId]/loading";
 import {
   getBattleRoom,
   getProblemDetail,
@@ -1052,6 +1053,10 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
     );
   }
 
+  if (!room && !error) {
+    return <BattleRoomLoading />;
+  }
+
   if (!room) {
     return (
       <div className="space-y-8">
@@ -1063,7 +1068,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         </div>
         <Panel variant="dark" title="오류" description="응답 메시지">
           <p className="text-sm leading-7 text-app-secondary">
-            {error ?? message}
+            {error}
           </p>
         </Panel>
       </div>

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -110,6 +110,7 @@ interface ProfilePaneProps {
     }>;
     myStatus: string | null;
     myUserId: number | null;
+    isJoining: boolean;
   } | null;
   previewPlayedCount: number;
   previewSolvedCount: number;
@@ -201,7 +202,7 @@ export default function ProfilePane({
                   <div className="rounded border border-app-border bg-app-base px-2 py-1.5">
                     <p className="text-[10px] text-app-dim">내 상태</p>
                     <p className="text-sm font-semibold text-app-primary">
-                      {battleSidebarState.myStatus ?? "-"}
+                      {battleSidebarState.isJoining ? "참가 중" : (battleSidebarState.myStatus ?? "-")}
                     </p>
                   </div>
                 </div>
@@ -225,8 +226,8 @@ export default function ProfilePane({
                             </span>
                           ) : null}
                         </div>
-                        <StatusPill tone={participantTone(participant.status)}>
-                          {participant.status}
+                        <StatusPill tone={participantTone(battleSidebarState.isJoining && participant.status === "ABANDONED" ? "PLAYING" : participant.status)}>
+                          {battleSidebarState.isJoining && participant.status === "ABANDONED" ? "PLAYING" : participant.status}
                         </StatusPill>
                       </div>
                     );

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -28,6 +28,7 @@ interface BattleSidebarState {
   participants: RoomResponse["participants"];
   myStatus: string | null;
   myUserId: number | null;
+  isJoining: boolean;
 }
 
 function formatRemainingTime(timerEnd: string | null) {
@@ -187,6 +188,7 @@ export default function IdeShell({
         participants: payload.participants,
         myStatus: me?.status ?? null,
         myUserId: memberId,
+        isJoining: me?.status === "ABANDONED",
       });
     };
 


### PR DESCRIPTION
## 작업 개요

- 각 페이지 전환 시 skeleton 대기화면 추가
- 배틀룸, 배틀결과 화면 로딩 시 에러화면 노출 수정. 값이 null일 경우 에러가 아닌 대기화면 표시
- 배틀시작 시 abandoned상태가 잠시 노출되는 현상 수정. join완료 후에는 abandoned상태 정상 노출

## 영향 범위


## 작업 내용


## 변경 사항


## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #74 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
