### PR TITLE
[feat] 마이페이지 풀이 히트맵 추가

### DIFF
--- a/src/app/api/members/me/solve-heatmap/route.ts
+++ b/src/app/api/members/me/solve-heatmap/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+import type { SolveHeatmapApiResponse } from "@/shared/api/contracts";
+import {
+  fetchBackendWithReissue,
+  getErrorMessage,
+  readJsonBody,
+} from "@/shared/api/backend";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const year = url.searchParams.get("year") ?? String(new Date().getFullYear());
+  const cookieStore = await cookies();
+
+  try {
+    const response = await fetchBackendWithReissue(
+      "/api/v1/members/me/solve-heatmap",
+      {
+        searchParams: {
+          year,
+        },
+      },
+      cookieStore,
+    );
+
+    if (response.status === 401) {
+      return NextResponse.json(
+        {
+          resultCode: "MEMBER_401",
+          msg: "로그인이 필요합니다.",
+          data: null,
+        } satisfies SolveHeatmapApiResponse,
+        { status: 401 },
+      );
+    }
+
+    const body = await readJsonBody<SolveHeatmapApiResponse>(response.clone());
+
+    if (!response.ok) {
+      return NextResponse.json(
+        body ?? {
+          resultCode: String(response.status),
+          msg: await getErrorMessage(response),
+          data: null,
+        },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json(
+      body ?? {
+        resultCode: "200",
+        msg: "풀이 히트맵 조회 성공",
+        data: null,
+      } satisfies SolveHeatmapApiResponse,
+    );
+  } catch {
+    return NextResponse.json(
+      {
+        resultCode: "MEMBER_503",
+        msg: "풀이 히트맵 조회에 실패했습니다.",
+        data: null,
+      } satisfies SolveHeatmapApiResponse,
+      { status: 503 },
+    );
+  }
+}

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -12,6 +12,9 @@ import type {
   RatingProgressApiResponse,
   RatingProgressResponse,
   RatingRequirementProgress,
+  SolveHeatmapApiResponse,
+  SolveHeatmapData,
+  SolveHeatmapDay,
 } from "@/shared/api/contracts";
 import { useAppSession } from "@/features/layout/session-context";
 import { formatDateTime } from "@/shared/utils/format-date-time";
@@ -64,6 +67,21 @@ async function readMyRatingProgress() {
   });
 
   const payload = (await response.json().catch(() => null)) as RatingProgressApiResponse | null;
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    payload,
+  };
+}
+
+async function readMySolveHeatmap(year: number) {
+  const response = await fetch(`/api/members/me/solve-heatmap?year=${year}`, {
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  const payload = (await response.json().catch(() => null)) as SolveHeatmapApiResponse | null;
 
   return {
     ok: response.ok,
@@ -195,6 +213,228 @@ function buildRequirementActionGuide(requirement: RatingRequirementProgress) {
 const statCardClass =
   "rounded-xl border border-app-border bg-app-surface px-3 py-2 shadow-[0_10px_22px_rgba(0,0,0,0.18)]";
 const infoCardClass = "rounded-xl border border-app-border bg-app-elevated px-3 py-2";
+const heatmapWeekdayLabels = [
+  { row: 1, label: "Mon" },
+  { row: 3, label: "Wed" },
+  { row: 5, label: "Fri" },
+];
+const heatmapLegendLevels: SolveHeatmapDay["level"][] = [0, 1, 2, 3, 4];
+const heatmapDateFormatter = new Intl.DateTimeFormat("ko-KR", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  weekday: "short",
+});
+
+function parseDateOnly(dateString: string) {
+  const [year, month, day] = dateString.split("-").map(Number);
+  return new Date(year, (month ?? 1) - 1, day ?? 1);
+}
+
+function formatHeatmapDate(dateString: string) {
+  return heatmapDateFormatter.format(parseDateOnly(dateString));
+}
+
+function getHeatmapCellBackground(level: SolveHeatmapDay["level"]) {
+  switch (level) {
+    case 1:
+      return "linear-gradient(180deg, rgba(35, 55, 51, 0.94) 0%, rgba(24, 37, 35, 1) 100%)";
+    case 2:
+      return "linear-gradient(180deg, rgba(31, 112, 72, 0.95) 0%, rgba(24, 79, 53, 1) 100%)";
+    case 3:
+      return "linear-gradient(180deg, rgba(74, 198, 110, 0.95) 0%, rgba(33, 133, 77, 1) 100%)";
+    case 4:
+      return "linear-gradient(180deg, rgba(132, 255, 147, 1) 0%, rgba(45, 188, 91, 1) 100%)";
+    default:
+      return "linear-gradient(180deg, rgba(32, 37, 46, 0.92) 0%, rgba(18, 22, 29, 1) 100%)";
+  }
+}
+
+function HeatmapSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-[6px] pl-11 text-[10px]">
+        {Array.from({ length: 14 }).map((_, index) => (
+          <div key={index} className="h-3 w-4 rounded bg-app-base" />
+        ))}
+      </div>
+      <div className="flex gap-3">
+        <div className="flex h-[148px] w-8 flex-col justify-between pt-0.5 text-[10px] text-app-dim">
+          <span className="h-3 w-6 rounded bg-app-base" />
+          <span className="h-3 w-6 rounded bg-app-base" />
+          <span className="h-3 w-6 rounded bg-app-base" />
+        </div>
+        <div className="flex gap-[6px]">
+          {Array.from({ length: 18 }).map((_, weekIndex) => (
+            <div key={weekIndex} className="flex flex-col gap-[6px]">
+              {Array.from({ length: 7 }).map((_, dayIndex) => (
+                <div
+                  key={`${weekIndex}-${dayIndex}`}
+                  className="h-4 w-4 animate-pulse rounded-[4px] bg-app-base"
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SolveHeatmapSection({
+  heatmap,
+  selectedYear,
+  isLoading,
+  error,
+  onSelectYear,
+}: {
+  heatmap: SolveHeatmapData | null;
+  selectedYear: number;
+  isLoading: boolean;
+  error: string | null;
+  onSelectYear: (year: number) => void;
+}) {
+  const availableYears =
+    heatmap?.availableYears.length ? [...heatmap.availableYears].sort((a, b) => b - a) : [selectedYear];
+  const monthLabelMap = new Map(heatmap?.monthLabels.map((item) => [item.weekIndex, item.label]) ?? []);
+  const weekCount = heatmap?.weeks.length ?? 0;
+
+  return (
+    <section className="rounded-2xl border border-app-border bg-app-surface p-4 shadow-[0_10px_24px_rgba(0,0,0,0.2)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-app-dim">solve-heatmap</p>
+          <h2 className="mt-2 text-sm font-semibold text-app-primary">풀이 잔디 히트맵</h2>
+          <p className="mt-1 text-xs text-app-muted">
+            {heatmap
+              ? `${heatmap.year}년 총 ${heatmap.totalSolvedCount.toLocaleString()}회 풀이 · 일일 최대 ${heatmap.maxDailySolvedCount.toLocaleString()}회`
+              : `${selectedYear}년 풀이 기록을 불러오는 중입니다.`}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {availableYears.map((year) => {
+            const isActive = year === selectedYear;
+
+            return (
+              <button
+                key={year}
+                type="button"
+                onClick={() => onSelectYear(year)}
+                disabled={isLoading && isActive}
+                className={`inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-semibold transition ${
+                  isActive
+                    ? "border-app-accent bg-app-accent/15 text-app-primary"
+                    : "border-app-border bg-app-base text-app-secondary hover:border-app-border-strong hover:bg-app-elevated"
+                }`}
+              >
+                {year}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-xl border border-app-warn/60 bg-app-warn/15 px-3 py-2 text-sm text-app-warn">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-4 rounded-2xl border border-app-border bg-app-base/80 px-5 py-5">
+        {isLoading ? (
+          <HeatmapSkeleton />
+        ) : !heatmap || heatmap.weeks.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-app-border px-4 py-10 text-center text-sm text-app-muted">
+            아직 풀이 기록이 없습니다.
+          </div>
+        ) : (
+          <div className="overflow-visible">
+            <div className="overflow-x-auto overflow-y-visible pb-1">
+              <div className="mx-auto w-fit min-w-[860px]">
+                <div className="mb-3 flex gap-[6px] pl-11 text-[10px] text-app-dim">
+                  {heatmap.weeks.map((_, weekIndex) => (
+                    <div key={weekIndex} className="w-4 shrink-0 text-left">
+                      {monthLabelMap.get(weekIndex) ?? ""}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex gap-3">
+                  <div className="flex h-[148px] w-8 flex-col justify-between pt-0.5 text-[10px] text-app-dim">
+                    {Array.from({ length: 7 }).map((_, rowIndex) => (
+                      <span key={rowIndex} className="inline-flex h-4 items-center justify-end">
+                        {heatmapWeekdayLabels.find((item) => item.row === rowIndex)?.label ?? ""}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div className="flex gap-[6px]">
+                    {heatmap.weeks.map((week, weekIndex) => (
+                      <div key={weekIndex} className="flex flex-col gap-[6px]">
+                        {week.days.map((day) => {
+                          const tooltipText = [
+                            formatHeatmapDate(day.date),
+                            `Total solved: ${day.totalSolvedCount}`,
+                            `Solo solved: ${day.soloSolvedCount}`,
+                            `Battle solved: ${day.battleSolvedCount}`,
+                          ].join("\n");
+                          const dayRowIndex = week.days.findIndex((item) => item.date === day.date);
+                          const tooltipPlacement =
+                            dayRowIndex <= 2
+                              ? "top-full mt-2 origin-top"
+                              : "bottom-full mb-2 origin-bottom";
+                          const tooltipAlignment =
+                            weekIndex <= 3
+                              ? "left-0 translate-x-0"
+                              : weekIndex >= weekCount - 4
+                                ? "right-0 left-auto translate-x-0"
+                                : "left-1/2 -translate-x-1/2";
+
+                          return (
+                            <button
+                              key={day.date}
+                              type="button"
+                              aria-label={tooltipText}
+                              className={`group relative z-0 h-4 w-4 shrink-0 rounded-[4px] border border-app-border/70 transition-transform hover:z-[90] hover:-translate-y-[1px] focus-visible:z-[90] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-accent/70 ${
+                                day.inSelectedYear ? "" : "opacity-35"
+                              } ${day.isToday ? "ring-1 ring-app-accent-soft ring-offset-1 ring-offset-app-base" : ""}`}
+                              style={{ background: getHeatmapCellBackground(day.level) }}
+                            >
+                              <span
+                                className={`pointer-events-none absolute z-[80] hidden w-[196px] flex-col overflow-hidden rounded-lg border border-app-border-strong bg-app-base px-3 py-2 text-left text-[11px] leading-5 text-app-primary shadow-[0_18px_34px_rgba(0,0,0,0.42)] group-hover:flex group-focus-visible:flex ${tooltipPlacement} ${tooltipAlignment}`}
+                              >
+                                <span className="block text-app-dim">{formatHeatmapDate(day.date)}</span>
+                                <span className="block">Total solved: {day.totalSolvedCount}</span>
+                                <span className="block">Solo solved: {day.soloSolvedCount}</span>
+                                <span className="block">Battle solved: {day.battleSolvedCount}</span>
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="mt-4 flex items-center justify-end gap-2 text-[11px] text-app-dim">
+                  <span>Less</span>
+                  {heatmapLegendLevels.map((level) => (
+                    <span
+                      key={level}
+                      className="inline-flex h-3.5 w-3.5 rounded-[4px] border border-app-border/70"
+                      style={{ background: getHeatmapCellBackground(level) }}
+                    />
+                  ))}
+                  <span>More</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
 
 function ResultCard({ item }: { item: MyBattleResultItem }) {
   return (
@@ -274,12 +514,18 @@ function LoadingRows() {
 
 export default function MyPageScreen() {
   const { session, sessionLoaded, refreshSession } = useAppSession();
+  const currentYear = new Date().getFullYear();
   const [myInfo, setMyInfo] = useState<MyInfoResponse | null>(null);
   const [myInfoError, setMyInfoError] = useState<string | null>(null);
   const [ratingProgress, setRatingProgress] = useState<RatingProgressResponse | null>(null);
   const [ratingProgressError, setRatingProgressError] = useState<string | null>(null);
   const [battleResults, setBattleResults] = useState<MyBattleResultItem[]>([]);
   const [pageInfo, setPageInfo] = useState(defaultPageInfo);
+  const [selectedYear, setSelectedYear] = useState(currentYear);
+  const [heatmap, setHeatmap] = useState<SolveHeatmapData | null>(null);
+  const [heatmapError, setHeatmapError] = useState<string | null>(null);
+  const [isHeatmapLoading, setIsHeatmapLoading] = useState(true);
+  const [hasInitializedHeatmap, setHasInitializedHeatmap] = useState(false);
   const [message, setMessage] = useState("내 전적을 불러오는 중입니다.");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -299,18 +545,28 @@ export default function MyPageScreen() {
         setMyInfoError(null);
         setRatingProgress(null);
         setRatingProgressError(null);
+        setHeatmap(null);
+        setHeatmapError(null);
+        setSelectedYear(currentYear);
+        setHasInitializedHeatmap(false);
         setBattleResults([]);
         setPageInfo(defaultPageInfo);
         setError(null);
         setIsLoading(false);
+        setIsHeatmapLoading(false);
         setMessage("로그인 후 내 전적을 확인할 수 있습니다.");
         return;
       }
 
-      const [myInfoResponse, battleResultsResponse, ratingProgressResponse] = await Promise.all([
+      setIsLoading(true);
+      setIsHeatmapLoading(true);
+      setHasInitializedHeatmap(false);
+
+      const [myInfoResponse, battleResultsResponse, ratingProgressResponse, heatmapResponse] = await Promise.all([
         readMyInfo(),
         readMyBattleResults(0, PAGE_SIZE),
         readMyRatingProgress(),
+        readMySolveHeatmap(currentYear),
       ]);
 
       if (!active) {
@@ -323,7 +579,9 @@ export default function MyPageScreen() {
         ratingProgressResponse.status === 401 ||
         ratingProgressResponse.payload?.resultCode === "MEMBER_401" ||
         battleResultsResponse.status === 401 ||
-        battleResultsResponse.payload?.resultCode === "MEMBER_401";
+        battleResultsResponse.payload?.resultCode === "MEMBER_401" ||
+        heatmapResponse.status === 401 ||
+        heatmapResponse.payload?.resultCode === "MEMBER_401";
 
       if (isUnauthorized) {
         void refreshSession();
@@ -331,16 +589,22 @@ export default function MyPageScreen() {
         setMyInfoError(null);
         setRatingProgress(null);
         setRatingProgressError(null);
+        setHeatmap(null);
+        setHeatmapError(null);
+        setSelectedYear(currentYear);
+        setHasInitializedHeatmap(false);
         setBattleResults([]);
         setPageInfo(defaultPageInfo);
         setError(null);
         setMessage(
           myInfoResponse.payload?.msg ??
             ratingProgressResponse.payload?.msg ??
+            heatmapResponse.payload?.msg ??
             battleResultsResponse.payload?.msg ??
             "로그인이 필요합니다.",
         );
         setIsLoading(false);
+        setIsHeatmapLoading(false);
         return;
       }
 
@@ -372,6 +636,23 @@ export default function MyPageScreen() {
         );
       }
 
+      if (
+        heatmapResponse.ok &&
+        heatmapResponse.payload &&
+        heatmapResponse.payload.resultCode === "200" &&
+        heatmapResponse.payload.data
+      ) {
+        setHeatmap(heatmapResponse.payload.data);
+        setSelectedYear(heatmapResponse.payload.data.year);
+        setHeatmapError(null);
+      } else {
+        setHeatmap(null);
+        setHeatmapError(heatmapResponse.payload?.msg ?? "풀이 히트맵을 불러오지 못했습니다.");
+      }
+
+      setIsHeatmapLoading(false);
+      setHasInitializedHeatmap(true);
+
       const { ok, payload } = battleResultsResponse;
 
       if (!ok || !payload || payload.resultCode !== "200" || !payload.data) {
@@ -393,7 +674,61 @@ export default function MyPageScreen() {
     return () => {
       active = false;
     };
-  }, [refreshSession, session.authenticated, sessionLoaded]);
+  }, [currentYear, refreshSession, session.authenticated, sessionLoaded]);
+
+  useEffect(() => {
+    if (!sessionLoaded || !session.authenticated || !hasInitializedHeatmap) {
+      return;
+    }
+
+    if (heatmap?.year === selectedYear) {
+      return;
+    }
+
+    let active = true;
+    setIsHeatmapLoading(true);
+
+    void (async () => {
+      const heatmapResponse = await readMySolveHeatmap(selectedYear);
+
+      if (!active) {
+        return;
+      }
+
+      if (heatmapResponse.status === 401 || heatmapResponse.payload?.resultCode === "MEMBER_401") {
+        void refreshSession();
+        setHeatmapError(heatmapResponse.payload?.msg ?? "로그인이 필요합니다.");
+        setIsHeatmapLoading(false);
+        return;
+      }
+
+      if (
+        heatmapResponse.ok &&
+        heatmapResponse.payload &&
+        heatmapResponse.payload.resultCode === "200" &&
+        heatmapResponse.payload.data
+      ) {
+        setHeatmap(heatmapResponse.payload.data);
+        setSelectedYear(heatmapResponse.payload.data.year);
+        setHeatmapError(null);
+      } else {
+        setHeatmapError(heatmapResponse.payload?.msg ?? "풀이 히트맵을 불러오지 못했습니다.");
+      }
+
+      setIsHeatmapLoading(false);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    hasInitializedHeatmap,
+    heatmap?.year,
+    refreshSession,
+    selectedYear,
+    session.authenticated,
+    sessionLoaded,
+  ]);
 
   async function handleLoadMore() {
     if (!session.authenticated || !pageInfo.hasNext || isLoadingMore) {
@@ -627,6 +962,14 @@ export default function MyPageScreen() {
                   </div>
                 </div>
               ) : null}
+
+              <SolveHeatmapSection
+                heatmap={heatmap}
+                selectedYear={selectedYear}
+                isLoading={isHeatmapLoading}
+                error={heatmapError}
+                onSelectYear={setSelectedYear}
+              />
 
               <section className="rounded-2xl border border-app-border bg-app-surface p-4 shadow-[0_10px_24px_rgba(0,0,0,0.2)]">
                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2">

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -296,7 +296,9 @@ function SolveHeatmapSection({
 }) {
   const availableYears =
     heatmap?.availableYears.length ? [...heatmap.availableYears].sort((a, b) => b - a) : [selectedYear];
-  const monthLabelMap = new Map(heatmap?.monthLabels.map((item) => [item.weekIndex, item.label]) ?? []);
+  const monthLabelMap = new Map(
+    (heatmap?.monthLabels ?? []).map((item) => [item.weekIndex, item.label]),
+  );
   const weekCount = heatmap?.weeks.length ?? 0;
 
   return (

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -170,6 +170,36 @@ export interface RankingDashboardResponse {
   reviewSummary: RankingDashboardReviewSummary;
 }
 
+export interface SolveHeatmapDay {
+  date: string;
+  soloSolvedCount: number;
+  battleSolvedCount: number;
+  totalSolvedCount: number;
+  level: 0 | 1 | 2 | 3 | 4;
+  inSelectedYear: boolean;
+  isToday: boolean;
+}
+
+export interface SolveHeatmapWeek {
+  days: SolveHeatmapDay[];
+}
+
+export interface SolveHeatmapMonthLabel {
+  weekIndex: number;
+  label: string;
+}
+
+export interface SolveHeatmapData {
+  year: number;
+  availableYears: number[];
+  totalSolvedCount: number;
+  maxDailySolvedCount: number;
+  monthLabels: SolveHeatmapMonthLabel[];
+  weeks: SolveHeatmapWeek[];
+}
+
+export type SolveHeatmapApiResponse = RsData<SolveHeatmapData | null>;
+
 export interface QueueJoinRequest {
   category: string;
   difficulty: Difficulty;


### PR DESCRIPTION
refs #98 
closes #98 

<hr />

<h2>📝 작업 내용</h2>
<p>
이번 PR은 마이페이지에 <strong>GitHub / 백준 스타일의 연간 풀이 히트맵</strong>을 추가한 작업입니다.
사용자가 날짜별 풀이 기록을 한눈에 확인할 수 있도록,
solo / battle 풀이 수를 주 단위 잔디 형태로 시각화했습니다.
</p>

<p>
이번 구현에서는 백엔드의
<code>GET /api/v1/members/me/solve-heatmap?year=YYYY</code>
응답을 기준으로,
</p>

<ul>
  <li>Next BFF route 추가</li>
  <li>heatmap 계약 타입 정의</li>
  <li>마이페이지 초기 로드 및 연도 전환 연동</li>
  <li>잔디 그리드 / 월 라벨 / 요일 라벨 / 툴팁 / 범례 UI 구현</li>
</ul>

<p>
까지 포함했습니다.
</p>

<hr />

<h3>1) solve heatmap API 계약 타입 추가</h3>
<p>
<code>src/shared/api/contracts.ts</code>에 풀이 히트맵 응답 타입을 추가했습니다.
</p>

<ul>
  <li><code>SolveHeatmapDay</code></li>
  <li><code>SolveHeatmapWeek</code></li>
  <li><code>SolveHeatmapMonthLabel</code></li>
  <li><code>SolveHeatmapData</code></li>
  <li><code>SolveHeatmapApiResponse</code></li>
</ul>

<p>
각 day 셀은 백엔드가 내려준 값을 그대로 사용합니다.
즉 프론트는 <code>level</code>을 다시 계산하지 않고,
아래 필드를 그대로 렌더링만 합니다.
</p>

<ul>
  <li><code>date</code></li>
  <li><code>soloSolvedCount</code></li>
  <li><code>battleSolvedCount</code></li>
  <li><code>totalSolvedCount</code></li>
  <li><code>level</code></li>
  <li><code>inSelectedYear</code></li>
  <li><code>isToday</code></li>
</ul>

<hr />

<h3>2) Next BFF route 추가</h3>
<p>
브라우저가 백엔드를 직접 호출하지 않도록,
<code>src/app/api/members/me/solve-heatmap/route.ts</code>를 추가했습니다.
</p>

<p>
프론트는 이제 아래 경로를 호출합니다.
</p>

<pre><code class="language-text">GET /api/members/me/solve-heatmap?year=YYYY</code></pre>

<p>
이 route는:
</p>

<ul>
  <li>현재 요청의 쿠키를 읽고</li>
  <li>백엔드 <code>/api/v1/members/me/solve-heatmap</code>로 프록시하며</li>
  <li>기존 members/me 계열과 동일한 401 / 503 처리 패턴을 유지합니다</li>
</ul>

<p>
응답은 <code>RsData</code> wrapper를 유지한 채 그대로 전달합니다.
</p>

<hr />

<h3>3) 마이페이지 데이터 흐름에 heatmap 추가</h3>
<p>
<code>src/features/my-page/screen.tsx</code>에 heatmap 조회 상태를 추가했습니다.
</p>

<ul>
  <li><code>selectedYear</code></li>
  <li><code>heatmap</code></li>
  <li><code>heatmapError</code></li>
  <li><code>isHeatmapLoading</code></li>
</ul>

<p>
초기 마이페이지 진입 시에는 기존 데이터와 함께 heatmap도 같이 불러옵니다.
</p>

<pre><code class="language-ts">Promise.all([
  readMyInfo(),
  readMyBattleResults(0, PAGE_SIZE),
  readMyRatingProgress(),
  readMySolveHeatmap(currentYear),
])</code></pre>

<p>
이후 연도 버튼을 클릭하면 해당 연도로 heatmap만 다시 조회합니다.
또한 401 응답 시에는 기존과 동일하게 <code>refreshSession()</code> 흐름을 타고,
heatmap 실패는 마이페이지 전체를 깨지 않고
heatmap 섹션 안에서만 에러로 처리되도록 분리했습니다.
</p>

<hr />

<h3>4) 마이페이지에 풀이 잔디 히트맵 섹션 추가</h3>
<p>
heatmap 섹션은 마이페이지 상단 stat 카드 / advanced stats 아래,
<strong>다음 티어 진행도 섹션 위</strong>에 배치했습니다.
</p>

<p>
구성은 다음과 같습니다.
</p>

<ul>
  <li>헤더: <code>solve-heatmap</code> 라벨, 섹션 제목, 연도별 총 풀이 수 / 일일 최대 풀이 수</li>
  <li>우측 연도 버튼: <code>availableYears</code> 기반 연도 탭</li>
  <li>본문: 주 단위 7칸 잔디 그리드</li>
  <li>하단: <code>Less ~ More</code> 범례</li>
</ul>

<p>
즉 마이페이지에 들어오면 사용자 입장에서
“올해 언제 얼마나 풀었는지”
바로 볼 수 있는 핵심 시각 요소가 추가된 상태입니다.
</p>

<hr />

<h3>5) GitHub 스타일 주간 잔디 그리드 렌더링</h3>
<p>
heatmap 본문은 백엔드의 <code>weeks[].days[]</code> 구조를 그대로 사용해
주 단위 세로 7칸 그리드로 렌더링합니다.
</p>

<ul>
  <li>상단: <code>monthLabels.weekIndex</code> 기준 월 라벨</li>
  <li>좌측: <code>Mon</code>, <code>Wed</code>, <code>Fri</code> 요일 라벨</li>
  <li>셀 크기: 고정 정사각형 칩</li>
  <li>모바일: 가로 스크롤 가능</li>
</ul>

<p>
즉 GitHub contribution graph처럼
가로는 week, 세로는 day 구조를 유지하면서,
현재 디자인 시스템의 다크/콘솔 톤에 맞게 커스텀했습니다.
</p>

<hr />

<h3>6) level 기반 그라데이션 잔디 색상 적용</h3>
<p>
셀 색상은 백엔드가 내려준 <code>level 0~4</code>만 사용하도록 했습니다.
프론트는 <code>totalSolvedCount</code>로 색을 다시 계산하지 않습니다.
</p>

<ul>
  <li><code>level 0</code>: 비활성/어두운 칸</li>
  <li><code>level 1~4</code>: 점점 진해지는 녹색 계열 그라데이션</li>
</ul>

<p>
또한:
</p>

<ul>
  <li><code>inSelectedYear=false</code> 셀은 opacity를 낮춰 비활성처럼 보이게 처리</li>
  <li><code>isToday=true</code> 셀은 ring으로 강조</li>
</ul>

<p>
즉 패딩 셀과 실제 선택 연도 셀이 시각적으로 구분되고,
오늘 날짜도 바로 인지할 수 있도록 했습니다.
</p>

<hr />

<h3>7) 셀 hover / focus 툴팁 추가</h3>
<p>
각 셀에 hover / focus 시 툴팁을 표시하도록 구현했습니다.
툴팁은 날짜와 함께 아래 3줄을 고정적으로 보여줍니다.
</p>

<ul>
  <li><code>Total solved: {totalSolvedCount}</code></li>
  <li><code>Solo solved: {soloSolvedCount}</code></li>
  <li><code>Battle solved: {battleSolvedCount}</code></li>
</ul>

<p>
즉 사용자는 단순히 색 단계만 보는 것이 아니라,
하루 풀이 수가 solo / battle에서 어떻게 구성됐는지도 바로 확인할 수 있습니다.
</p>

<hr />

<h3>8) 로딩 / 빈 상태 / 에러 상태 처리</h3>
<p>
heatmap API가 항상 정상 데이터만 준다고 가정하지 않고,
상태별 UI도 함께 추가했습니다.
</p>

<ul>
  <li>로딩 중: heatmap skeleton 표시</li>
  <li><code>weeks</code>가 비어 있을 때: “아직 풀이 기록이 없습니다” 빈 상태</li>
  <li>heatmap API 실패 시: heatmap 섹션 내부 에러 메시지 표시</li>
</ul>

<p>
즉 heatmap만 실패해도 마이페이지의 프로필/전적/티어 진행도는 그대로 유지됩니다.
</p>

<hr />

<h3>9) 레이아웃/정렬 및 hover 레이어 보정</h3>
<p>
구현 후 실제 렌더링을 보면서 UI 보정도 함께 진행했습니다.
</p>

<ul>
  <li>월 라벨과 요일 라벨 기준선을 셀 그리드와 더 잘 맞도록 조정</li>
  <li>heatmap 본문이 카드 내부에서 너무 치우치지 않도록 정렬 보정</li>
  <li>hover 툴팁이 다른 셀과 겹쳐 보이지 않도록 hover 셀의 z-index 정리</li>
</ul>

<p>
즉 단순히 데이터만 붙인 수준이 아니라,
실제 잔디형 컴포넌트로 사용할 수 있게 시각적인 완성도도 함께 다듬었습니다.
</p>

<hr />

<h3>10) 변경 파일</h3>
<ul>
  <li><code>src/shared/api/contracts.ts</code></li>
  <li><code>src/app/api/members/me/solve-heatmap/route.ts</code></li>
  <li><code>src/features/my-page/screen.tsx</code></li>
</ul>

<hr />

<h3>11) 테스트 / 확인 포인트</h3>
<ol>
  <li>로그인 상태로 마이페이지 진입 시 heatmap API가 함께 호출되는지 확인</li>
  <li><code>availableYears</code> 버튼 클릭 시 해당 연도로 heatmap만 재조회되는지 확인</li>
  <li><code>weeks[].days[]</code>가 주 단위 7칸 그리드로 정상 렌더링되는지 확인</li>
  <li><code>monthLabels.weekIndex</code> 기준 월 라벨이 올바른 위치에 표시되는지 확인</li>
  <li><code>level 0~4</code>가 의도한 5단계 색으로 보이는지 확인</li>
  <li><code>inSelectedYear=false</code> 셀이 흐리게, <code>isToday=true</code> 셀이 강조되어 보이는지 확인</li>
  <li>셀 hover / focus 시 툴팁이 날짜 + <code>Total / Solo / Battle</code> 구조로 표시되는지 확인</li>
  <li>heatmap 응답이 비었거나 실패해도 마이페이지 다른 영역이 깨지지 않는지 확인</li>
  <li>모바일 폭에서 가로 스크롤로 heatmap을 볼 수 있는지 확인</li>
</ol>

<p>
정적 검사는 <code>npx.cmd tsc --noEmit</code> 기준으로 통과했습니다.
</p>
