### PR TITLE
[fix] 문제 풀이 완료 후 불필요한 join 재요청 제거

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -601,7 +601,7 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
       !hasAttemptedJoinRef.current;
     const shouldRejoinFromPlaying =
       room.status === "PLAYING" &&
-      (participant?.status === "ABANDONED" || participant?.status === "SOLVED");
+      participant?.status === "ABANDONED";
 
     if (!shouldJoinFromWaiting && !shouldRejoinFromPlaying) {
       return;


### PR DESCRIPTION
## 작업 개요

SOLVED 상태를 shouldRejoinFromPlaying 조건에서 제외해

문제 풀이 완료 시 join API 500 에러가 발생하는 문제 수정

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- [ ] 작업 1
- [ ] 작업 2

## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
