### PR TITLE
[feat] 메인 홈 랭킹 대시보드를 battleRating 기준으로 재정렬

### DIFF
--- a/src/features/home/components/rating-preview-panel.tsx
+++ b/src/features/home/components/rating-preview-panel.tsx
@@ -6,6 +6,7 @@ import type {
   RankingDashboardGateProgress,
   RankingDashboardResponse,
   RankingDashboardTagStat,
+  RankingDashboardTierDistribution,
   RankingDashboardTrendPoint,
 } from "@/shared/api/contracts";
 
@@ -14,6 +15,23 @@ interface ApiErrorResponse {
 }
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
+
+const tierWindowByFamily = {
+  BRONZE: ["BRONZE_5", "BRONZE_4", "BRONZE_3", "BRONZE_2", "BRONZE_1", "SILVER_5"],
+  SILVER: ["SILVER_5", "SILVER_4", "SILVER_3", "SILVER_2", "SILVER_1", "GOLD_5"],
+  GOLD: ["GOLD_5", "GOLD_4", "GOLD_3", "GOLD_2", "GOLD_1", "PLATINUM_5"],
+  PLATINUM: [
+    "PLATINUM_5",
+    "PLATINUM_4",
+    "PLATINUM_3",
+    "PLATINUM_2",
+    "PLATINUM_1",
+    "DIAMOND_5",
+  ],
+  DIAMOND: ["DIAMOND_5", "DIAMOND_4", "DIAMOND_3", "DIAMOND_2", "DIAMOND_1", "MASTER_4"],
+  MASTER: ["MASTER_4", "MASTER_3", "MASTER_2", "MASTER_1", "GOD"],
+  GOD: ["MASTER_4", "MASTER_3", "MASTER_2", "MASTER_1", "GOD"],
+} as const;
 
 async function readRankingDashboard(signal: AbortSignal) {
   const response = await fetch("/api/v1/rankings/me/dashboard", {
@@ -32,8 +50,82 @@ async function readRankingDashboard(signal: AbortSignal) {
 }
 
 function formatSignedNumber(value: number) {
-  if (value > 0) return `+${numberFormatter.format(value)}`;
+  if (value > 0) {
+    return `+${numberFormatter.format(value)}`;
+  }
+
   return numberFormatter.format(value);
+}
+
+function formatPercentileLabel(percentile: number) {
+  if (percentile <= 50) {
+    return `상위 ${percentile.toFixed(1)}%`;
+  }
+
+  return `하위 ${(100 - percentile).toFixed(1)}%`;
+}
+
+function getTierFamily(tier: string) {
+  if (tier === "GOD") {
+    return "GOD";
+  }
+
+  const [family] = tier.split("_");
+
+  if (family in tierWindowByFamily) {
+    return family as keyof typeof tierWindowByFamily;
+  }
+
+  return null;
+}
+
+function abbreviateTier(tier: string) {
+  if (tier === "GOD") {
+    return "GOD";
+  }
+
+  const [family, level] = tier.split("_");
+  const prefixMap: Record<string, string> = {
+    BRONZE: "B",
+    SILVER: "S",
+    GOLD: "G",
+    PLATINUM: "P",
+    DIAMOND: "D",
+    MASTER: "M",
+  };
+
+  if (!level) {
+    return tier;
+  }
+
+  return `${prefixMap[family] ?? family.charAt(0)}${level}`;
+}
+
+function getVisibleTierDistribution(
+  items: RankingDashboardTierDistribution[],
+  currentTier: string,
+) {
+  const family = getTierFamily(currentTier);
+
+  if (!family) {
+    return items;
+  }
+
+  const visibleTiers = tierWindowByFamily[family];
+  const itemMap = new Map(items.map((item) => [item.tier, item]));
+
+  return visibleTiers.map((tier) => {
+    const existing = itemMap.get(tier);
+
+    return (
+      existing ?? {
+        tier,
+        count: 0,
+        percentage: 0,
+        isMyTier: tier === currentTier,
+      }
+    );
+  });
 }
 
 function getGateTone(index: number) {
@@ -90,12 +182,12 @@ function TrendChart({ scoreTrend }: { scoreTrend: RankingDashboardTrendPoint[] }
   }
 
   return (
-    <div className="mt-4 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
+    <div className="mt-4 flex min-h-[20rem] flex-1 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
       <svg
         viewBox="0 0 100 78"
         role="img"
         aria-label="최근 배틀 레이팅 변화 그래프"
-        className="h-40 w-full overflow-visible"
+        className="h-full min-h-[17rem] w-full overflow-visible"
       >
         <defs>
           <linearGradient id="ratingDashboardTrendGradient" x1="0" x2="1" y1="0" y2="0">
@@ -199,11 +291,65 @@ function TagStatsList({ items }: { items: RankingDashboardTagStat[] }) {
             />
           </div>
           <p className="mt-1 text-[10px] text-app-dim">
-            solved {numberFormatter.format(item.solvedCount)} / submissions{" "}
-            {numberFormatter.format(item.submissionCount)}
+            AC 문제 {numberFormatter.format(item.solvedCount)}개 / 제출{" "}
+            {numberFormatter.format(item.submissionCount)}회
           </p>
         </div>
       ))}
+    </div>
+  );
+}
+
+function TierDistributionCard({
+  items,
+  currentTier,
+  maxPercentage,
+}: {
+  items: RankingDashboardTierDistribution[];
+  currentTier: string;
+  maxPercentage: number;
+}) {
+  return (
+    <div className="rounded-lg border border-app-border bg-app-base p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="font-mono text-xs text-app-dim">tier distribution</p>
+        <p className="font-mono text-xs text-app-secondary">내 위치: {currentTier}</p>
+      </div>
+      {items.length === 0 ? (
+        <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
+          티어 분포 데이터가 아직 없습니다.
+        </div>
+      ) : (
+        <div className="-mx-1 overflow-x-auto px-1 pb-2">
+          <div className="flex min-w-max items-end justify-center gap-3">
+            {items.map((item) => {
+              const height = Math.max(6, Math.round((item.percentage / maxPercentage) * 100));
+
+              return (
+                <div
+                  key={item.tier}
+                  className="flex w-12 shrink-0 flex-col items-center gap-2"
+                  title={`${item.tier}: ${numberFormatter.format(item.count)}명 (${item.percentage}%)`}
+                >
+                  <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
+                    <div
+                      className={`w-full rounded-t-md ${
+                        item.isMyTier
+                          ? "bg-gradient-to-t from-app-accent to-app-success"
+                          : "bg-gradient-to-t from-app-border-strong to-app-surface"
+                      }`}
+                      style={{ height: `${height}%` }}
+                    />
+                  </div>
+                  <span className="font-mono text-[10px] text-app-dim">
+                    {abbreviateTier(item.tier)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -253,8 +399,13 @@ export default function RatingPreviewPanel() {
         const nextDashboard = await readRankingDashboard(controller.signal);
         setDashboard(nextDashboard);
       } catch (caught) {
-        if (controller.signal.aborted) return;
-        setError(caught instanceof Error ? caught.message : "랭킹 대시보드를 불러오지 못했습니다.");
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setError(
+          caught instanceof Error ? caught.message : "랭킹 대시보드를 불러오지 못했습니다.",
+        );
       } finally {
         if (!controller.signal.aborted) {
           setIsLoading(false);
@@ -279,9 +430,14 @@ export default function RatingPreviewPanel() {
 
   const { profile } = dashboard;
   const nextTierLabel = profile.nextTier ?? "최고 티어";
+  const battleRating = profile.battleRating;
+  const visibleTierDistribution = getVisibleTierDistribution(
+    dashboard.tierDistribution,
+    profile.tier,
+  );
   const tierDistributionMax = Math.max(
     1,
-    ...dashboard.tierDistribution.map((item) => item.percentage),
+    ...visibleTierDistribution.map((item) => item.percentage),
   );
 
   return (
@@ -291,11 +447,10 @@ export default function RatingPreviewPanel() {
           <p className="font-mono text-xs uppercase tracking-[0.24em] text-app-accent-soft">
             RATING_MONITOR
           </p>
-          <h2 className="mt-1 text-lg font-semibold text-app-primary">
-            내 성장/랭킹 대시보드
-          </h2>
+          <h2 className="mt-1 text-lg font-semibold text-app-primary">내 성장/랭킹 대시보드</h2>
           <p className="mt-1 text-xs text-app-secondary">
-            {profile.nickname}님의 배틀 레이팅, 승급 조건, 주변 랭킹을 실시간 운영 데이터로 보여줍니다.
+            {profile.nickname}의 배틀 레이팅, 승급 조건, 주변 랭킹을 실시간 운영 데이터로
+            보여줍니다.
           </p>
         </div>
 
@@ -309,12 +464,17 @@ export default function RatingPreviewPanel() {
             <p className="mt-1 text-app-primary">#{numberFormatter.format(profile.rank)}</p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
-            <p className="text-app-dim">SCORE</p>
-            <p className="mt-1 text-app-success">{numberFormatter.format(profile.score)}</p>
+            <p className="text-app-dim">B.RATING</p>
+            <p className="mt-1 text-app-success">{numberFormatter.format(battleRating)}</p>
           </div>
-          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
-            <p className="text-app-dim">TOP2</p>
-            <p className="mt-1 text-app-accent-soft">{profile.top2Rate}%</p>
+          <div
+            className="rounded-md border border-app-border bg-app-base px-3 py-2"
+            title="최근 완료 배틀 기준 Top2 비율"
+          >
+            <p className="text-app-dim">TOP2 RATE</p>
+            <p className="mt-1 text-app-accent-soft">
+              {profile.top2Rate}% ({numberFormatter.format(profile.top2SampleSize)}판)
+            </p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
             <p className="text-app-dim">MATCH</p>
@@ -325,8 +485,8 @@ export default function RatingPreviewPanel() {
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.9fr)]">
-        <div className="rounded-lg border border-app-border bg-app-base p-4">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+        <div className="flex h-full min-h-[32rem] flex-col rounded-lg border border-app-border bg-app-base p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="font-mono text-xs text-app-dim">battle score trend</p>
@@ -339,7 +499,7 @@ export default function RatingPreviewPanel() {
                   : "border-app-danger/40 bg-app-danger/10 text-app-danger"
               }`}
             >
-              {formatSignedNumber(profile.scoreDeltaTotal)}
+              최근 변동 {formatSignedNumber(profile.scoreDeltaTotal)}
             </span>
           </div>
 
@@ -357,9 +517,9 @@ export default function RatingPreviewPanel() {
 
           <div className="rounded-lg border border-app-border bg-app-base p-4">
             <div className="mb-3 flex items-center justify-between">
-              <p className="font-mono text-xs text-app-dim">nearby ranking</p>
+              <p className="font-mono text-xs text-app-dim">battle nearby ranking</p>
               <span className="font-mono text-xs text-app-accent-soft">
-                TOP {profile.percentile.toFixed(1)}%
+                {formatPercentileLabel(profile.percentile)}
               </span>
             </div>
             {dashboard.nearbyRanking.length === 0 ? (
@@ -384,66 +544,29 @@ export default function RatingPreviewPanel() {
               </div>
             )}
           </div>
+
+          <TierDistributionCard
+            items={visibleTierDistribution}
+            currentTier={profile.tier}
+            maxPercentage={tierDistributionMax}
+          />
         </div>
       </div>
 
-      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.8fr)]">
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
         <div className="rounded-lg border border-app-border bg-app-base p-4">
-          <div className="mb-3 flex items-center justify-between">
-            <p className="font-mono text-xs text-app-dim">tier distribution</p>
-            <p className="font-mono text-xs text-app-secondary">내 위치: {profile.tier}</p>
-          </div>
-          {dashboard.tierDistribution.length === 0 ? (
-            <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
-              티어 분포 데이터가 아직 없습니다.
-            </div>
-          ) : (
-            <div className="flex h-28 items-end gap-2">
-              {dashboard.tierDistribution.map((item) => {
-                const height = Math.max(6, Math.round((item.percentage / tierDistributionMax) * 100));
-
-                return (
-                  <div key={item.tier} className="flex min-w-0 flex-1 flex-col items-center gap-2">
-                    <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
-                      <div
-                        className={`w-full rounded-t-md ${
-                          item.isMyTier
-                            ? "bg-gradient-to-t from-app-accent to-app-success"
-                            : "bg-gradient-to-t from-app-border-strong to-app-surface"
-                        }`}
-                        style={{ height: `${height}%` }}
-                        title={`${item.tier}: ${item.count}명 (${item.percentage}%)`}
-                      />
-                    </div>
-                    <span className="truncate font-mono text-[10px] text-app-dim">{item.tier}</span>
-                  </div>
-                );
-              })}
-            </div>
-          )}
+          <p className="font-mono text-xs text-app-dim">tag strength</p>
+          <TagStatsList items={dashboard.tagStats} />
         </div>
 
-        <div className="grid gap-4">
-          <div className="rounded-lg border border-app-border bg-app-base p-4">
-            <p className="font-mono text-xs text-app-dim">tag strength</p>
-            <TagStatsList items={dashboard.tagStats} />
-          </div>
-
-          <div className="rounded-lg border border-app-border bg-app-base p-4">
-            <p className="font-mono text-xs text-app-dim">review queue</p>
-            <div className="mt-3 grid grid-cols-2 gap-2 font-mono text-xs">
-              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                <p className="text-app-dim">TODAY</p>
-                <p className="mt-1 text-app-warn">
-                  {numberFormatter.format(dashboard.reviewSummary.dueTodayCount)}
-                </p>
-              </div>
-              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-                <p className="text-app-dim">UPCOMING</p>
-                <p className="mt-1 text-app-primary">
-                  {numberFormatter.format(dashboard.reviewSummary.upcomingCount)}
-                </p>
-              </div>
+        <div className="rounded-lg border border-app-border bg-app-base p-4">
+          <p className="font-mono text-xs text-app-dim">today review</p>
+          <div className="mt-3 font-mono text-xs">
+            <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+              <p className="text-app-dim">오늘 복습</p>
+              <p className="mt-1 text-app-warn">
+                {numberFormatter.format(dashboard.reviewSummary.dueTodayCount)}
+              </p>
             </div>
           </div>
         </div>

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -111,9 +111,11 @@ export interface RankingDashboardProfile {
   rank: number;
   percentile: number;
   score: number;
+  battleRating: number;
   nextTier: string | null;
   battleMatchCount: number;
   top2Rate: number;
+  top2SampleSize: number;
   scoreDeltaTotal: number;
 }
 


### PR DESCRIPTION
refs #91 
closes #91 

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 메인 홈 랭킹 대시보드를 <strong>battleRating 기준으로 다시 정렬</strong>하고,
대시보드 내 주요 지표의 의미가 더 명확하게 보이도록 UI와 타입 계약을 함께 정리한 작업입니다.
</p>

<p>
기존 대시보드는 ranking 관련 필드와 battleRating 관련 필드가 섞여 있었고,
프론트에서도 일부 값을 임시 보정하거나 라벨만으로 의미를 추측하는 상태였습니다.
이번 변경에서는 새 API 기준에 맞춰
</p>

<ul>
  <li>배틀 레이팅 축으로 보는 영역</li>
  <li>랭킹/분포를 보여주는 영역</li>
</ul>

<p>
을 다시 정리하고, 함께 진행한 대시보드 UI 개선 사항도 반영했습니다.
</p>

<hr />

<h3>1) 랭킹 대시보드 타입 계약 업데이트</h3>
<p>
<code>src/shared/api/contracts.ts</code>의
<code>RankingDashboardProfile</code> 타입에 아래 필드를 추가했습니다.
</p>

<ul>
  <li><code>battleRating</code></li>
  <li><code>top2SampleSize</code></li>
</ul>

<pre><code class="language-ts">export interface RankingDashboardProfile {
  memberId: number;
  nickname: string;
  tier: string;
  rank: number;
  percentile: number;
  score: number;
  battleRating: number;
  nextTier: string | null;
  battleMatchCount: number;
  top2Rate: number;
  top2SampleSize: number;
  scoreDeltaTotal: number;
}</code></pre>

<p>
이로써 프론트는 더 이상 배틀 레이팅 값을
<code>profile.score</code>에서 유추하지 않고,
명시적으로 <code>profile.battleRating</code>를 사용할 수 있게 되었습니다.
</p>

<hr />

<h3>2) 상단 요약 카드를 battleRating 기준으로 정리</h3>
<p>
상단 요약 카드에서 기존 <code>SCORE</code> 카드는
사용자 입장에서 <code>members.score</code>와 배틀 레이팅이 혼동될 여지가 있었습니다.
이번 PR에서는 해당 카드를 <code>B.RATING</code>으로 바꾸고,
실제 표시값도 <code>profile.battleRating</code>을 사용하도록 변경했습니다.
</p>

<p>
즉 상단 요약 영역은 이제 아래 의미로 읽히게 됩니다.
</p>

<ul>
  <li><code>TIER</code>: battleRating 기준 티어</li>
  <li><code>RANK</code>: battleRating 기준 순위</li>
  <li><code>B.RATING</code>: 현재 배틀 레이팅</li>
  <li><code>TOP2 RATE</code>: 최근 완료 배틀 기준 Top2 비율</li>
  <li><code>MATCH</code>: 배틀 수</li>
</ul>

<hr />

<h3>3) TOP2 비율에 표본 수 함께 표시</h3>
<p>
이전에는 <code>top2Rate</code>만 표시되어
예를 들어 <code>100%</code>가 보일 때도 표본 수가 2판인지 20판인지 알기 어려웠습니다.
</p>

<p>
이번 변경에서는 <code>profile.top2SampleSize</code>를 함께 사용해
아래처럼 표시하도록 했습니다.
</p>

<pre><code class="language-text">100% (2판)
50% (10판)
0% (0판)
</code></pre>

<p>
즉 사용자가 현재 Top2 비율이 어떤 표본에서 나온 값인지
즉시 이해할 수 있도록 개선했습니다.
</p>

<hr />

<h3>4) recent trend / promotion gate는 battleRating 기준 유지</h3>
<p>
최근 배틀 레이팅 변화 그래프는 기존처럼 <code>scoreTrend</code>를 사용하지만,
이제 의미를 명확히 <strong>battleRating 추이</strong>로 해석합니다.
</p>

<p>
또한 그래프 우측 badge는
<code>profile.scoreDeltaTotal</code>을 이용해
<code>최근 변동 +15</code> 같은 형태로 유지했습니다.
</p>

<p>
<code>promotion gate</code>의 <code>SCORE</code> 항목도
더 이상 프론트에서 <code>profile.score</code>로 보정하지 않고,
백엔드가 내려준 <code>gateProgress[key="SCORE"]</code>를 그대로 사용하도록 정리했습니다.
즉 승급 게이지는 이제 battleRating 기준으로 직접 해석됩니다.
</p>

<hr />

<h3>5) nearby ranking / percentile 표현 정리</h3>
<p>
이번 API 업데이트 기준으로
<code>nearbyRanking</code>, <code>rank</code>, <code>percentile</code>, <code>tierDistribution</code>은
이제 모두 battleRating 기준으로 이해할 수 있습니다.
</p>

<p>
그래서 프론트에서도 주변 랭킹 카드 제목을
<code>battle nearby ranking</code>으로 명확히 바꾸고,
percentile도 단순 숫자 대신 사용자 입장에서 더 자연스럽게 읽히도록 정리했습니다.
</p>

<ul>
  <li><code>percentile &lt;= 50</code> → <code>상위 x.x%</code></li>
  <li><code>percentile &gt; 50</code> → <code>하위 x.x%</code></li>
</ul>

<p>
예:
</p>

<ul>
  <li><code>12.3</code> → <code>상위 12.3%</code></li>
  <li><code>98.1</code> → <code>하위 1.9%</code></li>
</ul>

<p>
즉 기존의 <code>TOP 98.1%</code>처럼 헷갈리는 표현을 제거하고,
현재 내 상대적 위치를 더 직관적으로 보여주도록 했습니다.
</p>

<hr />

<h3>6) tier distribution UI 재배치 및 축약 라벨 적용</h3>
<p>
티어 분포 차트는 기존에 너무 넓은 영역을 차지하면서도,
티어 라벨이 길어 겹치기 쉬운 문제가 있었습니다.
</p>

<p>
이번 PR에서는 아래 보정을 함께 반영했습니다.
</p>

<ul>
  <li>현재 대분류 구간 + 다음 구간 첫 티어만 표시</li>
  <li>라벨 축약 적용</li>
  <li>tooltip으로 full tier / 인원 / 비율 제공</li>
  <li>카드 위치를 보조 카드 컬럼 쪽으로 재배치</li>
  <li>가로 스크롤 + 최소 너비로 좁은 화면에서도 겹침 방지</li>
</ul>

<p>
축약 예시는 다음과 같습니다.
</p>

<ul>
  <li><code>BRONZE_5</code> → <code>B5</code></li>
  <li><code>SILVER_5</code> → <code>S5</code></li>
  <li><code>GOLD_1</code> → <code>G1</code></li>
  <li><code>PLATINUM_3</code> → <code>P3</code></li>
</ul>

<hr />

<h3>7) tag strength / today review 카드 문구 정리</h3>
<p>
대시보드 보조 카드 영역도 함께 다듬었습니다.
</p>

<ul>
  <li><code>tag strength</code>: <code>solved 1 / submissions 3</code> → <code>AC 문제 1개 / 제출 3회</code></li>
  <li><code>review queue</code>: <code>today review</code> 단일 카드로 단순화</li>
</ul>

<p>
즉 사용자가 의미를 추측해야 하던 표현을
서비스 용어에 맞는 한국어 문구로 정리했습니다.
</p>

<hr />

<h3>8) 그래프 카드 레이아웃 보정</h3>
<p>
최근 배틀 레이팅 변화 카드도 함께 조정했습니다.
기존에는 그래프가 카드 상단에만 몰려 있고,
아래 공간이 많이 비어 보여 시각적으로 밸런스가 좋지 않았습니다.
</p>

<p>
이번 PR에서는 해당 카드를 flex 구조로 바꾸고,
차트 높이를 더 키워서 카드의 세로 공간을 자연스럽게 사용하도록 보정했습니다.
</p>

<hr />

<h3>9) 변경 파일</h3>
<ul>
  <li><code>src/shared/api/contracts.ts</code></li>
  <li><code>src/features/home/components/rating-preview-panel.tsx</code></li>
</ul>

<p>
이번 PR은 랭킹 대시보드 계약 타입과 메인 홈 대시보드 렌더링만 수정했으며,
매칭 WebSocket/ready-check 로직은 변경하지 않았습니다.
</p>

<hr />

<h3>10) 테스트 / 확인 포인트</h3>
<ol>
  <li><code>profile.battleRating=1120</code>, <code>profile.score=1580</code>일 때 상단 카드가 <code>1120</code>을 표시하는지 확인</li>
  <li><code>top2Rate=100</code>, <code>top2SampleSize=2</code>일 때 <code>100% (2판)</code> 형태로 보이는지 확인</li>
  <li><code>gateProgress[key="SCORE"]</code>가 battleRating 기준으로 그대로 표시되는지 확인</li>
  <li>최근 배틀 레이팅 변화 그래프가 정상 렌더링되고 카드 높이를 자연스럽게 채우는지 확인</li>
  <li><code>nearby ranking</code> 카드에서 percentile이 <code>상위/하위</code> 형식으로 보이는지 확인</li>
  <li><code>tierDistribution</code>이 현재 구간 중심으로 렌더링되고 라벨이 겹치지 않는지 확인</li>
  <li><code>tagStats</code>, <code>reviewSummary</code>가 비어 있어도 fallback UI가 깨지지 않는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx.cmd tsc --noEmit</code> 기준으로 통과했습니다.
</p>
