### PR TITLE
[feat] 새로고침 후 언어 선택 유지 및 Redis 코드 로딩 순서 보장

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -447,7 +447,13 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
             return;
           }
           const fallbackProblem = getProblemDetail(fallbackRoom.problemId);
-          const nextLanguage = resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
+          const preferredLanguage = readPreferredEditorLanguage();
+          const supportedLanguages = fallbackProblem?.supportedLanguages ?? [];
+          const nextLanguage =
+            preferredLanguage &&
+            (supportedLanguages.length === 0 || supportedLanguages.includes(preferredLanguage))
+              ? preferredLanguage
+              : resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
           const nextStarterCode = resolveStarterCode(fallbackProblem, nextLanguage);
           roomRef.current = fallbackRoom;
           setRoom(fallbackRoom);
@@ -510,22 +516,58 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                 defaultLanguage: nextProblem.defaultLanguage ?? fallbackProblem.defaultLanguage,
               }
             : nextProblem;
-        const nextLanguage = resolveDefaultLanguage(mergedProblem, submitTemplate.language);
+        const preferredLanguage = readPreferredEditorLanguage();
+        const supportedLanguages = mergedProblem?.supportedLanguages ?? [];
+        const nextLanguage =
+          preferredLanguage &&
+          (supportedLanguages.length === 0 || supportedLanguages.includes(preferredLanguage))
+            ? preferredLanguage
+            : resolveDefaultLanguage(mergedProblem, submitTemplate.language);
         const nextStarterCode = resolveStarterCode(mergedProblem, nextLanguage);
+
+        let redisCode: string | null = null;
+        const stateRes = await fetch(`/api/battle/rooms/${roomId}/state`, { cache: "no-store" });
+        if (active && stateRes.ok) {
+          const stateData = (await stateRes.json()) as BattleRoomStateResponse;
+          if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
+            redisCode = stateData.myCode;
+          }
+        }
+
+        if (!active) return;
+
         setProblem(mergedProblem);
         setLanguage(nextLanguage);
-        setCode(nextStarterCode);
+        setCode(redisCode ?? nextStarterCode);
         setMessage("");
       } else {
         if (!active) {
           return;
         }
         const fallbackProblem = getProblemDetail(nextRoom.problemId);
-        const nextLanguage = resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
+        const preferredLanguage = readPreferredEditorLanguage();
+        const supportedLanguages = fallbackProblem?.supportedLanguages ?? [];
+        const nextLanguage =
+          preferredLanguage &&
+          (supportedLanguages.length === 0 || supportedLanguages.includes(preferredLanguage))
+            ? preferredLanguage
+            : resolveDefaultLanguage(fallbackProblem, submitTemplate.language);
         const nextStarterCode = resolveStarterCode(fallbackProblem, nextLanguage);
+
+        let redisCode: string | null = null;
+        const stateRes = await fetch(`/api/battle/rooms/${roomId}/state`, { cache: "no-store" });
+        if (active && stateRes.ok) {
+          const stateData = (await stateRes.json()) as BattleRoomStateResponse;
+          if (typeof stateData.myCode === "string" && stateData.myCode.length > 0) {
+            redisCode = stateData.myCode;
+          }
+        }
+
+        if (!active) return;
+
         setProblem(fallbackProblem);
         setLanguage(nextLanguage);
-        setCode(nextStarterCode);
+        setCode(redisCode ?? nextStarterCode);
         setMessage("문제 상세 조회에 실패해 샘플 설명을 함께 표시합니다.");
       }
     })();


### PR DESCRIPTION
## 작업 개요

 localStorage에 저장된 언어가 문제의 supportedLanguages에 포함되면 resolveDefaultLanguage 대신 우선 적용
fix(battle-room): Redis 코드 로딩을 언어 결정 이후로 순서 보장
                                                                                                                                                  
  room load effect에서 언어 결정 후 state API를 fetch해 
  redisCode ?? starterCode를 setCode로 한 번만 적용

## 영향 범위


## 작업 내용

- [ ] 작업 1
- [ ] 작업 2

## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
