### PR TITLE
[refactor] 메인 레이팅 모니터 및 마이페이지 티어 가이드 개선

### DIFF
--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -95,9 +95,9 @@ export default function QueueEditorPane({
           </button>
         </div>
 
-        <div ref={editorPaneRef} className="flex-1 overflow-hidden bg-app-base">
+        <div ref={editorPaneRef} className="flex-1 overflow-y-auto bg-app-base">
           <div
-            className="grid h-full grid-cols-[56px_minmax(0,1fr)] bg-app-base font-mono"
+            className="grid min-h-full grid-cols-[56px_minmax(0,1fr)] bg-app-base font-mono"
             style={editorContentStyle}
           >
             <div className="border-r border-app-border/70 bg-app-base px-3 py-4 text-right text-app-syntax-line-number">

--- a/src/features/home/components/rating-preview-panel.tsx
+++ b/src/features/home/components/rating-preview-panel.tsx
@@ -15,23 +15,41 @@ interface ApiErrorResponse {
 }
 
 const numberFormatter = new Intl.NumberFormat("ko-KR");
+const TIER_BUCKETS = ["UNRANKED", "BRONZE", "SILVER", "GOLD", "PLATINUM", "DIAMOND", "MASTER", "GOD"] as const;
+type TierBucket = (typeof TIER_BUCKETS)[number];
+const BUCKET_SUBTIERS: Record<TierBucket, string[]> = {
+  UNRANKED: ["UNRANKED"],
+  BRONZE: ["BRONZE_5", "BRONZE_4", "BRONZE_3", "BRONZE_2", "BRONZE_1"],
+  SILVER: ["SILVER_5", "SILVER_4", "SILVER_3", "SILVER_2", "SILVER_1"],
+  GOLD: ["GOLD_5", "GOLD_4", "GOLD_3", "GOLD_2", "GOLD_1"],
+  PLATINUM: ["PLATINUM_5", "PLATINUM_4", "PLATINUM_3", "PLATINUM_2", "PLATINUM_1"],
+  DIAMOND: ["DIAMOND_5", "DIAMOND_4", "DIAMOND_3", "DIAMOND_2", "DIAMOND_1"],
+  MASTER: ["MASTER_4", "MASTER_3", "MASTER_2", "MASTER_1"],
+  GOD: ["GOD"],
+};
 
-const tierWindowByFamily = {
-  BRONZE: ["BRONZE_5", "BRONZE_4", "BRONZE_3", "BRONZE_2", "BRONZE_1", "SILVER_5"],
-  SILVER: ["SILVER_5", "SILVER_4", "SILVER_3", "SILVER_2", "SILVER_1", "GOLD_5"],
-  GOLD: ["GOLD_5", "GOLD_4", "GOLD_3", "GOLD_2", "GOLD_1", "PLATINUM_5"],
-  PLATINUM: [
-    "PLATINUM_5",
-    "PLATINUM_4",
-    "PLATINUM_3",
-    "PLATINUM_2",
-    "PLATINUM_1",
-    "DIAMOND_5",
-  ],
-  DIAMOND: ["DIAMOND_5", "DIAMOND_4", "DIAMOND_3", "DIAMOND_2", "DIAMOND_1", "MASTER_4"],
-  MASTER: ["MASTER_4", "MASTER_3", "MASTER_2", "MASTER_1", "GOD"],
-  GOD: ["MASTER_4", "MASTER_3", "MASTER_2", "MASTER_1", "GOD"],
-} as const;
+function bucketFillClass(bucket: TierBucket) {
+  switch (bucket) {
+    case "UNRANKED":
+      return "from-slate-600 to-slate-400";
+    case "BRONZE":
+      return "from-amber-700 to-amber-500";
+    case "SILVER":
+      return "from-sky-500 to-cyan-300";
+    case "GOLD":
+      return "from-yellow-600 to-yellow-300";
+    case "PLATINUM":
+      return "from-teal-500 to-emerald-300";
+    case "DIAMOND":
+      return "from-blue-600 to-indigo-300";
+    case "MASTER":
+      return "from-violet-600 to-fuchsia-400";
+    case "GOD":
+      return "from-pink-600 to-rose-400";
+    default:
+      return "from-slate-600 to-slate-400";
+  }
+}
 
 async function readRankingDashboard(signal: AbortSignal) {
   const response = await fetch("/api/v1/rankings/me/dashboard", {
@@ -50,82 +68,8 @@ async function readRankingDashboard(signal: AbortSignal) {
 }
 
 function formatSignedNumber(value: number) {
-  if (value > 0) {
-    return `+${numberFormatter.format(value)}`;
-  }
-
+  if (value > 0) return `+${numberFormatter.format(value)}`;
   return numberFormatter.format(value);
-}
-
-function formatPercentileLabel(percentile: number) {
-  if (percentile <= 50) {
-    return `상위 ${percentile.toFixed(1)}%`;
-  }
-
-  return `하위 ${(100 - percentile).toFixed(1)}%`;
-}
-
-function getTierFamily(tier: string) {
-  if (tier === "GOD") {
-    return "GOD";
-  }
-
-  const [family] = tier.split("_");
-
-  if (family in tierWindowByFamily) {
-    return family as keyof typeof tierWindowByFamily;
-  }
-
-  return null;
-}
-
-function abbreviateTier(tier: string) {
-  if (tier === "GOD") {
-    return "GOD";
-  }
-
-  const [family, level] = tier.split("_");
-  const prefixMap: Record<string, string> = {
-    BRONZE: "B",
-    SILVER: "S",
-    GOLD: "G",
-    PLATINUM: "P",
-    DIAMOND: "D",
-    MASTER: "M",
-  };
-
-  if (!level) {
-    return tier;
-  }
-
-  return `${prefixMap[family] ?? family.charAt(0)}${level}`;
-}
-
-function getVisibleTierDistribution(
-  items: RankingDashboardTierDistribution[],
-  currentTier: string,
-) {
-  const family = getTierFamily(currentTier);
-
-  if (!family) {
-    return items;
-  }
-
-  const visibleTiers = tierWindowByFamily[family];
-  const itemMap = new Map(items.map((item) => [item.tier, item]));
-
-  return visibleTiers.map((tier) => {
-    const existing = itemMap.get(tier);
-
-    return (
-      existing ?? {
-        tier,
-        count: 0,
-        percentage: 0,
-        isMyTier: tier === currentTier,
-      }
-    );
-  });
 }
 
 function getGateTone(index: number) {
@@ -146,32 +90,46 @@ function getGatePercent(item: RankingDashboardGateProgress) {
   return Math.max(0, Math.min(100, Math.round((item.current / item.target) * 100)));
 }
 
-function getTrendPoints(scoreTrend: RankingDashboardTrendPoint[]) {
+function buildTrendGeometry(scoreTrend: RankingDashboardTrendPoint[]) {
   if (scoreTrend.length === 0) {
-    return "";
+    return null;
   }
 
   const scores = scoreTrend.map((item) => item.score);
   const min = Math.min(...scores);
   const max = Math.max(...scores);
   const range = Math.max(1, max - min);
+  const canvasWidth = Math.max(680, 140 + (scoreTrend.length - 1) * 72);
+  const xStart = 56;
+  const xEnd = canvasWidth - 40;
+  const yTop = 18;
+  const yBottom = 86;
+  const gridYs = [yTop, yTop + (yBottom - yTop) / 3, yTop + ((yBottom - yTop) * 2) / 3, yBottom];
+  const labelStep = Math.max(1, Math.ceil(scoreTrend.length / 10));
 
-  return scoreTrend
-    .map((item, index) => {
-      const x = scoreTrend.length === 1 ? 50 : 10 + index * (84 / (scoreTrend.length - 1));
-      const y = 70 - ((item.score - min) / range) * 48;
+  const plotted = scoreTrend.map((item, index) => {
+    const x = scoreTrend.length === 1 ? (xStart + xEnd) / 2 : xStart + index * ((xEnd - xStart) / (scoreTrend.length - 1));
+    const y = yBottom - ((item.score - min) / range) * (yBottom - yTop);
+    return { x, y, item, index };
+  });
 
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
+  return {
+    min,
+    max,
+    canvasWidth,
+    xStart,
+    xEnd,
+    yTop,
+    yBottom,
+    gridYs,
+    labelStep,
+    plotted,
+    points: plotted.map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`).join(" "),
+  };
 }
 
 function TrendChart({ scoreTrend }: { scoreTrend: RankingDashboardTrendPoint[] }) {
-  const points = useMemo(() => getTrendPoints(scoreTrend), [scoreTrend]);
-  const scores = scoreTrend.map((item) => item.score);
-  const min = scores.length > 0 ? Math.min(...scores) : 0;
-  const max = scores.length > 0 ? Math.max(...scores) : 0;
-  const range = Math.max(1, max - min);
+  const geometry = useMemo(() => buildTrendGeometry(scoreTrend), [scoreTrend]);
 
   if (scoreTrend.length === 0) {
     return (
@@ -181,54 +139,74 @@ function TrendChart({ scoreTrend }: { scoreTrend: RankingDashboardTrendPoint[] }
     );
   }
 
-  return (
-    <div className="mt-4 flex min-h-[20rem] flex-1 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
-      <svg
-        viewBox="0 0 100 78"
-        role="img"
-        aria-label="최근 배틀 레이팅 변화 그래프"
-        className="h-full min-h-[17rem] w-full overflow-visible"
-      >
-        <defs>
-          <linearGradient id="ratingDashboardTrendGradient" x1="0" x2="1" y1="0" y2="0">
-            <stop offset="0%" stopColor="#8b5cf6" />
-            <stop offset="55%" stopColor="#38bdf8" />
-            <stop offset="100%" stopColor="#22c55e" />
-          </linearGradient>
-        </defs>
-        {[18, 34, 50, 66].map((y) => (
-          <line
-            key={y}
-            x1="8"
-            x2="94"
-            y1={y}
-            y2={y}
-            stroke="rgba(148,163,184,0.16)"
-            strokeWidth="0.45"
-          />
-        ))}
-        <polyline
-          points={points}
-          fill="none"
-          stroke="url(#ratingDashboardTrendGradient)"
-          strokeWidth="2.4"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {scoreTrend.map((item, index) => {
-          const x = scoreTrend.length === 1 ? 50 : 10 + index * (84 / (scoreTrend.length - 1));
-          const y = 70 - ((item.score - min) / range) * 48;
+  if (!geometry) {
+    return null;
+  }
 
-          return (
-            <g key={`${item.label}-${item.occurredAt}`}>
-              <circle cx={x} cy={y} r="2.6" fill="#0f172a" stroke="#38bdf8" strokeWidth="1.4" />
-              <text x={x} y="77" textAnchor="middle" className="fill-app-dim text-[4px]">
-                {item.label}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
+  const { min, max, canvasWidth, xStart, xEnd, yTop, yBottom, gridYs, labelStep, plotted, points } = geometry;
+
+  return (
+    <div className="mt-4 rounded-md border border-app-border/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] p-3">
+      <div className="overflow-x-auto">
+        <svg
+          width={canvasWidth}
+          viewBox={`0 0 ${canvasWidth} 112`}
+          role="img"
+          aria-label="최근 배틀 레이팅 변화 그래프"
+          className="h-56 min-w-full"
+        >
+          <defs>
+            <linearGradient id="ratingDashboardTrendGradient" x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="#8b5cf6" />
+              <stop offset="55%" stopColor="#38bdf8" />
+              <stop offset="100%" stopColor="#22c55e" />
+            </linearGradient>
+          </defs>
+          {gridYs.map((y) => (
+            <line
+              key={y}
+              x1={xStart}
+              x2={xEnd}
+              y1={y}
+              y2={y}
+              stroke="rgba(148,163,184,0.18)"
+              strokeWidth="1"
+            />
+          ))}
+          <text x="10" y={yTop + 2} className="fill-app-dim text-[10px]">
+            {numberFormatter.format(max)}
+          </text>
+          <text x="10" y={yBottom + 2} className="fill-app-dim text-[10px]">
+            {numberFormatter.format(min)}
+          </text>
+          <polyline
+            points={points}
+            fill="none"
+            stroke="url(#ratingDashboardTrendGradient)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          {plotted.map(({ x, y, item, index }) => {
+            const shouldShowLabel = index % labelStep === 0 || index === plotted.length - 1;
+            const signedDelta = item.delta > 0 ? `+${item.delta}` : `${item.delta}`;
+            return (
+              <g key={`${item.label}-${item.occurredAt}`}>
+                <circle cx={x} cy={y} r="4" fill="#0f172a" stroke="#38bdf8" strokeWidth="2" />
+                <title>{`${item.label} | SR ${numberFormatter.format(item.score)} (${signedDelta})`}</title>
+                {shouldShowLabel ? (
+                  <text x={x} y="106" textAnchor="middle" className="fill-app-dim text-[10px]">
+                    {item.label}
+                  </text>
+                ) : null}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <p className="mt-2 px-1 text-[11px] text-app-dim">
+        각 점은 해당 배틀 정산 직후의 SR입니다. 데이터가 늘어나면 그래프는 오른쪽으로 확장되며 가로 스크롤로 볼 수 있습니다.
+      </p>
     </div>
   );
 }
@@ -291,8 +269,8 @@ function TagStatsList({ items }: { items: RankingDashboardTagStat[] }) {
             />
           </div>
           <p className="mt-1 text-[10px] text-app-dim">
-            AC 문제 {numberFormatter.format(item.solvedCount)}개 / 제출{" "}
-            {numberFormatter.format(item.submissionCount)}회
+            solved {numberFormatter.format(item.solvedCount)} / submissions{" "}
+            {numberFormatter.format(item.submissionCount)}
           </p>
         </div>
       ))}
@@ -300,63 +278,78 @@ function TagStatsList({ items }: { items: RankingDashboardTagStat[] }) {
   );
 }
 
-function TierDistributionCard({
-  items,
-  currentTier,
-  maxPercentage,
-}: {
-  items: RankingDashboardTierDistribution[];
-  currentTier: string;
-  maxPercentage: number;
-}) {
-  return (
-    <div className="rounded-lg border border-app-border bg-app-base p-4">
-      <div className="mb-3 flex items-center justify-between">
-        <p className="font-mono text-xs text-app-dim">tier distribution</p>
-        <p className="font-mono text-xs text-app-secondary">내 위치: {currentTier}</p>
-      </div>
-      {items.length === 0 ? (
-        <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
-          티어 분포 데이터가 아직 없습니다.
-        </div>
-      ) : (
-        <div className="-mx-1 overflow-x-auto px-1 pb-2">
-          <div className="flex min-w-max items-end justify-center gap-3">
-            {items.map((item) => {
-              const height = Math.max(6, Math.round((item.percentage / maxPercentage) * 100));
+function tierBucketOf(tier: string): TierBucket {
+  if (tier === "UNRANKED") return "UNRANKED";
+  const [head] = tier.split("_");
+  if (head === "BRONZE") return "BRONZE";
+  if (head === "SILVER") return "SILVER";
+  if (head === "GOLD") return "GOLD";
+  if (head === "PLATINUM") return "PLATINUM";
+  if (head === "DIAMOND") return "DIAMOND";
+  if (head === "MASTER") return "MASTER";
+  if (head === "GOD") return "GOD";
+  return "UNRANKED";
+}
 
-              return (
-                <div
-                  key={item.tier}
-                  className="flex w-12 shrink-0 flex-col items-center gap-2"
-                  title={`${item.tier}: ${numberFormatter.format(item.count)}명 (${item.percentage}%)`}
-                >
-                  <div className="relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated">
-                    <div
-                      className={`w-full rounded-t-md ${
-                        item.isMyTier
-                          ? "bg-gradient-to-t from-app-accent to-app-success"
-                          : "bg-gradient-to-t from-app-border-strong to-app-surface"
-                      }`}
-                      style={{ height: `${height}%` }}
-                    />
-                  </div>
-                  <span className="font-mono text-[10px] text-app-dim">
-                    {abbreviateTier(item.tier)}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
+function buildTierBucketDistribution(
+  items: RankingDashboardTierDistribution[],
+  myTier: string,
+): {
+  bucket: TierBucket;
+  count: number;
+  percentage: number;
+  isMyBucket: boolean;
+  tooltip: string;
+}[] {
+  const countByTier = new Map<string, number>();
+  items.forEach((item) => {
+    countByTier.set(item.tier, item.count);
+  });
+
+  const countByBucket = new Map<TierBucket, number>(TIER_BUCKETS.map((bucket) => [bucket, 0]));
+
+  items.forEach((item) => {
+    const bucket = tierBucketOf(item.tier);
+    const current = countByBucket.get(bucket) ?? 0;
+    countByBucket.set(bucket, current + item.count);
+  });
+
+  const total = Math.max(
+    1,
+    Array.from(countByBucket.values()).reduce((sum, count) => sum + count, 0),
   );
+  const myBucket = tierBucketOf(myTier);
+
+  return TIER_BUCKETS.map((bucket) => {
+    const count = countByBucket.get(bucket) ?? 0;
+    const percentage = Math.round((count * 1000) / total) / 10;
+    const subtiers = BUCKET_SUBTIERS[bucket];
+    const lines = [`${bucket}: ${numberFormatter.format(count)}명 (${percentage}%)`];
+
+    if (subtiers.length > 1) {
+      subtiers.forEach((tier) => {
+        const tierCount = countByTier.get(tier) ?? 0;
+        const ratioInBucket = count > 0 ? Math.round((tierCount * 1000) / count) / 10 : 0;
+        const mineMark = tier === myTier ? "★ " : "";
+        lines.push(`${mineMark}${tier}: ${numberFormatter.format(tierCount)}명 (${ratioInBucket}%)`);
+      });
+    }
+
+    const tooltip = lines.join("\n");
+
+    return {
+      bucket,
+      count,
+      percentage,
+      isMyBucket: bucket === myBucket,
+      tooltip,
+    };
+  });
 }
 
 function LoadingState() {
   return (
-    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
+    <section className="mt-5 w-full rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
       <div className="animate-pulse space-y-4">
         <div className="h-4 w-40 rounded bg-app-elevated" />
         <div className="h-6 w-72 rounded bg-app-elevated" />
@@ -373,7 +366,7 @@ function LoadingState() {
 
 function ErrorState({ message }: { message: string }) {
   return (
-    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
+    <section className="mt-5 w-full rounded-lg border border-app-border/80 bg-app-surface/70 p-4">
       <p className="font-mono text-xs uppercase tracking-[0.24em] text-app-accent-soft">
         RATING_MONITOR
       </p>
@@ -399,13 +392,8 @@ export default function RatingPreviewPanel() {
         const nextDashboard = await readRankingDashboard(controller.signal);
         setDashboard(nextDashboard);
       } catch (caught) {
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        setError(
-          caught instanceof Error ? caught.message : "랭킹 대시보드를 불러오지 못했습니다.",
-        );
+        if (controller.signal.aborted) return;
+        setError(caught instanceof Error ? caught.message : "랭킹 대시보드를 불러오지 못했습니다.");
       } finally {
         if (!controller.signal.aborted) {
           setIsLoading(false);
@@ -430,31 +418,28 @@ export default function RatingPreviewPanel() {
 
   const { profile } = dashboard;
   const nextTierLabel = profile.nextTier ?? "최고 티어";
-  const battleRating = profile.battleRating;
-  const visibleTierDistribution = getVisibleTierDistribution(
-    dashboard.tierDistribution,
-    profile.tier,
-  );
-  const tierDistributionMax = Math.max(
-    1,
-    ...visibleTierDistribution.map((item) => item.percentage),
-  );
+  const tierBucketDistribution = buildTierBucketDistribution(dashboard.tierDistribution, profile.tier);
+  const tierDistributionMax = Math.max(1, ...tierBucketDistribution.map((item) => item.count));
+  const totalInDistribution = tierBucketDistribution.reduce((sum, item) => sum + item.count, 0);
+  const myBucket = tierBucketOf(profile.tier);
+  const myBucketInfo = tierBucketDistribution.find((item) => item.isMyBucket);
 
   return (
-    <section className="mt-5 max-w-6xl rounded-lg border border-app-border/80 bg-app-surface/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.22)]">
+    <section className="mt-5 w-full rounded-lg border border-app-border/80 bg-app-surface/70 p-4 shadow-[0_18px_60px_rgba(0,0,0,0.22)]">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div>
           <p className="font-mono text-xs uppercase tracking-[0.24em] text-app-accent-soft">
             RATING_MONITOR
           </p>
-          <h2 className="mt-1 text-lg font-semibold text-app-primary">내 성장/랭킹 대시보드</h2>
+          <h2 className="mt-1 text-lg font-semibold text-app-primary">
+            내 성장/랭킹 대시보드
+          </h2>
           <p className="mt-1 text-xs text-app-secondary">
-            {profile.nickname}의 배틀 레이팅, 승급 조건, 주변 랭킹을 실시간 운영 데이터로
-            보여줍니다.
+            {profile.nickname}님의 배틀 레이팅, 승급 조건, 주변 랭킹을 실시간 운영 데이터로 보여줍니다.
           </p>
         </div>
 
-        <div className="grid grid-cols-2 gap-2 text-center font-mono text-xs sm:grid-cols-5">
+        <div className="grid grid-cols-2 gap-2 text-center font-mono text-xs md:grid-cols-5">
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
             <p className="text-app-dim">TIER</p>
             <p className="mt-1 text-app-warn">{profile.tier}</p>
@@ -464,17 +449,12 @@ export default function RatingPreviewPanel() {
             <p className="mt-1 text-app-primary">#{numberFormatter.format(profile.rank)}</p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
-            <p className="text-app-dim">B.RATING</p>
-            <p className="mt-1 text-app-success">{numberFormatter.format(battleRating)}</p>
+            <p className="text-app-dim">SR</p>
+            <p className="mt-1 text-app-success">{numberFormatter.format(profile.battleRating)}</p>
           </div>
-          <div
-            className="rounded-md border border-app-border bg-app-base px-3 py-2"
-            title="최근 완료 배틀 기준 Top2 비율"
-          >
-            <p className="text-app-dim">TOP2 RATE</p>
-            <p className="mt-1 text-app-accent-soft">
-              {profile.top2Rate}% ({numberFormatter.format(profile.top2SampleSize)}판)
-            </p>
+          <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
+            <p className="text-app-dim">TOP2</p>
+            <p className="mt-1 text-app-accent-soft">{profile.top2Rate}%</p>
           </div>
           <div className="rounded-md border border-app-border bg-app-base px-3 py-2">
             <p className="text-app-dim">MATCH</p>
@@ -485,8 +465,8 @@ export default function RatingPreviewPanel() {
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
-        <div className="flex h-full min-h-[32rem] flex-col rounded-lg border border-app-border bg-app-base p-4">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.9fr)]">
+        <div className="rounded-lg border border-app-border bg-app-base p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <p className="font-mono text-xs text-app-dim">battle score trend</p>
@@ -499,7 +479,7 @@ export default function RatingPreviewPanel() {
                   : "border-app-danger/40 bg-app-danger/10 text-app-danger"
               }`}
             >
-              최근 변동 {formatSignedNumber(profile.scoreDeltaTotal)}
+              {formatSignedNumber(profile.scoreDeltaTotal)}
             </span>
           </div>
 
@@ -517,11 +497,15 @@ export default function RatingPreviewPanel() {
 
           <div className="rounded-lg border border-app-border bg-app-base p-4">
             <div className="mb-3 flex items-center justify-between">
-              <p className="font-mono text-xs text-app-dim">battle nearby ranking</p>
-              <span className="font-mono text-xs text-app-accent-soft">
-                {formatPercentileLabel(profile.percentile)}
-              </span>
+              <p className="font-mono text-xs text-app-dim">nearby ranking</p>
+              <div className="flex items-center gap-2 font-mono text-xs">
+                <span className="rounded border border-app-border px-2 py-0.5 text-app-primary">
+                  #{numberFormatter.format(profile.rank)}
+                </span>
+                <span className="text-app-accent-soft">TOP {profile.percentile.toFixed(1)}%</span>
+              </div>
             </div>
+            <p className="mb-2 text-[11px] text-app-dim">순위 숫자가 작을수록 상위권입니다.</p>
             {dashboard.nearbyRanking.length === 0 ? (
               <p className="text-xs text-app-dim">주변 랭킹 데이터가 아직 없습니다.</p>
             ) : (
@@ -536,7 +520,7 @@ export default function RatingPreviewPanel() {
                     }`}
                   >
                     <span>
-                      #{numberFormatter.format(item.rank)} {item.nickname}
+                      {numberFormatter.format(item.rank)}위 {item.nickname}
                     </span>
                     <span>{numberFormatter.format(item.score)}</span>
                   </div>
@@ -544,29 +528,89 @@ export default function RatingPreviewPanel() {
               </div>
             )}
           </div>
-
-          <TierDistributionCard
-            items={visibleTierDistribution}
-            currentTier={profile.tier}
-            maxPercentage={tierDistributionMax}
-          />
         </div>
       </div>
 
-      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(260px,0.8fr)]">
         <div className="rounded-lg border border-app-border bg-app-base p-4">
-          <p className="font-mono text-xs text-app-dim">tag strength</p>
-          <TagStatsList items={dashboard.tagStats} />
+          <div className="mb-3 flex items-center justify-between">
+            <p className="font-mono text-xs text-app-dim">tier distribution</p>
+          </div>
+          {tierBucketDistribution.every((item) => item.count === 0) ? (
+            <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-app-border/80 bg-app-elevated/40 text-xs text-app-dim">
+              티어 분포 데이터가 아직 없습니다.
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex h-32 items-end gap-2">
+                {tierBucketDistribution.map((item) => {
+                  const height = Math.max(6, Math.round(item.percentage));
+                  const fillClass = bucketFillClass(item.bucket);
+
+                  return (
+                    <div key={item.bucket} className="group flex min-w-0 flex-1 flex-col items-center gap-1.5">
+                      <div
+                        className={`relative flex h-20 w-full items-end overflow-hidden rounded-t-md bg-app-elevated ${
+                          item.isMyBucket
+                            ? "ring-2 ring-app-accent/75 shadow-[0_0_20px_rgba(139,92,246,0.35)]"
+                            : "ring-1 ring-app-border/70"
+                        }`}
+                      >
+                        <div
+                          className={`absolute inset-0 bg-gradient-to-b ${fillClass} opacity-15 transition-opacity group-hover:opacity-25`}
+                          title={item.tooltip}
+                        />
+                        <div
+                          className={`w-full rounded-t-md bg-gradient-to-t ${fillClass} ${
+                            item.isMyBucket ? "opacity-100" : "opacity-85"
+                          }`}
+                          style={{ height: `${height}%` }}
+                          title={item.tooltip}
+                        />
+                        <div className="pointer-events-none absolute -top-8 left-1/2 z-10 -translate-x-1/2 whitespace-nowrap rounded bg-app-base px-2 py-1 text-[10px] text-app-primary opacity-0 shadow-[0_8px_20px_rgba(0,0,0,0.35)] transition-opacity group-hover:opacity-100">
+                          {item.bucket} · {numberFormatter.format(item.count)}명 · {item.percentage}%
+                        </div>
+                      </div>
+                      <span
+                        className={`truncate font-mono text-[10px] ${
+                          item.isMyBucket ? "text-app-primary" : "text-app-dim"
+                        }`}
+                      >
+                        {item.bucket}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="font-mono text-xs text-app-secondary">
+                전체 {numberFormatter.format(totalInDistribution)}명 중 내 구간({myBucket}){" "}
+                {numberFormatter.format(myBucketInfo?.count ?? 0)}명 ({myBucketInfo?.percentage ?? 0}%)
+              </p>
+            </div>
+          )}
         </div>
 
-        <div className="rounded-lg border border-app-border bg-app-base p-4">
-          <p className="font-mono text-xs text-app-dim">today review</p>
-          <div className="mt-3 font-mono text-xs">
-            <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
-              <p className="text-app-dim">오늘 복습</p>
-              <p className="mt-1 text-app-warn">
-                {numberFormatter.format(dashboard.reviewSummary.dueTodayCount)}
-              </p>
+        <div className="grid gap-4">
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <p className="font-mono text-xs text-app-dim">tag strength</p>
+            <TagStatsList items={dashboard.tagStats} />
+          </div>
+
+          <div className="rounded-lg border border-app-border bg-app-base p-4">
+            <p className="font-mono text-xs text-app-dim">review queue</p>
+            <div className="mt-3 grid grid-cols-2 gap-2 font-mono text-xs">
+              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <p className="text-app-dim">TODAY</p>
+                <p className="mt-1 text-app-warn">
+                  {numberFormatter.format(dashboard.reviewSummary.dueTodayCount)}
+                </p>
+              </div>
+              <div className="rounded-md border border-app-border bg-app-elevated px-3 py-2">
+                <p className="text-app-dim">UPCOMING</p>
+                <p className="mt-1 text-app-primary">
+                  {numberFormatter.format(dashboard.reviewSummary.upcomingCount)}
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -393,11 +393,11 @@ export default function IdeShell({
 
   const layoutColumnsClass = isQuickMenuOpen
     ? isPanelOpen
-      ? "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_250px] xl:grid-cols-[260px_minmax(0,1fr)_290px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_320px]"
-      : "grid-cols-1 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(1200px,1fr)_38px]"
+      ? "grid-cols-1 md:grid-cols-[220px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_240px] xl:grid-cols-[260px_minmax(0,1fr)_280px] 2xl:grid-cols-[290px_minmax(0,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[220px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_38px] xl:grid-cols-[260px_minmax(0,1fr)_38px] 2xl:grid-cols-[290px_minmax(0,1fr)_38px]"
     : isPanelOpen
-      ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_250px] xl:grid-cols-[48px_minmax(0,1fr)_290px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_320px]"
-      : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(1200px,1fr)_38px]";
+      ? "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_240px] xl:grid-cols-[48px_minmax(0,1fr)_280px] 2xl:grid-cols-[48px_minmax(0,1fr)_320px]"
+      : "grid-cols-1 md:grid-cols-[48px_minmax(0,1fr)] lg:grid-cols-[48px_minmax(0,1fr)_38px] xl:grid-cols-[48px_minmax(0,1fr)_38px] 2xl:grid-cols-[48px_minmax(0,1fr)_38px]";
 
   const projectTreeItems = useMemo<QuickMenuTreeItem[]>(() => {
     const isCurrent = (href: string) =>

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -127,21 +127,22 @@ function buildRequirementActionGuide(requirement: RatingRequirementProgress) {
   }
 
   if (requirement.key === "battleRating") {
-    const remaining = Math.max(0, requirement.required - requirement.current);
-    const realisticFast = Math.max(1, Math.ceil(remaining / 15));
-    const realisticSafe = Math.max(1, Math.ceil(remaining / 8));
-    const optimistic = Math.max(1, Math.ceil(remaining / 25));
+    const remaining = Math.max(0, Math.ceil(requirement.required - requirement.current));
+    const normalFast = Math.max(1, Math.ceil(remaining / 15));
+    const normalSafe = Math.max(1, Math.ceil(remaining / 8));
+    const earlyFast = Math.max(1, Math.ceil(remaining / 25));
+    const earlySafe = Math.max(1, Math.ceil(remaining / 15));
     const absoluteMin = Math.max(1, Math.ceil(remaining / 35));
-    return `배틀 SR 조건입니다. 동급 매칭 체감 기준(+8~15)으로 약 ${realisticFast}~${realisticSafe}판, 초반 K 구간(+15~25) 기준 약 ${optimistic}판이 필요합니다. (+35는 상한이라 이론 최소 ${absoluteMin}판)`;
-  }
 
-  if (requirement.key === "hardBattleRating") {
-    const remaining = Math.max(0, requirement.required - requirement.current);
-    const realisticFast = Math.max(1, Math.ceil(remaining / 15));
-    const realisticSafe = Math.max(1, Math.ceil(remaining / 8));
-    const optimistic = Math.max(1, Math.ceil(remaining / 25));
-    const absoluteMin = Math.max(1, Math.ceil(remaining / 35));
-    return `Hard SR은 난이도 2000+ 배틀에서만 반영됩니다. 동급 매칭 체감 기준(+8~15)으로 약 ${realisticFast}~${realisticSafe}판, 초반 K 구간(+15~25) 기준 약 ${optimistic}판이 필요합니다. (+35는 상한이라 이론 최소 ${absoluteMin}판)`;
+    if (remaining <= 20) {
+      return `배틀 SR 근접 구간입니다. 남은 ${remaining}점 기준 동급 매칭 체감(+8~15)으로 약 ${normalFast}~${normalSafe}판, 초반 K 구간(+15~25)에서는 약 ${earlyFast}판(이론 최소 ${absoluteMin}판)으로 도달 가능합니다.`;
+    }
+
+    if (remaining <= 60) {
+      return `배틀 SR 중간 구간입니다. 남은 ${remaining}점 기준 동급 매칭 체감(+8~15)으로 약 ${normalFast}~${normalSafe}판, 초반 K 구간(+15~25) 기준 약 ${earlyFast}~${earlySafe}판이 필요합니다.`;
+    }
+
+    return `배틀 SR 장기 구간입니다. 남은 ${remaining}점 기준 동급 매칭 체감(+8~15)으로 약 ${normalFast}~${normalSafe}판이 필요하고, 초반 K 구간(+15~25)에서도 약 ${earlyFast}~${earlySafe}판이 필요합니다. (+35는 상한이라 이론 최소 ${absoluteMin}판)`;
   }
 
   if (requirement.key === "activityPoint" || requirement.key === "firstSolveScore") {
@@ -444,7 +445,6 @@ export default function MyPageScreen() {
     ratingProgress?.current.battleRating ??
     myInfo?.battleRating ??
     (typeof myInfo?.score === "number" ? myInfo.score : null);
-  const hardBattleRating = ratingProgress?.current.hardBattleRating ?? myInfo?.hardBattleRating ?? null;
   const firstSolveScore = ratingProgress?.current.activityPoint ?? myInfo?.firstSolveScore ?? null;
   const tierScore = myInfo?.tierScore ?? battleRating;
   const recentTop2Ratio =
@@ -455,6 +455,10 @@ export default function MyPageScreen() {
         : null;
   const nextTier = ratingProgress?.next ?? null;
   const nextRequirements = nextTier?.requirements ?? [];
+  const apRequirement =
+    nextRequirements.find(
+      (requirement) => requirement.key === "activityPoint" || requirement.key === "firstSolveScore",
+    ) ?? null;
   const satisfiedRequirementCount = nextRequirements.filter((requirement) => requirement.satisfied).length;
 
   return (
@@ -479,7 +483,7 @@ export default function MyPageScreen() {
       </div>
 
       <div className="flex-1 overflow-auto bg-app-base">
-        <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+        <div className="w-full px-4 py-6 sm:px-6">
           <section className="mb-5 rounded-2xl border border-app-border bg-gradient-to-r from-app-surface to-app-elevated px-4 py-4 shadow-[0_14px_32px_rgba(0,0,0,0.22)]">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
@@ -580,13 +584,7 @@ export default function MyPageScreen() {
 
               {showAdvancedStats ? (
                 <div className="space-y-3">
-                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                    <div className={infoCardClass}>
-                      <p className="text-xs text-app-dim">Hard SR</p>
-                      <p className="mt-1 text-base font-semibold text-app-primary">
-                        {hardBattleRating ?? "-"}
-                      </p>
-                    </div>
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                     <div className={infoCardClass}>
                       <p className="text-xs text-app-dim">랭킹 표시 점수 (tierScore)</p>
                       <p className="mt-1 text-base font-semibold text-app-primary">{tierScore ?? "-"}</p>
@@ -657,6 +655,22 @@ export default function MyPageScreen() {
                   <p className="text-sm text-app-success">현재 GOD 티어입니다. 더 높은 티어는 없습니다.</p>
                 ) : (
                   <div className="space-y-3">
+                    {apRequirement ? (
+                      <div className="rounded-xl border border-app-border bg-app-base px-3 py-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="text-sm font-medium text-app-primary">AP (firstSolveScore)</p>
+                          <p className="text-xs font-semibold text-app-accent-soft">승급 필수</p>
+                        </div>
+                        <p className="mt-1 text-xs text-app-muted">
+                          현재 {Math.round(firstSolveScore ?? 0)} / 목표 {Math.round(apRequirement.required)} · 남은 값{" "}
+                          {Math.max(0, Math.round(apRequirement.required - apRequirement.current))}
+                        </p>
+                        <p className="mt-2 text-xs text-app-secondary">
+                          다음 티어 승급에 AP 조건이 포함됩니다. first solve를 누적해 목표를 채우세요.
+                        </p>
+                      </div>
+                    ) : null}
+
                     <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
                       <p className="text-app-secondary">{nextTier.message}</p>
                       <p className="text-app-dim">

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -50,7 +50,6 @@ export interface MyInfoResponse {
   tier: string;
   role: string;
   battleRating?: number | null;
-  hardBattleRating?: number | null;
   firstSolveScore?: number | null;
   tierScore?: number | null;
   battleMatchCount?: number | null;
@@ -86,7 +85,6 @@ export interface CurrentTierProgress {
   displayTier: string;
   tier: string;
   battleRating: number;
-  hardBattleRating: number;
   activityPoint: number;
   battleMatchCount: number;
   firstSolvedProblemCount: number;


### PR DESCRIPTION
## 작업 개요

- 메인 화면의 레이팅 모니터 영역과 마이페이지 티어 진행도 안내를 개선해, 현재 점수 상태와 다음 티어 목표를 더 쉽게 읽을 수 있도록 정리했습니다.

## 영향 범위

- route: `/`(메인), `/mypage`
- feature: 레이팅 모니터 UI, 티어 진행도 안내 문구/노출 정보
- api/bff: 변경 없음

## 작업 내용

- [x] 메인 레이팅 모니터 레이아웃/정보 밀도 개선
- [x] 마이페이지 티어 진행도 가이드 문구 및 표시 로직 개선

## 변경 사항

- 메인 레이팅 모니터 카드 구성을 정리해 핵심 지표 가독성 향상
- 마이페이지에서 다음 티어 달성 조건 안내를 직관적으로 보이도록 개선
- 과도한 정보 노출을 줄이고 필요한 항목 중심으로 화면 정리

## 테스트 및 확인

- [x] `npm run lint` (warning만 존재, error 없음)
- [x] `npx tsc --noEmit`
- [x] 주요 라우트 수동 확인
- [x] API/BFF 연동 확인

## 관련 이슈

- close #89

## 스크린샷 / 영상

- UI 변경 사항은 PR 코멘트 또는 추가 첨부 예정

## 참고 자료

- 없음
