### PR TITLE
[feat] 혼자풀기 페이지에 복습 스케줄 상태 및 복습 제외 버튼 추가

### DIFF
--- a/src/features/problem-solo/screen.tsx
+++ b/src/features/problem-solo/screen.tsx
@@ -9,6 +9,7 @@ import SockJS from "sockjs-client";
 import type {
   ApiErrorResponse,
   ProblemDetailResponse,
+  ReviewScheduleResponse,
   SoloRunRequest,
   SoloRunResponse,
   SoloSubmitRequest,
@@ -498,6 +499,10 @@ export default function ProblemSoloScreen({
   const [submitState, setSubmitState] = useState<SoloSubmitState>(
     createInitialSubmitState,
   );
+  const [reviewSchedule, setReviewSchedule] =
+    useState<ReviewScheduleResponse | null>(null);
+  const [isDismissing, setIsDismissing] = useState(false);
+
   const [leftPaneRatio, setLeftPaneRatio] = useState(() => {
     const stored = readStoredLayout();
     return stored?.leftPaneRatio ?? DEFAULT_LEFT_PANE_RATIO;
@@ -668,6 +673,29 @@ export default function ProblemSoloScreen({
   }, [code, language, problem, session.member?.memberId]);
 
   useEffect(() => {
+    if (!sessionLoaded || !session.authenticated) {
+      setReviewSchedule(null);
+      return;
+    }
+
+    let active = true;
+
+    (async () => {
+      const res = await fetch(`/api/v1/review?problemId=${problemId}`, {
+        cache: "no-store",
+      });
+      if (active && res.ok) {
+        const body = await res.json();
+        setReviewSchedule(body.data ?? null);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [problemId, session.authenticated, sessionLoaded]);
+
+  useEffect(() => {
     const memberId = session.member?.memberId;
 
     if (!session.authenticated || !memberId) {
@@ -796,6 +824,17 @@ export default function ProblemSoloScreen({
 
   function handleContentLanguageChange(nextLanguage: ContentLanguage) {
     setContentLanguage(nextLanguage);
+  }
+
+  async function handleDismissReview() {
+    setIsDismissing(true);
+    await fetch(`/api/v1/review/dismiss?problemId=${problemId}`, {
+      method: "PATCH",
+    });
+    setReviewSchedule((prev) =>
+      prev ? { ...prev, isReviewRequired: false } : null,
+    );
+    setIsDismissing(false);
   }
 
   function handleResetDraft() {
@@ -1407,6 +1446,26 @@ export default function ProblemSoloScreen({
                                 {problem.language?.toUpperCase()}
                               </StatusPill>
                             </div>
+                            <div className="mt-3 flex items-center justify-between gap-2">
+                              <span className="text-sm text-app-secondary">
+                                풀이횟수:{" "}
+                                <span className="font-semibold text-app-primary">
+                                  {reviewSchedule?.reviewCount ?? 0}회
+                                </span>
+                              </span>
+                              <button
+                                type="button"
+                                onClick={handleDismissReview}
+                                disabled={
+                                  !reviewSchedule ||
+                                  !reviewSchedule.isReviewRequired ||
+                                  isDismissing
+                                }
+                                className="rounded-md border border-app-border px-2.5 py-1 text-xs font-semibold text-app-secondary transition hover:border-app-border-strong hover:text-app-primary disabled:cursor-not-allowed disabled:text-app-dim"
+                              >
+                                이 문제 복습 안하기
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -1866,6 +1925,26 @@ export default function ProblemSoloScreen({
                         <StatusPill variant="dark">
                           {problem.language?.toUpperCase()}
                         </StatusPill>
+                      </div>
+                      <div className="mt-3 flex items-center justify-between gap-2">
+                        <span className="text-sm text-app-secondary">
+                          풀이횟수:{" "}
+                          <span className="font-semibold text-app-primary">
+                            {reviewSchedule?.reviewCount ?? 0}회
+                          </span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={handleDismissReview}
+                          disabled={
+                            !reviewSchedule ||
+                            !reviewSchedule.isReviewRequired ||
+                            isDismissing
+                          }
+                          className="rounded-md border border-app-border px-2.5 py-1 text-xs font-semibold text-app-secondary transition hover:border-app-border-strong hover:text-app-primary disabled:cursor-not-allowed disabled:text-app-dim"
+                        >
+                          이 문제 복습 안하기
+                        </button>
                       </div>
                     </div>
                   </div>

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -489,3 +489,8 @@ export interface UncheckedBattleResult {
   scoreDelta: number;
   problemTitle: string;
 }
+
+export interface ReviewScheduleResponse {
+  reviewCount: number;
+  isReviewRequired: boolean;
+}


### PR DESCRIPTION
## 작업 개요

- 문제 진입 시 복습 스케줄 조회 API 호출 (로그인 상태와 독립적인 별도 effect)
- 풀이횟수 표시 (스케줄 없으면 0회)
- '이 문제 복습 안하기' 버튼: 풀이횟수 0 또는 isReviewRequired=false 시 비활성화

## 영향 범위

- route:
- feature:
- api/bff:

## 작업 내용

- [ ] 작업 1
- [ ] 작업 2

## 변경 사항

- 주요 변경 사항을 항목별로 정리해주세요.

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] 주요 라우트 수동 확인
- [ ] API/BFF 연동 확인

## 관련 이슈

- close #

## 스크린샷 / 영상

- 필요 시 UI 변경 전후를 첨부해주세요.

## 참고 자료

- 필요 시 문서, 피그마, 메모를 남겨주세요.
