### PR TITLE
[Refactor] 배틀종료 시 강제로 배틀결과 화면으로 리다이렉트 되는 로직을 알림 방식으로 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,17 @@ pre {
   color: #0b0f16;
 }
 
+@keyframes toast-pop {
+  0%   { opacity: 0; transform: translateY(-12px); }
+  12%  { opacity: 1; transform: translateY(0); }
+  75%  { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-12px); }
+}
+
+.animate-toast-pop {
+  animation: toast-pop 3s ease forwards;
+}
+
 @keyframes skeleton-shimmer {
   0% { background-position: -200% center; }
   100% { background-position: 200% center; }

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { SessionResponse } from "@/shared/api/contracts";
 import { StatusPill } from "@/shared/ui";
 import { formatRoleLabel } from "@/shared/utils/format-role-label";
+import type { NotificationItem } from "@/features/layout/ide-shell";
 
 const ideDbRailTopItems = [
   { icon: "notifications", title: "알림" },
@@ -26,7 +27,6 @@ function renderDbRailIcon(name: string) {
       return (
         <svg viewBox="0 0 16 16" fill="none" className={baseClass}>
           <path d="M8 3a3 3 0 0 0-3 3v2.2l-1 1.6h8l-1-1.6V6a3 3 0 0 0-3-3Z" stroke="currentColor" strokeWidth="1.2" />
-          <circle cx="12.2" cy="3.8" r="1.4" fill="var(--app-danger)" />
         </svg>
       );
     case "search":
@@ -99,6 +99,10 @@ function renderDbRailIcon(name: string) {
 interface ProfilePaneProps {
   isProfilePanelOpen: boolean;
   onToggleProfilePanel: () => void;
+  isNotificationPanelOpen: boolean;
+  onToggleNotificationPanel: () => void;
+  notifications: NotificationItem[];
+  onMarkNotificationRead: (id: string) => void;
   session: SessionResponse;
   battleSidebarState?: {
     status: "WAITING" | "PLAYING" | "FINISHED";
@@ -125,6 +129,10 @@ interface ProfilePaneProps {
 export default function ProfilePane({
   isProfilePanelOpen,
   onToggleProfilePanel,
+  isNotificationPanelOpen,
+  onToggleNotificationPanel,
+  notifications,
+  onMarkNotificationRead,
   session,
   battleSidebarState,
   previewPlayedCount,
@@ -136,6 +144,7 @@ export default function ProfilePane({
   isBusy,
   onLogout,
 }: ProfilePaneProps) {
+  const unreadCount = notifications.filter((n) => !n.read).length;
   const battleStatusTone =
     battleSidebarState?.status === "PLAYING"
       ? "success"
@@ -155,10 +164,58 @@ export default function ProfilePane({
     return "default" as const;
   };
 
+  const isPanelOpen = isProfilePanelOpen || isNotificationPanelOpen;
+
   return (
     <aside className="min-h-0 bg-app-elevated md:col-span-2 lg:col-span-1">
-      <div className={`grid h-full ${isProfilePanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
-        <div className={`min-h-0 ${isProfilePanelOpen ? "block" : "hidden"}`}>
+      <div className={`grid h-full ${isPanelOpen ? "grid-cols-[minmax(0,1fr)_38px]" : "grid-cols-[38px]"}`}>
+        <div className={`min-h-0 ${isPanelOpen ? "block" : "hidden"}`}>
+          {isNotificationPanelOpen ? (
+            <>
+              <div className="flex h-12 items-center justify-between border-b border-app-border-strong/80 px-4">
+                <p className="text-sm font-semibold text-app-primary">알림</p>
+                {unreadCount > 0 && (
+                  <span className="rounded-full bg-app-danger px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                    {unreadCount}
+                  </span>
+                )}
+              </div>
+              <div className="h-full overflow-y-auto p-3">
+                {notifications.length === 0 ? (
+                  <p className="text-center text-xs text-app-dim py-6">새 알림이 없습니다.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {notifications.map((n) => (
+                      <div
+                        key={n.id}
+                        className={`rounded-md border p-3 text-xs ${
+                          n.read
+                            ? "border-app-border bg-app-base text-app-secondary"
+                            : "border-app-accent/40 bg-app-accent/10 text-app-primary"
+                        }`}
+                      >
+                        <p className="font-medium">{n.message}</p>
+                        <p className="mt-1 text-app-dim">
+                          {new Date(n.timestamp).toLocaleTimeString("ko-KR", {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          })}
+                        </p>
+                        <Link
+                          href={`/battle/results/${n.roomId}`}
+                          onClick={() => onMarkNotificationRead(n.id)}
+                          className="mt-2 inline-flex h-7 items-center justify-center rounded border border-app-border bg-app-elevated px-2 text-[11px] font-medium text-app-primary transition hover:bg-app-surface"
+                        >
+                          결과 보기
+                        </Link>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
           <div className="flex h-12 items-center justify-between border-b border-app-border-strong/80 px-4">
             <p className="text-sm font-semibold text-app-primary">프로필</p>
           </div>
@@ -311,30 +368,42 @@ export default function ProfilePane({
               )}
             </div>
           </div>
+            </>
+          )}
         </div>
 
         <div className="flex min-h-0 flex-col items-center justify-between border-l border-app-border-strong/80 bg-app-rail py-2">
           <div className="flex flex-col items-center gap-2">
-            {ideDbRailTopItems.map((item) => (
+            {ideDbRailTopItems.map((item) => {
+              const isActive =
+                (item.icon === "database" && isProfilePanelOpen) ||
+                (item.icon === "notifications" && isNotificationPanelOpen);
+              return (
               <button
                 key={item.title}
                 type="button"
                 onClick={() => {
                   if (item.icon === "database") {
                     onToggleProfilePanel();
+                  } else if (item.icon === "notifications") {
+                    onToggleNotificationPanel();
                   }
                 }}
                 title={item.title}
                 aria-label={item.title}
-                className={`h-8 w-8 rounded-md border transition ${
-                  item.icon === "database" && isProfilePanelOpen
+                className={`relative h-8 w-8 rounded-md border transition ${
+                  isActive
                     ? "border-app-accent/70 bg-app-accent text-white shadow-[0_0_0_1px_var(--app-accent-glow)]"
                     : "border-transparent text-app-muted hover:bg-app-elevated/90 hover:text-app-primary"
                 }`}
               >
                 <span className="flex items-center justify-center">{renderDbRailIcon(item.icon)}</span>
+                {item.icon === "notifications" && unreadCount > 0 && !isNotificationPanelOpen && (
+                  <span className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-app-danger" />
+                )}
               </button>
-            ))}
+              );
+            })}
           </div>
           <div className="flex flex-col items-center gap-2">
             {ideDbRailBottomItems.map((item) => (

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -186,9 +186,11 @@ export default function ProfilePane({
                 ) : (
                   <div className="space-y-2">
                     {notifications.map((n) => (
-                      <div
+                      <Link
                         key={n.id}
-                        className={`rounded-md border p-3 text-xs ${
+                        href={`/battle/results/${n.roomId}`}
+                        onClick={() => onMarkNotificationRead(n.id)}
+                        className={`block rounded-md border p-3 text-xs transition hover:brightness-110 ${
                           n.read
                             ? "border-app-border bg-app-base text-app-secondary"
                             : "border-app-accent/40 bg-app-accent/10 text-app-primary"
@@ -201,14 +203,7 @@ export default function ProfilePane({
                             minute: "2-digit",
                           })}
                         </p>
-                        <Link
-                          href={`/battle/results/${n.roomId}`}
-                          onClick={() => onMarkNotificationRead(n.id)}
-                          className="mt-2 inline-flex h-7 items-center justify-center rounded border border-app-border bg-app-elevated px-2 text-[11px] font-medium text-app-primary transition hover:bg-app-surface"
-                        >
-                          결과 보기
-                        </Link>
-                      </div>
+                      </Link>
                     ))}
                   </div>
                 )}

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -6,6 +6,7 @@ import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
 import type {
+  BattleResultWsMessage,
   MyBattleResultItem,
   MyBattleResultsResponse,
   RoomResponse,
@@ -19,6 +20,15 @@ import QuickMenuPane, {
 import SessionContext from "@/features/layout/session-context";
 
 const PREVIEW_RESULTS_SIZE = 5;
+
+export interface NotificationItem {
+  id: string;
+  type: "BATTLE_RESULT";
+  roomId: number;
+  message: string;
+  timestamp: number;
+  read: boolean;
+}
 
 interface BattleSidebarState {
   status: RoomResponse["status"];
@@ -92,6 +102,8 @@ export default function IdeShell({
   const refreshInFlightRef = useRef<Promise<SessionResponse> | null>(null);
   const [isQuickMenuOpen, setIsQuickMenuOpen] = useState(false);
   const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
+  const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [session, setSession] = useState<SessionResponse>(initialSession);
   const [sessionLoaded, setSessionLoaded] = useState(true);
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
@@ -162,32 +174,36 @@ export default function IdeShell({
     let active = true;
 
     const poll = async () => {
-      const response = await fetch(`/api/battle/rooms/${targetRoomId}`, {
-        cache: "no-store",
-        credentials: "include",
-      });
+      try {
+        const response = await fetch(`/api/battle/rooms/${targetRoomId}`, {
+          cache: "no-store",
+          credentials: "include",
+        });
 
-      if (!active) {
-        return;
+        if (!active) {
+          return;
+        }
+
+        if (!response.ok) {
+          setBattleSidebarState(null);
+          return;
+        }
+
+        const payload = (await response.json()) as RoomResponse;
+        const me =
+          payload.participants.find((item) => item.userId === memberId) ?? null;
+
+        setBattleSidebarState({
+          status: payload.status,
+          remainingTime: formatRemainingTime(payload.timerEnd),
+          participants: payload.participants,
+          myStatus: me?.status ?? null,
+          myUserId: memberId,
+          isJoining: me?.status === "ABANDONED",
+        });
+      } catch {
+        // 네비게이션 중 fetch 취소 등 무시
       }
-
-      if (!response.ok) {
-        setBattleSidebarState(null);
-        return;
-      }
-
-      const payload = (await response.json()) as RoomResponse;
-      const me =
-        payload.participants.find((item) => item.userId === memberId) ?? null;
-
-      setBattleSidebarState({
-        status: payload.status,
-        remainingTime: formatRemainingTime(payload.timerEnd),
-        participants: payload.participants,
-        myStatus: me?.status ?? null,
-        myUserId: memberId,
-        isJoining: me?.status === "ABANDONED",
-      });
     };
 
     void poll();
@@ -265,7 +281,6 @@ export default function IdeShell({
     };
   }, [refreshSession, session.authenticated]);
 
-
   // 전역 WebSocket: /topic/user/{myId}/battle 구독 (배틀 결과 실시간 수신)
   useEffect(() => {
     if (!session.authenticated || !session.member) return;
@@ -298,7 +313,25 @@ export default function IdeShell({
             return;
           }
 
-          // TODO: 배틀 종료 알림 처리 예정
+          if (
+            typeof payload === "object" &&
+            payload !== null &&
+            "type" in payload &&
+            (payload as { type: unknown }).type === "BATTLE_RESULT"
+          ) {
+            const msg = payload as BattleResultWsMessage;
+            setNotifications((prev) => [
+              {
+                id: crypto.randomUUID(),
+                type: "BATTLE_RESULT",
+                roomId: msg.roomId,
+                message: `Room ${msg.roomId} 배틀이 종료되었습니다.`,
+                timestamp: Date.now(),
+                read: false,
+              },
+              ...prev,
+            ]);
+          }
         });
       },
     });
@@ -308,7 +341,13 @@ export default function IdeShell({
     return () => {
       void client.deactivate();
     };
-  }, [router, session.authenticated, session.member]);
+  }, [session.authenticated, session.member]);
+
+  const handleMarkNotificationRead = useCallback((id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+  }, []);
 
   async function handleLogout() {
     setIsLoggingOut(true);
@@ -340,11 +379,14 @@ export default function IdeShell({
   );
   const previewScoreDeltaLabel =
     previewScoreDelta > 0 ? `+${previewScoreDelta}` : String(previewScoreDelta);
+
+  const isPanelOpen = isProfilePanelOpen || isNotificationPanelOpen;
+
   const layoutColumnsClass = isQuickMenuOpen
-    ? isProfilePanelOpen
+    ? isPanelOpen
       ? "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]"
       : "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_38px]"
-    : isProfilePanelOpen
+    : isPanelOpen
       ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_250px] xl:grid-cols-[48px_minmax(0,1fr)_290px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_320px]"
       : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_38px]";
 
@@ -443,9 +485,17 @@ export default function IdeShell({
 
           <ProfilePane
             isProfilePanelOpen={isProfilePanelOpen}
-            onToggleProfilePanel={() =>
-              setIsProfilePanelOpen((current) => !current)
-            }
+            onToggleProfilePanel={() => {
+              setIsProfilePanelOpen((current) => !current);
+              setIsNotificationPanelOpen(false);
+            }}
+            isNotificationPanelOpen={isNotificationPanelOpen}
+            onToggleNotificationPanel={() => {
+              setIsNotificationPanelOpen((current) => !current);
+              setIsProfilePanelOpen(false);
+            }}
+            notifications={notifications}
+            onMarkNotificationRead={handleMarkNotificationRead}
             session={session}
             battleSidebarState={battleSidebarState}
             previewPlayedCount={previewPlayedCount}

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -104,6 +104,8 @@ export default function IdeShell({
   const [isProfilePanelOpen, setIsProfilePanelOpen] = useState(true);
   const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false);
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [toast, setToast] = useState<{ key: number; message: string } | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [session, setSession] = useState<SessionResponse>(initialSession);
   const [sessionLoaded, setSessionLoaded] = useState(true);
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
@@ -320,17 +322,26 @@ export default function IdeShell({
             (payload as { type: unknown }).type === "BATTLE_RESULT"
           ) {
             const msg = payload as BattleResultWsMessage;
+            const notifMessage = `Room ${msg.roomId} 배틀이 종료되었습니다.`;
             setNotifications((prev) => [
               {
                 id: crypto.randomUUID(),
                 type: "BATTLE_RESULT",
                 roomId: msg.roomId,
-                message: `Room ${msg.roomId} 배틀이 종료되었습니다.`,
+                message: notifMessage,
                 timestamp: Date.now(),
                 read: false,
               },
               ...prev,
             ]);
+            if (toastTimerRef.current) {
+              clearTimeout(toastTimerRef.current);
+            }
+            setToast({ key: Date.now(), message: "참여했던 배틀이 종료되었습니다." });
+            toastTimerRef.current = setTimeout(() => {
+              setToast(null);
+              toastTimerRef.current = null;
+            }, 3000);
           }
         });
       },
@@ -462,6 +473,16 @@ export default function IdeShell({
     <SessionContext.Provider
       value={{ session, sessionLoaded, refreshSession, applySession }}
     >
+      {toast && (
+        <div
+          key={toast.key}
+          className="animate-toast-pop pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center"
+        >
+          <div className="rounded-xl border border-app-accent/40 bg-app-surface px-5 py-3 text-sm font-medium text-app-primary shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+            {toast.message}
+          </div>
+        </div>
+      )}
       <div className="flex h-full min-h-0 flex-1 overflow-hidden bg-app-base">
         <div className={`grid h-full w-full ${layoutColumnsClass}`}>
           <QuickMenuPane

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -6,12 +6,10 @@ import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
 import type {
-  BattleResultWsMessage,
   MyBattleResultItem,
   MyBattleResultsResponse,
   RoomResponse,
   SessionResponse,
-  UncheckedBattleResult,
 } from "@/shared/api/contracts";
 
 import ProfilePane from "@/features/home/components/profile-pane";
@@ -267,28 +265,6 @@ export default function IdeShell({
     };
   }, [refreshSession, session.authenticated]);
 
-  // 로그인 시 미확인 배틀 결과 조회 → 있으면 결과 화면으로 이동
-  useEffect(() => {
-    if (!session.authenticated) return;
-
-    void (async () => {
-      try {
-        const response = await fetch("/api/battle/result/unchecked", {
-          cache: "no-store",
-          credentials: "include",
-        });
-
-        if (!response.ok) return;
-
-        const result = (await response.json()) as UncheckedBattleResult | null;
-        if (result?.roomId) {
-          router.push(`/battle/results/${result.roomId}`);
-        }
-      } catch {
-        // 미확인 결과 조회 실패는 무시
-      }
-    })();
-  }, [router, session.authenticated]);
 
   // 전역 WebSocket: /topic/user/{myId}/battle 구독 (배틀 결과 실시간 수신)
   useEffect(() => {
@@ -322,15 +298,7 @@ export default function IdeShell({
             return;
           }
 
-          if (
-            typeof payload === "object" &&
-            payload !== null &&
-            "type" in payload &&
-            (payload as { type: unknown }).type === "BATTLE_RESULT"
-          ) {
-            const msg = payload as BattleResultWsMessage;
-            router.push(`/battle/results/${msg.roomId}`);
-          }
+          // TODO: 배틀 종료 알림 처리 예정
         });
       },
     });

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -105,7 +105,6 @@ export default function IdeShell({
   const [isNotificationPanelOpen, setIsNotificationPanelOpen] = useState(false);
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [toast, setToast] = useState<{ key: number; message: string } | null>(null);
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [session, setSession] = useState<SessionResponse>(initialSession);
   const [sessionLoaded, setSessionLoaded] = useState(true);
   const [recentResults, setRecentResults] = useState<MyBattleResultItem[]>([]);
@@ -334,14 +333,7 @@ export default function IdeShell({
               },
               ...prev,
             ]);
-            if (toastTimerRef.current) {
-              clearTimeout(toastTimerRef.current);
-            }
             setToast({ key: Date.now(), message: "참여했던 배틀이 종료되었습니다." });
-            toastTimerRef.current = setTimeout(() => {
-              setToast(null);
-              toastTimerRef.current = null;
-            }, 3000);
           }
         });
       },
@@ -353,6 +345,12 @@ export default function IdeShell({
       void client.deactivate();
     };
   }, [session.authenticated, session.member]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(id);
+  }, [toast]);
 
   const handleMarkNotificationRead = useCallback((id: string) => {
     setNotifications((prev) =>


### PR DESCRIPTION
## 작업 개요

배틀 종료 시 사용자 동의 없이 결과 화면으로 강제 이동되던 동작을 제거하고,

우측 사이드바 알림 패널과 상단 토스트를 통해 배틀 종료를 알리는 방식으로 개선합니다.

사용자가 원하는 시점에 결과 화면으로 이동할 수 있어 사용성이 향상됩니다.

## 영향 범위

- route: `/battle/rooms/[roomId]`, `/battle/results/[roomId]`

- feature: 배틀 종료 알림, 우측 사이드바 알림 패널

- api/bff: WebSocket `/topic/user/{myId}/battle` (BATTLE*_RESULT 메시지 처리 변경)*

*## 작업 내용*

*- [x] 배틀 종료 시 강제 리다이렉트 제거*

*- [x] 로그인 시 미확인 배틀 결과 자동 이동 제거*

*- [x] 우측 rail 알림 아이콘 클릭 시 알림 패널 열기/닫기*

*- [x] WebSocket BATTLE_*RESULT 수신 시 알림 목록 추가 및 상단 토스트 표시

*- [x] 알림 카드 클릭 시 결과 페이지 이동 및 읽음 처리

## 변경 사항

- `ide-shell.tsx`: WebSocket BATTLE*_RESULT 수신 시 `router.push` 대신 알림 목록(`NotificationItem[]`)에 항목 추가*

*- `ide-shell.tsx`: 로그인 시 미확인 배틀 결과 조회 후 자동 이동 로직 제거*

*- `ide-shell.tsx`: 알림 패널 상태(`isNotificationPanelOpen`) 추가, 알림/프로필 패널 exclusive 토글 처리*

*- `ide-shell.tsx`: BATTLE_*RESULT 수신 시 화면 상단에 3초간 fade-in/fade-out 토스트 표시

- `profile-pane.tsx`: rail 알림 아이콘에 onClick 연결 및 active 강조 스타일 적용

- `profile-pane.tsx`: 읽지 않은 알림 있을 때 알림 아이콘에 빨간 뱃지 표시

- `profile-pane.tsx`: 알림 패널 UI 추가 — 알림 카드 클릭 시 결과 화면 이동 및 읽음 처리

- `globals.css`: 토스트용 `toast-pop` 키프레임 애니메이션 추가

- 알림 목록은 React state로 관리 (새로고침 시 초기화, localStorage 저장은 추후 개선 예정)

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #83 

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
