### PR TITLE
[Feat] 메인 홈 랭킹 대시보드 구현

### DIFF
--- a/src/app/api/v1/rankings/me/dashboard/route.ts
+++ b/src/app/api/v1/rankings/me/dashboard/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { RankingDashboardResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET() {
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      "/api/v1/rankings/me/dashboard",
+      {},
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json({ message: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    const body = await readJsonBody<RankingDashboardResponse>(response.clone());
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { message: await getErrorMessage(response) },
+        { status: response.status },
+      );
+    }
+
+    if (!body) {
+      return NextResponse.json(
+        { message: "랭킹 대시보드 응답을 읽지 못했습니다." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(body);
+  } catch {
+    return NextResponse.json(
+      { message: "랭킹 대시보드 조회에 실패했습니다." },
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, RefObject } from "react";
 import type { Difficulty } from "@/shared/api/contracts";
 
 import type { QueueCategoryOption, QueueCategoryValue } from "../data";
+import RatingPreviewPanel from "./rating-preview-panel";
 
 interface QueueEditorPaneProps {
   editorPaneRef: RefObject<HTMLDivElement | null>;
@@ -208,6 +209,7 @@ export default function QueueEditorPane({
                   {error ?? terminalMessage}
                 </div>
               ) : null}
+              <RatingPreviewPanel />
             </div>
           </div>
         </div>

--- a/src/features/home/components/rating-preview-panel.tsx
+++ b/src/features/home/components/rating-preview-panel.tsx
@@ -1,0 +1,198 @@
+const ratingTrend = [
+  { label: "D-6", value: 1216 },
+  { label: "D-5", value: 1224 },
+  { label: "D-4", value: 1239 },
+  { label: "D-3", value: 1228 },
+  { label: "D-2", value: 1257 },
+  { label: "D-1", value: 1271 },
+  { label: "NOW", value: 1284 },
+];
+
+const gateProgress = [
+  { label: "AP", value: 140, target: 220, tone: "from-app-accent to-app-accent-soft" },
+  { label: "1400+", value: 8, target: 12, tone: "from-app-warn to-app-success" },
+  { label: "Top2", value: 45, target: 55, suffix: "%", tone: "from-app-success to-app-accent-soft" },
+];
+
+const nearbyRanks = [
+  { rank: 40, nickname: "j10@aa.com", score: 1291 },
+  { rank: 41, nickname: "n3@aa.com", score: 1288 },
+  { rank: 42, nickname: "nm2@aa.com", score: 1284, isMe: true },
+  { rank: 43, nickname: "j2@aa.com", score: 1279 },
+];
+
+const tierDistribution = [
+  { tier: "B5", value: 22 },
+  { tier: "B4", value: 34 },
+  { tier: "B3", value: 48 },
+  { tier: "B2", value: 39 },
+  { tier: "B1", value: 26 },
+  { tier: "S5", value: 18 },
+  { tier: "S4", value: 9 },
+];
+
+const trendValues = ratingTrend.map((item) => item.value);
+const trendMin = Math.min(...trendValues);
+const trendMax = Math.max(...trendValues);
+const trendRange = Math.max(1, trendMax - trendMin);
+const trendPoints = ratingTrend
+  .map((item, index) => {
+    const x = 10 + index * 14;
+    const y = 70 - ((item.value - trendMin) / trendRange) * 48;
+
+    return `${x},${y.toFixed(1)}`;
+  })
+  .join(" ");
+
+export default function RatingPreviewPanel() {
+  return (
+    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.22)]">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.24em] text-app-accent-soft">
+            RATING_MONITOR
+          </p>
+          <h2 className="mt-1 text-lg font-semibold text-app-primary">
+            내 성장 그래프 미리보기
+          </h2>
+          <p className="mt-1 text-xs text-app-secondary">
+            mock data로 구성한 랭킹 대시보드 예시입니다. 실제 API가 붙으면 현재 티어, 승급 게이트,
+            주변 랭킹을 함께 보여줄 수 있습니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2 text-center font-mono text-xs">
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">TIER</p>
+            <p className="mt-1 text-app-warn">BRONZE_1</p>
+          </div>
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">RANK</p>
+            <p className="mt-1 text-app-primary">#42</p>
+          </div>
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">SR</p>
+            <p className="mt-1 text-app-success">1284</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.9fr)]">
+        <div className="rounded-lg border border-app-border bg-app-base p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="font-mono text-xs text-app-dim">battleRating trend</p>
+              <p className="mt-1 text-sm font-semibold text-app-primary">최근 7회 SR 변화</p>
+            </div>
+            <span className="rounded-full border border-app-success/40 bg-app-success/10 px-2 py-1 font-mono text-xs text-app-success">
+              +68 SR
+            </span>
+          </div>
+
+          <div className="mt-4 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
+            <svg viewBox="0 0 100 78" role="img" aria-label="최근 7회 레이팅 변화 그래프" className="h-40 w-full overflow-visible">
+              <defs>
+                <linearGradient id="ratingTrendGradient" x1="0" x2="1" y1="0" y2="0">
+                  <stop offset="0%" stopColor="#8b5cf6" />
+                  <stop offset="55%" stopColor="#38bdf8" />
+                  <stop offset="100%" stopColor="#22c55e" />
+                </linearGradient>
+              </defs>
+              {[18, 34, 50, 66].map((y) => (
+                <line key={y} x1="8" x2="94" y1={y} y2={y} stroke="rgba(148,163,184,0.16)" strokeWidth="0.45" />
+              ))}
+              <polyline points={trendPoints} fill="none" stroke="url(#ratingTrendGradient)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              {ratingTrend.map((item, index) => {
+                const x = 10 + index * 14;
+                const y = 70 - ((item.value - trendMin) / trendRange) * 48;
+
+                return (
+                  <g key={item.label}>
+                    <circle cx={x} cy={y} r="2.6" fill="#0f172a" stroke="#38bdf8" strokeWidth="1.4" />
+                    <text x={x} y="77" textAnchor="middle" className="fill-app-dim text-[4px]">
+                      {item.label}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <p className="font-mono text-xs text-app-dim">promotion gate</p>
+            <p className="mt-1 text-sm font-semibold text-app-primary">SILVER_5까지 남은 조건</p>
+            <div className="mt-4 space-y-3">
+              {gateProgress.map((item) => {
+                const percent = Math.min(100, Math.round((item.value / item.target) * 100));
+
+                return (
+                  <div key={item.label}>
+                    <div className="mb-1 flex justify-between font-mono text-xs">
+                      <span className="text-app-secondary">{item.label}</span>
+                      <span className="text-app-primary">
+                        {item.value}
+                        {item.suffix ?? ""} / {item.target}
+                        {item.suffix ?? ""}
+                      </span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-app-elevated">
+                      <div className={`h-full rounded-full bg-gradient-to-r ${item.tone}`} style={{ width: `${percent}%` }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="font-mono text-xs text-app-dim">nearby ranking</p>
+              <span className="font-mono text-xs text-app-accent-soft">TOP 18%</span>
+            </div>
+            <div className="space-y-2">
+              {nearbyRanks.map((item) => (
+                <div
+                  key={item.rank}
+                  className={`flex items-center justify-between rounded-md border px-3 py-2 font-mono text-xs ${
+                    item.isMe
+                      ? "border-app-accent/50 bg-app-accent/15 text-app-primary"
+                      : "border-app-border bg-app-elevated/70 text-app-secondary"
+                  }`}
+                >
+                  <span>#{item.rank} {item.nickname}</span>
+                  <span>{item.score}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg border border-app-border bg-app-base p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <p className="font-mono text-xs text-app-dim">tier distribution</p>
+          <p className="font-mono text-xs text-app-secondary">내 위치는 BRONZE_1 끝자락</p>
+        </div>
+        <div className="flex h-28 items-end gap-2">
+          {tierDistribution.map((item) => (
+            <div key={item.tier} className="flex min-w-0 flex-1 flex-col items-center gap-2">
+              <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
+                <div
+                  className={`w-full rounded-t-md ${
+                    item.tier === "B1"
+                      ? "bg-gradient-to-t from-app-accent to-app-success"
+                      : "bg-gradient-to-t from-app-border-strong to-app-surface"
+                  }`}
+                  style={{ height: `${item.value}%` }}
+                />
+              </div>
+              <span className="font-mono text-[10px] text-app-dim">{item.tier}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/home/components/rating-preview-panel.tsx
+++ b/src/features/home/components/rating-preview-panel.tsx
@@ -1,50 +1,289 @@
-const ratingTrend = [
-  { label: "D-6", value: 1216 },
-  { label: "D-5", value: 1224 },
-  { label: "D-4", value: 1239 },
-  { label: "D-3", value: 1228 },
-  { label: "D-2", value: 1257 },
-  { label: "D-1", value: 1271 },
-  { label: "NOW", value: 1284 },
-];
+"use client";
 
-const gateProgress = [
-  { label: "AP", value: 140, target: 220, tone: "from-app-accent to-app-accent-soft" },
-  { label: "1400+", value: 8, target: 12, tone: "from-app-warn to-app-success" },
-  { label: "Top2", value: 45, target: 55, suffix: "%", tone: "from-app-success to-app-accent-soft" },
-];
+import { useEffect, useMemo, useState } from "react";
 
-const nearbyRanks = [
-  { rank: 40, nickname: "j10@aa.com", score: 1291 },
-  { rank: 41, nickname: "n3@aa.com", score: 1288 },
-  { rank: 42, nickname: "nm2@aa.com", score: 1284, isMe: true },
-  { rank: 43, nickname: "j2@aa.com", score: 1279 },
-];
+import type {
+  RankingDashboardGateProgress,
+  RankingDashboardResponse,
+  RankingDashboardTagStat,
+  RankingDashboardTrendPoint,
+} from "@/shared/api/contracts";
 
-const tierDistribution = [
-  { tier: "B5", value: 22 },
-  { tier: "B4", value: 34 },
-  { tier: "B3", value: 48 },
-  { tier: "B2", value: 39 },
-  { tier: "B1", value: 26 },
-  { tier: "S5", value: 18 },
-  { tier: "S4", value: 9 },
-];
+interface ApiErrorResponse {
+  message?: string;
+}
 
-const trendValues = ratingTrend.map((item) => item.value);
-const trendMin = Math.min(...trendValues);
-const trendMax = Math.max(...trendValues);
-const trendRange = Math.max(1, trendMax - trendMin);
-const trendPoints = ratingTrend
-  .map((item, index) => {
-    const x = 10 + index * 14;
-    const y = 70 - ((item.value - trendMin) / trendRange) * 48;
+const numberFormatter = new Intl.NumberFormat("ko-KR");
 
-    return `${x},${y.toFixed(1)}`;
-  })
-  .join(" ");
+async function readRankingDashboard(signal: AbortSignal) {
+  const response = await fetch("/api/v1/rankings/me/dashboard", {
+    cache: "no-store",
+    credentials: "include",
+    signal,
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+
+    throw new Error(payload?.message ?? "랭킹 대시보드를 불러오지 못했습니다.");
+  }
+
+  return (await response.json()) as RankingDashboardResponse;
+}
+
+function formatSignedNumber(value: number) {
+  if (value > 0) return `+${numberFormatter.format(value)}`;
+  return numberFormatter.format(value);
+}
+
+function getGateTone(index: number) {
+  const tones = [
+    "from-app-accent to-app-accent-soft",
+    "from-app-warn to-app-success",
+    "from-app-success to-app-accent-soft",
+  ];
+
+  return tones[index % tones.length];
+}
+
+function getGatePercent(item: RankingDashboardGateProgress) {
+  if (item.target <= 0 || item.current >= item.target) {
+    return 100;
+  }
+
+  return Math.max(0, Math.min(100, Math.round((item.current / item.target) * 100)));
+}
+
+function getTrendPoints(scoreTrend: RankingDashboardTrendPoint[]) {
+  if (scoreTrend.length === 0) {
+    return "";
+  }
+
+  const scores = scoreTrend.map((item) => item.score);
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const range = Math.max(1, max - min);
+
+  return scoreTrend
+    .map((item, index) => {
+      const x = scoreTrend.length === 1 ? 50 : 10 + index * (84 / (scoreTrend.length - 1));
+      const y = 70 - ((item.score - min) / range) * 48;
+
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+function TrendChart({ scoreTrend }: { scoreTrend: RankingDashboardTrendPoint[] }) {
+  const points = useMemo(() => getTrendPoints(scoreTrend), [scoreTrend]);
+  const scores = scoreTrend.map((item) => item.score);
+  const min = scores.length > 0 ? Math.min(...scores) : 0;
+  const max = scores.length > 0 ? Math.max(...scores) : 0;
+  const range = Math.max(1, max - min);
+
+  if (scoreTrend.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
+        아직 표시할 배틀 레이팅 추이가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
+      <svg
+        viewBox="0 0 100 78"
+        role="img"
+        aria-label="최근 배틀 레이팅 변화 그래프"
+        className="h-40 w-full overflow-visible"
+      >
+        <defs>
+          <linearGradient id="ratingDashboardTrendGradient" x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stopColor="#8b5cf6" />
+            <stop offset="55%" stopColor="#38bdf8" />
+            <stop offset="100%" stopColor="#22c55e" />
+          </linearGradient>
+        </defs>
+        {[18, 34, 50, 66].map((y) => (
+          <line
+            key={y}
+            x1="8"
+            x2="94"
+            y1={y}
+            y2={y}
+            stroke="rgba(148,163,184,0.16)"
+            strokeWidth="0.45"
+          />
+        ))}
+        <polyline
+          points={points}
+          fill="none"
+          stroke="url(#ratingDashboardTrendGradient)"
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {scoreTrend.map((item, index) => {
+          const x = scoreTrend.length === 1 ? 50 : 10 + index * (84 / (scoreTrend.length - 1));
+          const y = 70 - ((item.score - min) / range) * 48;
+
+          return (
+            <g key={`${item.label}-${item.occurredAt}`}>
+              <circle cx={x} cy={y} r="2.6" fill="#0f172a" stroke="#38bdf8" strokeWidth="1.4" />
+              <text x={x} y="77" textAnchor="middle" className="fill-app-dim text-[4px]">
+                {item.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function GateProgressList({ items }: { items: RankingDashboardGateProgress[] }) {
+  if (items.length === 0) {
+    return (
+      <div className="mt-4 rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 px-3 py-5 text-xs text-app-dim">
+        다음 티어 조건 데이터가 아직 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 space-y-3">
+      {items.map((item, index) => {
+        const percent = getGatePercent(item);
+        const completed = percent >= 100;
+
+        return (
+          <div key={item.key}>
+            <div className="mb-1 flex justify-between font-mono text-xs">
+              <span className="text-app-secondary">{item.label}</span>
+              <span className={completed ? "text-app-success" : "text-app-primary"}>
+                {numberFormatter.format(item.current)}
+                {item.suffix} / {numberFormatter.format(item.target)}
+                {item.suffix}
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-app-elevated">
+              <div
+                className={`h-full rounded-full bg-gradient-to-r ${getGateTone(index)}`}
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TagStatsList({ items }: { items: RankingDashboardTagStat[] }) {
+  if (items.length === 0) {
+    return <p className="mt-3 text-xs text-app-dim">태그별 통계는 아직 없습니다.</p>;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {items.slice(0, 4).map((item) => (
+        <div key={item.tag}>
+          <div className="mb-1 flex justify-between font-mono text-[11px]">
+            <span className="text-app-secondary">{item.tag}</span>
+            <span className="text-app-primary">{item.accuracy}%</span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-app-elevated">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-app-accent to-app-success"
+              style={{ width: `${Math.max(0, Math.min(100, item.accuracy))}%` }}
+            />
+          </div>
+          <p className="mt-1 text-[10px] text-app-dim">
+            solved {numberFormatter.format(item.solvedCount)} / submissions{" "}
+            {numberFormatter.format(item.submissionCount)}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
+      <div className="animate-pulse space-y-4">
+        <div className="h-4 w-40 rounded bg-app-elevated" />
+        <div className="h-6 w-72 rounded bg-app-elevated" />
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="h-20 rounded bg-app-elevated" />
+          <div className="h-20 rounded bg-app-elevated" />
+          <div className="h-20 rounded bg-app-elevated" />
+        </div>
+        <div className="h-44 rounded bg-app-elevated" />
+      </div>
+    </section>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
+      <p className="font-mono text-xs uppercase tracking-[0.24em] text-app-accent-soft">
+        RATING_MONITOR
+      </p>
+      <div className="mt-3 rounded-md border border-app-danger/50 bg-app-danger/10 px-3 py-3 text-xs text-app-danger">
+        {message}
+      </div>
+    </section>
+  );
+}
 
 export default function RatingPreviewPanel() {
+  const [dashboard, setDashboard] = useState<RankingDashboardResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadDashboard() {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const nextDashboard = await readRankingDashboard(controller.signal);
+        setDashboard(nextDashboard);
+      } catch (caught) {
+        if (controller.signal.aborted) return;
+        setError(caught instanceof Error ? caught.message : "랭킹 대시보드를 불러오지 못했습니다.");
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadDashboard();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (error || !dashboard) {
+    return <ErrorState message={error ?? "랭킹 대시보드 데이터가 없습니다."} />;
+  }
+
+  const { profile } = dashboard;
+  const nextTierLabel = profile.nextTier ?? "최고 티어";
+  const tierDistributionMax = Math.max(
+    1,
+    ...dashboard.tierDistribution.map((item) => item.percentage),
+  );
+
   return (
     <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.22)]">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
@@ -53,26 +292,35 @@ export default function RatingPreviewPanel() {
             RATING_MONITOR
           </p>
           <h2 className="mt-1 text-lg font-semibold text-app-primary">
-            내 성장 그래프 미리보기
+            내 성장/랭킹 대시보드
           </h2>
           <p className="mt-1 text-xs text-app-secondary">
-            mock data로 구성한 랭킹 대시보드 예시입니다. 실제 API가 붙으면 현재 티어, 승급 게이트,
-            주변 랭킹을 함께 보여줄 수 있습니다.
+            {profile.nickname}님의 배틀 레이팅, 승급 조건, 주변 랭킹을 실시간 운영 데이터로 보여줍니다.
           </p>
         </div>
 
-        <div className="grid grid-cols-3 gap-2 text-center font-mono text-xs">
+        <div className="grid grid-cols-2 gap-2 text-center font-mono text-xs sm:grid-cols-5">
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
             <p className="text-app-dim">TIER</p>
-            <p className="mt-1 text-app-warn">BRONZE_1</p>
+            <p className="mt-1 text-app-warn">{profile.tier}</p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
             <p className="text-app-dim">RANK</p>
-            <p className="mt-1 text-app-primary">#42</p>
+            <p className="mt-1 text-app-primary">#{numberFormatter.format(profile.rank)}</p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
-            <p className="text-app-dim">SR</p>
-            <p className="mt-1 text-app-success">1284</p>
+            <p className="text-app-dim">SCORE</p>
+            <p className="mt-1 text-app-success">{numberFormatter.format(profile.score)}</p>
+          </div>
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">TOP2</p>
+            <p className="mt-1 text-app-accent-soft">{profile.top2Rate}%</p>
+          </div>
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">MATCH</p>
+            <p className="mt-1 text-app-primary">
+              {numberFormatter.format(profile.battleMatchCount)}
+            </p>
           </div>
         </div>
       </div>
@@ -81,116 +329,123 @@ export default function RatingPreviewPanel() {
         <div className="rounded-lg border border-app-border bg-app-base p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="font-mono text-xs text-app-dim">battleRating trend</p>
-              <p className="mt-1 text-sm font-semibold text-app-primary">최근 7회 SR 변화</p>
+              <p className="font-mono text-xs text-app-dim">battle score trend</p>
+              <p className="mt-1 text-sm font-semibold text-app-primary">최근 배틀 레이팅 변화</p>
             </div>
-            <span className="rounded-full border border-app-success/40 bg-app-success/10 px-2 py-1 font-mono text-xs text-app-success">
-              +68 SR
+            <span
+              className={`rounded-full border px-2 py-1 font-mono text-xs ${
+                profile.scoreDeltaTotal >= 0
+                  ? "border-app-success/40 bg-app-success/10 text-app-success"
+                  : "border-app-danger/40 bg-app-danger/10 text-app-danger"
+              }`}
+            >
+              {formatSignedNumber(profile.scoreDeltaTotal)}
             </span>
           </div>
 
-          <div className="mt-4 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
-            <svg viewBox="0 0 100 78" role="img" aria-label="최근 7회 레이팅 변화 그래프" className="h-40 w-full overflow-visible">
-              <defs>
-                <linearGradient id="ratingTrendGradient" x1="0" x2="1" y1="0" y2="0">
-                  <stop offset="0%" stopColor="#8b5cf6" />
-                  <stop offset="55%" stopColor="#38bdf8" />
-                  <stop offset="100%" stopColor="#22c55e" />
-                </linearGradient>
-              </defs>
-              {[18, 34, 50, 66].map((y) => (
-                <line key={y} x1="8" x2="94" y1={y} y2={y} stroke="rgba(148,163,184,0.16)" strokeWidth="0.45" />
-              ))}
-              <polyline points={trendPoints} fill="none" stroke="url(#ratingTrendGradient)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
-              {ratingTrend.map((item, index) => {
-                const x = 10 + index * 14;
-                const y = 70 - ((item.value - trendMin) / trendRange) * 48;
-
-                return (
-                  <g key={item.label}>
-                    <circle cx={x} cy={y} r="2.6" fill="#0f172a" stroke="#38bdf8" strokeWidth="1.4" />
-                    <text x={x} y="77" textAnchor="middle" className="fill-app-dim text-[4px]">
-                      {item.label}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
-          </div>
+          <TrendChart scoreTrend={dashboard.scoreTrend} />
         </div>
 
         <div className="grid gap-4">
           <div className="rounded-lg border border-app-border bg-app-base p-4">
             <p className="font-mono text-xs text-app-dim">promotion gate</p>
-            <p className="mt-1 text-sm font-semibold text-app-primary">SILVER_5까지 남은 조건</p>
-            <div className="mt-4 space-y-3">
-              {gateProgress.map((item) => {
-                const percent = Math.min(100, Math.round((item.value / item.target) * 100));
-
-                return (
-                  <div key={item.label}>
-                    <div className="mb-1 flex justify-between font-mono text-xs">
-                      <span className="text-app-secondary">{item.label}</span>
-                      <span className="text-app-primary">
-                        {item.value}
-                        {item.suffix ?? ""} / {item.target}
-                        {item.suffix ?? ""}
-                      </span>
-                    </div>
-                    <div className="h-2 overflow-hidden rounded-full bg-app-elevated">
-                      <div className={`h-full rounded-full bg-gradient-to-r ${item.tone}`} style={{ width: `${percent}%` }} />
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+            <p className="mt-1 text-sm font-semibold text-app-primary">
+              {profile.nextTier ? `${nextTierLabel}까지 남은 조건` : "최고 티어 구간"}
+            </p>
+            <GateProgressList items={dashboard.gateProgress} />
           </div>
 
           <div className="rounded-lg border border-app-border bg-app-base p-4">
             <div className="mb-3 flex items-center justify-between">
               <p className="font-mono text-xs text-app-dim">nearby ranking</p>
-              <span className="font-mono text-xs text-app-accent-soft">TOP 18%</span>
+              <span className="font-mono text-xs text-app-accent-soft">
+                TOP {profile.percentile.toFixed(1)}%
+              </span>
             </div>
-            <div className="space-y-2">
-              {nearbyRanks.map((item) => (
-                <div
-                  key={item.rank}
-                  className={`flex items-center justify-between rounded-md border px-3 py-2 font-mono text-xs ${
-                    item.isMe
-                      ? "border-app-accent/50 bg-app-accent/15 text-app-primary"
-                      : "border-app-border bg-app-elevated/70 text-app-secondary"
-                  }`}
-                >
-                  <span>#{item.rank} {item.nickname}</span>
-                  <span>{item.score}</span>
-                </div>
-              ))}
-            </div>
+            {dashboard.nearbyRanking.length === 0 ? (
+              <p className="text-xs text-app-dim">주변 랭킹 데이터가 아직 없습니다.</p>
+            ) : (
+              <div className="space-y-2">
+                {dashboard.nearbyRanking.map((item) => (
+                  <div
+                    key={item.memberId}
+                    className={`flex items-center justify-between rounded-md border px-3 py-2 font-mono text-xs ${
+                      item.isMe
+                        ? "border-app-accent/50 bg-app-accent/15 text-app-primary"
+                        : "border-app-border bg-app-elevated/70 text-app-secondary"
+                    }`}
+                  >
+                    <span>
+                      #{numberFormatter.format(item.rank)} {item.nickname}
+                    </span>
+                    <span>{numberFormatter.format(item.score)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>
 
-      <div className="mt-4 rounded-lg border border-app-border bg-app-base p-4">
-        <div className="mb-3 flex items-center justify-between">
-          <p className="font-mono text-xs text-app-dim">tier distribution</p>
-          <p className="font-mono text-xs text-app-secondary">내 위치는 BRONZE_1 끝자락</p>
-        </div>
-        <div className="flex h-28 items-end gap-2">
-          {tierDistribution.map((item) => (
-            <div key={item.tier} className="flex min-w-0 flex-1 flex-col items-center gap-2">
-              <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
-                <div
-                  className={`w-full rounded-t-md ${
-                    item.tier === "B1"
-                      ? "bg-gradient-to-t from-app-accent to-app-success"
-                      : "bg-gradient-to-t from-app-border-strong to-app-surface"
-                  }`}
-                  style={{ height: `${item.value}%` }}
-                />
-              </div>
-              <span className="font-mono text-[10px] text-app-dim">{item.tier}</span>
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.8fr)]">
+        <div className="rounded-lg border border-app-border bg-app-base p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <p className="font-mono text-xs text-app-dim">tier distribution</p>
+            <p className="font-mono text-xs text-app-secondary">내 위치: {profile.tier}</p>
+          </div>
+          {dashboard.tierDistribution.length === 0 ? (
+            <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
+              티어 분포 데이터가 아직 없습니다.
             </div>
-          ))}
+          ) : (
+            <div className="flex h-28 items-end gap-2">
+              {dashboard.tierDistribution.map((item) => {
+                const height = Math.max(6, Math.round((item.percentage / tierDistributionMax) * 100));
+
+                return (
+                  <div key={item.tier} className="flex min-w-0 flex-1 flex-col items-center gap-2">
+                    <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
+                      <div
+                        className={`w-full rounded-t-md ${
+                          item.isMyTier
+                            ? "bg-gradient-to-t from-app-accent to-app-success"
+                            : "bg-gradient-to-t from-app-border-strong to-app-surface"
+                        }`}
+                        style={{ height: `${height}%` }}
+                        title={`${item.tier}: ${item.count}명 (${item.percentage}%)`}
+                      />
+                    </div>
+                    <span className="truncate font-mono text-[10px] text-app-dim">{item.tier}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-4">
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <p className="font-mono text-xs text-app-dim">tag strength</p>
+            <TagStatsList items={dashboard.tagStats} />
+          </div>
+
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <p className="font-mono text-xs text-app-dim">review queue</p>
+            <div className="mt-3 grid grid-cols-2 gap-2 font-mono text-xs">
+              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <p className="text-app-dim">TODAY</p>
+                <p className="mt-1 text-app-warn">
+                  {numberFormatter.format(dashboard.reviewSummary.dueTodayCount)}
+                </p>
+              </div>
+              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <p className="text-app-dim">UPCOMING</p>
+                <p className="mt-1 text-app-primary">
+                  {numberFormatter.format(dashboard.reviewSummary.upcomingCount)}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -104,6 +104,72 @@ export interface RatingProgressResponse {
 
 export type RatingProgressApiResponse = RsData<RatingProgressResponse | null>;
 
+export interface RankingDashboardProfile {
+  memberId: number;
+  nickname: string;
+  tier: string;
+  rank: number;
+  percentile: number;
+  score: number;
+  nextTier: string | null;
+  battleMatchCount: number;
+  top2Rate: number;
+  scoreDeltaTotal: number;
+}
+
+export interface RankingDashboardTrendPoint {
+  label: string;
+  occurredAt: string;
+  score: number;
+  delta: number;
+}
+
+export interface RankingDashboardGateProgress {
+  key: string;
+  label: string;
+  current: number;
+  target: number;
+  suffix: string;
+}
+
+export interface RankingDashboardNearbyRank {
+  rank: number;
+  memberId: number;
+  nickname: string;
+  tier: string;
+  score: number;
+  isMe: boolean;
+}
+
+export interface RankingDashboardTierDistribution {
+  tier: string;
+  count: number;
+  percentage: number;
+  isMyTier: boolean;
+}
+
+export interface RankingDashboardTagStat {
+  tag: string;
+  solvedCount: number;
+  submissionCount: number;
+  accuracy: number;
+}
+
+export interface RankingDashboardReviewSummary {
+  dueTodayCount: number;
+  upcomingCount: number;
+}
+
+export interface RankingDashboardResponse {
+  profile: RankingDashboardProfile;
+  scoreTrend: RankingDashboardTrendPoint[];
+  gateProgress: RankingDashboardGateProgress[];
+  nearbyRanking: RankingDashboardNearbyRank[];
+  tierDistribution: RankingDashboardTierDistribution[];
+  tagStats: RankingDashboardTagStat[];
+  reviewSummary: RankingDashboardReviewSummary;
+}
+
 export interface QueueJoinRequest {
   category: string;
   difficulty: Difficulty;


### PR DESCRIPTION
refs #82
closes #82

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈의 빈 공간을 활용해
<strong>내 성장/랭킹 상태를 한눈에 볼 수 있는 랭킹 대시보드</strong>를 구현한 작업입니다.
</p>

<p>
초기에는 mock 데이터 기반 프로토타입으로 대시보드 레이아웃과 그래프 구성을 먼저 잡았고,
이후 실제 <code>GET /api/v1/rankings/me/dashboard</code> 응답을 사용하도록 API 연동까지 완료했습니다.
</p>

<p>
즉 이번 PR은
</p>

<ul>
  <li>메인 홈 대시보드 UI 추가</li>
  <li>랭킹 대시보드 응답 타입 정의</li>
  <li>Next BFF route 추가</li>
  <li>실데이터 기반 렌더링 전환</li>
</ul>

<p>
까지 한 번에 포함합니다.
</p>

<hr />

<h3>1) 메인 홈에 랭킹 대시보드 영역 추가</h3>
<p>
기존 메인 홈은 매칭 설정 영역 아래 빈 공간이 커서,
사용자 입장에서는 첫 진입 시 정보 밀도가 낮게 느껴질 수 있었습니다.
이번 PR에서는 이 공간을 활용해 <strong>랭킹/성장 대시보드</strong>를 배치했습니다.
</p>

<p>
대시보드는 기존 Spring Boot 콘솔형 UI 톤을 유지하면서,
메인 홈의 문맥과 자연스럽게 어울리도록 아래 구성을 사용합니다.
</p>

<ul>
  <li>상단 요약 카드</li>
  <li>최근 배틀 레이팅 변화 그래프</li>
  <li>승급 조건 진행률</li>
  <li>내 주변 랭킹</li>
  <li>티어 분포도</li>
  <li>태그 강점 통계</li>
  <li>복습 요약</li>
</ul>

<hr />

<h3>2) 대시보드 전용 컴포넌트 추가</h3>
<p>
<code>src/features/home/components/rating-preview-panel.tsx</code>를 새로 추가했습니다.
이 컴포넌트가 메인 홈 대시보드 전체 렌더링을 담당합니다.
</p>

<p>
초기 프로토타입에서는 mock 데이터를 사용해 시각 구조를 먼저 검증했고,
현재는 실제 API 응답을 fetch해서 렌더링하도록 바뀌었습니다.
</p>

<p>
핵심 렌더링 영역은 아래와 같습니다.
</p>

<ul>
  <li><code>profile</code> 기반 요약 카드</li>
  <li><code>scoreTrend</code> 기반 라인 차트</li>
  <li><code>gateProgress</code> 기반 progress bar</li>
  <li><code>nearbyRanking</code> 기반 주변 순위 리스트</li>
  <li><code>tierDistribution</code> 기반 티어 분포 막대 차트</li>
  <li><code>tagStats</code> 기반 태그 강점 표시</li>
  <li><code>reviewSummary</code> 기반 복습 요약 카드</li>
</ul>

<hr />

<h3>3) 메인 홈 에디터 패널에 대시보드 연결</h3>
<p>
<code>src/features/home/components/queue-editor-pane.tsx</code>에서
기존 매칭 설정 에디터 UI 하단에 랭킹 대시보드를 렌더링하도록 연결했습니다.
</p>

<p>
즉 메인 홈 구조는 유지하면서도,
사용자가 별도 페이지로 이동하지 않아도
현재 내 랭킹/성장 상태를 바로 확인할 수 있게 했습니다.
</p>

<hr />

<h3>4) 랭킹 대시보드 응답 타입 정의 추가</h3>
<p>
<code>src/shared/api/contracts.ts</code>에
랭킹 대시보드 API 계약을 위한 타입을 추가했습니다.
</p>

<ul>
  <li><code>RankingDashboardProfile</code></li>
  <li><code>RankingDashboardTrendPoint</code></li>
  <li><code>RankingDashboardGateProgress</code></li>
  <li><code>RankingDashboardNearbyRank</code></li>
  <li><code>RankingDashboardTierDistribution</code></li>
  <li><code>RankingDashboardTagStat</code></li>
  <li><code>RankingDashboardReviewSummary</code></li>
  <li><code>RankingDashboardResponse</code></li>
</ul>

<pre><code class="language-ts">export interface RankingDashboardResponse {
  profile: RankingDashboardProfile;
  scoreTrend: RankingDashboardTrendPoint[];
  gateProgress: RankingDashboardGateProgress[];
  nearbyRanking: RankingDashboardNearbyRank[];
  tierDistribution: RankingDashboardTierDistribution[];
  tagStats: RankingDashboardTagStat[];
  reviewSummary: RankingDashboardReviewSummary;
}</code></pre>

<p>
중요한 점은 이 API가 기존 <code>RsData</code> 래퍼를 쓰지 않고,
최상위 JSON이 바로 대시보드 객체라는 점을 그대로 반영했다는 것입니다.
</p>

<hr />

<h3>5) Next BFF route 추가</h3>
<p>
실제 백엔드 API를 프론트에서 직접 호출하지 않도록,
<code>src/app/api/v1/rankings/me/dashboard/route.ts</code>를 추가했습니다.
</p>

<p>
이 route는:
</p>

<ul>
  <li>쿠키 기반 인증 유지</li>
  <li>백엔드 <code>/api/v1/rankings/me/dashboard</code> 프록시</li>
  <li>401 / 502 / 503 에러 처리</li>
  <li><code>RsData</code>가 아닌 순수 JSON body 그대로 전달</li>
</ul>

<p>
를 담당합니다.
</p>

<pre><code class="language-ts">const response = await fetchBackendWithReissue(
  "/api/v1/rankings/me/dashboard",
  {},
  cookieStore,
);

const body = await readJsonBody&lt;RankingDashboardResponse&gt;(response.clone());

return NextResponse.json(body);</code></pre>

<hr />

<h3>6) 프론트 fetch 로직 추가</h3>
<p>
<code>rating-preview-panel.tsx</code> 안에서
<code>/api/v1/rankings/me/dashboard</code>를 직접 호출하는 fetch 로직을 추가했습니다.
</p>

<pre><code class="language-ts">const response = await fetch("/api/v1/rankings/me/dashboard", {
  cache: "no-store",
  credentials: "include",
  signal,
});</code></pre>

<p>
이때 응답은 <code>res.data</code>로 꺼내지 않고,
fetch 결과 JSON 자체를 <code>RankingDashboardResponse</code>로 처리합니다.
</p>

<hr />

<h3>7) 로딩 / 에러 / 빈 데이터 fallback 처리</h3>
<p>
메인 홈에서 대시보드가 추가되면서,
초기 렌더 시 깜빡이거나 레이아웃이 무너지는 것을 막기 위해
상태별 fallback도 함께 추가했습니다.
</p>

<ul>
  <li>로딩 중: skeleton 스타일의 loading state 표시</li>
  <li>에러 발생 시: 에러 패널 표시</li>
  <li>빈 배열일 경우: 차트/리스트 대신 안내 문구 표시</li>
  <li><code>profile.nextTier === null</code>이면 최고 티어 문구 표시</li>
</ul>

<p>
즉 백엔드 응답이 일부 비어 있어도 메인 홈 대시보드가 깨지지 않도록 구성했습니다.
</p>

<hr />

<h3>8) 그래프/카드별 실제 활용 데이터</h3>
<p>
이번 PR에서 각 카드/그래프는 아래 응답 필드를 사용합니다.
</p>

<ul>
  <li>요약 카드: <code>profile.tier</code>, <code>profile.rank</code>, <code>profile.score</code>, <code>profile.top2Rate</code>, <code>profile.battleMatchCount</code></li>
  <li>상단 배지: <code>profile.scoreDeltaTotal</code></li>
  <li>라인 차트: <code>scoreTrend</code></li>
  <li>승급 조건: <code>gateProgress</code></li>
  <li>주변 랭킹: <code>nearbyRanking</code></li>
  <li>티어 분포도: <code>tierDistribution</code></li>
  <li>태그 강점: <code>tagStats</code></li>
  <li>복습 요약: <code>reviewSummary</code></li>
</ul>

<p>
즉 단순 순위표가 아니라,
<strong>현재 내 상태 + 최근 변화 + 승급 방향성</strong>을 동시에 보여주는 구성을 목표로 했습니다.
</p>

<hr />

<h3>9) 반응형 레이아웃 적용</h3>
<p>
메인 홈의 넓은 빈 공간을 채우면서도
기존 홈 레이아웃이 무너지지 않도록,
대시보드는 반응형 grid로 구성했습니다.
</p>

<ul>
  <li>데스크톱: 좌우 2단 구조</li>
  <li>좁은 화면: 카드가 아래로 자연스럽게 쌓이는 구조</li>
  <li>요약 카드: <code>sm:grid-cols-5</code> 기준으로 확장</li>
</ul>

<p>
즉 화면 폭이 줄어들어도 정보 블록 단위로 자연스럽게 줄바꿈되도록 설계했습니다.
</p>

<hr />

<h3>10) 변경 파일</h3>
<ul>
  <li><code>src/features/home/components/queue-editor-pane.tsx</code></li>
  <li><code>src/features/home/components/rating-preview-panel.tsx</code></li>
  <li><code>src/shared/api/contracts.ts</code></li>
  <li><code>src/app/api/v1/rankings/me/dashboard/route.ts</code></li>
</ul>

<hr />

<h3>11) 테스트 / 확인 포인트</h3>
<ol>
  <li>로그인 상태에서 메인 홈 진입 시 <code>/api/v1/rankings/me/dashboard</code>가 호출되는지 확인</li>
  <li>대시보드 API 응답이 <code>RsData</code>가 아닌 순수 JSON body 형태로 정상 처리되는지 확인</li>
  <li><code>profile</code> 값이 상단 요약 카드에 정상 반영되는지 확인</li>
  <li><code>scoreTrend</code> 길이에 따라 라인 차트가 정상 렌더링되는지 확인</li>
  <li><code>gateProgress</code>의 <code>current / target</code> 값이 진행률 바로 표시되는지 확인</li>
  <li><code>nearbyRanking</code>에서 <code>isMe=true</code> row가 강조되는지 확인</li>
  <li><code>tierDistribution</code>에서 <code>isMyTier=true</code> 막대가 강조되는지 확인</li>
  <li><code>tagStats</code>, <code>reviewSummary</code>가 비어 있어도 fallback UI가 깨지지 않는지 확인</li>
  <li>401/503 등 에러 상황에서 에러 패널이 정상 노출되는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx.cmd tsc --noEmit</code> 기준으로 통과했습니다.
</p>
