### PR TITLE
배틀룸에서 사용자 상태 공유에 폴링하던것을 제거

### DIFF
--- a/src/features/battle-room/screen.tsx
+++ b/src/features/battle-room/screen.tsx
@@ -10,7 +10,9 @@ import SockJS from "sockjs-client";
 import type {
   ApiErrorResponse,
   BattleRoomStateResponse,
+  BattleStartedWsMessage,
   JoinRoomResponse,
+  ParticipantStatusChangedWsMessage,
   ProblemDetailResponse,
   RoomResponse,
   RunTestCaseResult,
@@ -699,13 +701,20 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
         }
       },
       onConnect: () => {
-        // 재연결 시 ABANDONED 상태면 grace period 취소를 위해 join 호출
-        const currentRoom = roomRef.current;
-        const me = currentRoom?.participants.find(
-          (p) => p.userId === session.member?.memberId,
-        );
-        if (currentRoom?.status === "PLAYING" && me?.status === "ABANDONED") {
-          void fetch(`/api/battle/rooms/${roomId}/join`, { method: "POST" });
+        // 재연결 시 서버 상태를 재조회해 ABANDONED 여부를 확인한다.
+        // WS가 끊긴 동안 백엔드가 participant를 ABANDONED로 전환했을 수 있지만,
+        // 끊겨 있는 동안은 이벤트를 받지 못하므로 roomRef는 여전히 PLAYING을 가리킨다.
+        // roomRef가 null이면 초기 연결이므로 스킵 (별도 useEffect가 초기 room 조회를 담당).
+        if (roomRef.current !== null) {
+          void fetch(`/api/battle/rooms/${roomId}`, { cache: "no-store" })
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data: RoomResponse | null) => {
+              if (data) {
+                roomRef.current = data;
+                setRoom(data);
+                // setRoom 후 shouldRejoinFromPlaying useEffect가 ABANDONED 여부를 감지해 join 처리
+              }
+            });
         }
 
         client.subscribe(`/topic/room/${roomId}`, (message) => {
@@ -723,7 +732,49 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
 
           const type = (payload as { type: unknown }).type;
 
-          if (type === "BATTLE_STARTED" || type === "PARTICIPANT_DONE") {
+          if (type === "BATTLE_STARTED") {
+            const msg = payload as BattleStartedWsMessage;
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                status: "PLAYING" as const,
+                timerEnd:
+                  typeof msg.timerEnd === "string" || msg.timerEnd === null
+                    ? msg.timerEnd
+                    : current.timerEnd,
+              };
+              roomRef.current = nextRoom;
+              return nextRoom;
+            });
+            return;
+          }
+
+          if (type === "PARTICIPANT_STATUS_CHANGED") {
+            const msg = payload as ParticipantStatusChangedWsMessage;
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                participants: current.participants.map((participant) =>
+                  participant.userId === msg.userId
+                    ? { ...participant, status: msg.status }
+                    : participant,
+                ),
+              };
+              roomRef.current = nextRoom;
+              return nextRoom;
+            });
+            return;
+          }
+
+          if (type === "PARTICIPANT_DONE") {
             void fetch(`/api/battle/rooms/${roomId}`, { cache: "no-store" })
               .then((res) => (res.ok ? res.json() : null))
               .then((data: RoomResponse | null) => {
@@ -732,6 +783,22 @@ export default function BattleRoomScreen({ roomId }: { roomId: string }) {
                   setRoom(data);
                 }
               });
+            return;
+          }
+
+          if (type === "BATTLE_FINISHED") {
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                status: "FINISHED" as const,
+              };
+              roomRef.current = nextRoom;
+              return nextRoom;
+            });
             return;
           }
 

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -7,8 +7,10 @@ import SockJS from "sockjs-client";
 
 import type {
   BattleResultWsMessage,
+  BattleStartedWsMessage,
   MyBattleResultItem,
   MyBattleResultsResponse,
+  ParticipantStatusChangedWsMessage,
   RoomResponse,
   SessionResponse,
 } from "@/shared/api/contracts";
@@ -32,6 +34,7 @@ export interface NotificationItem {
 
 interface BattleSidebarState {
   status: RoomResponse["status"];
+  timerEnd: string | null;
   remainingTime: string;
   participants: RoomResponse["participants"];
   myStatus: string | null;
@@ -87,6 +90,39 @@ async function readMyBattleResultsPreview(size: number) {
     ok: response.ok,
     status: response.status,
     payload,
+  };
+}
+
+function createBattleSidebarState(payload: RoomResponse, memberId: number): BattleSidebarState {
+  const me = payload.participants.find((item) => item.userId === memberId) ?? null;
+
+  return {
+    status: payload.status,
+    timerEnd: payload.timerEnd,
+    remainingTime: formatRemainingTime(payload.timerEnd),
+    participants: payload.participants,
+    myStatus: me?.status ?? null,
+    myUserId: memberId,
+    isJoining: me?.status === "ABANDONED",
+  };
+}
+
+function updateBattleSidebarParticipantStatus(
+  current: BattleSidebarState,
+  message: ParticipantStatusChangedWsMessage,
+): BattleSidebarState {
+  const participants = current.participants.map((participant) =>
+    participant.userId === message.userId
+      ? { ...participant, status: message.status }
+      : participant,
+  );
+  const me = participants.find((participant) => participant.userId === current.myUserId) ?? null;
+
+  return {
+    ...current,
+    participants,
+    myStatus: me?.status ?? null,
+    isJoining: me?.status === "ABANDONED",
   };
 }
 
@@ -173,8 +209,85 @@ export default function IdeShell({
     }
 
     let active = true;
+    const client = new Client({
+      webSocketFactory: () =>
+        new SockJS(
+          `${process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080"}/ws`,
+        ),
+      reconnectDelay: 3000,
+      beforeConnect: async () => {
+        client.connectHeaders = {};
+        try {
+          const res = await fetch("/api/v1/ws/token", { method: "POST" });
+          if (res.ok) {
+            const data = (await res.json()) as { token: string };
+            client.connectHeaders = { "X-WS-Token": data.token };
+          }
+        } catch {
+          // 荑좏궎 湲곕컲 ?몄쬆?쇰줈 ?대갚
+        }
+      },
+      onConnect: () => {
+        client.subscribe(`/topic/room/${targetRoomId}`, (frame) => {
+          let payload: unknown;
+          try {
+            payload = JSON.parse(frame.body) as unknown;
+          } catch {
+            return;
+          }
 
-    const poll = async () => {
+          if (typeof payload !== "object" || payload === null || !("type" in payload)) {
+            return;
+          }
+
+          const type = (payload as { type: unknown }).type;
+
+          if (type === "PARTICIPANT_STATUS_CHANGED") {
+            const message = payload as ParticipantStatusChangedWsMessage;
+            setBattleSidebarState((current) =>
+              current ? updateBattleSidebarParticipantStatus(current, message) : current,
+            );
+            return;
+          }
+
+          if (type === "BATTLE_STARTED") {
+            const message = payload as BattleStartedWsMessage;
+            setBattleSidebarState((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextTimerEnd =
+                typeof message.timerEnd === "string" || message.timerEnd === null
+                  ? message.timerEnd
+                  : current.timerEnd;
+
+              return {
+                ...current,
+                status: "PLAYING",
+                timerEnd: nextTimerEnd,
+                remainingTime: formatRemainingTime(nextTimerEnd),
+              };
+            });
+            return;
+          }
+
+          if (type === "BATTLE_FINISHED") {
+            setBattleSidebarState((current) =>
+              current
+                ? {
+                    ...current,
+                    status: "FINISHED",
+                    remainingTime: formatRemainingTime(current.timerEnd),
+                  }
+                : current,
+            );
+          }
+        });
+      },
+    });
+
+    const loadSidebarState = async () => {
       try {
         const response = await fetch(`/api/battle/rooms/${targetRoomId}`, {
           cache: "no-store",
@@ -191,33 +304,41 @@ export default function IdeShell({
         }
 
         const payload = (await response.json()) as RoomResponse;
-        const me =
-          payload.participants.find((item) => item.userId === memberId) ?? null;
-
-        setBattleSidebarState({
-          status: payload.status,
-          remainingTime: formatRemainingTime(payload.timerEnd),
-          participants: payload.participants,
-          myStatus: me?.status ?? null,
-          myUserId: memberId,
-          isJoining: me?.status === "ABANDONED",
-        });
+        setBattleSidebarState(createBattleSidebarState(payload, memberId));
+        client.activate();
       } catch {
         // 네비게이션 중 fetch 취소 등 무시
       }
     };
 
-    void poll();
-
-    const intervalId = window.setInterval(() => {
-      void poll();
-    }, 1000);
+    void loadSidebarState();
 
     return () => {
       active = false;
-      window.clearInterval(intervalId);
+      void client.deactivate();
     };
   }, [pathname, session.authenticated, session.member]);
+
+  useEffect(() => {
+    if (!battleSidebarState?.timerEnd) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setBattleSidebarState((current) =>
+        current
+          ? {
+              ...current,
+              remainingTime: formatRemainingTime(current.timerEnd),
+            }
+          : current,
+      );
+    }, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [battleSidebarState?.timerEnd]);
 
   useEffect(() => {
     const isSoloProblemRoute = /^\/problems\/\d+$/.test(pathname);

--- a/src/features/layout/ide-shell.tsx
+++ b/src/features/layout/ide-shell.tsx
@@ -224,7 +224,7 @@ export default function IdeShell({
             client.connectHeaders = { "X-WS-Token": data.token };
           }
         } catch {
-          // 荑좏궎 湲곕컲 ?몄쬆?쇰줈 ?대갚
+          // 쿠키 기반 인증으로 폴백
         }
       },
       onConnect: () => {

--- a/src/features/spectate-room/screen.tsx
+++ b/src/features/spectate-room/screen.tsx
@@ -8,9 +8,10 @@ import SockJS from "sockjs-client";
 
 import type {
   ApiErrorResponse,
-  BattleFinishedWsMessage,
+  BattleStartedWsMessage,
   CodeSyncWsMessage,
   CodeUpdateWsMessage,
+  ParticipantStatusChangedWsMessage,
   ProblemDetailResponse,
   RoomResponse,
 } from "@/shared/api/contracts";
@@ -192,13 +193,71 @@ export default function SpectateRoomScreen({ roomId }: { roomId: string }) {
           } catch {
             return;
           }
-          if (
-            typeof payload === "object" &&
-            payload !== null &&
-            "type" in payload &&
-            (payload as { type: unknown }).type === "BATTLE_FINISHED"
-          ) {
+          if (typeof payload !== "object" || payload === null || !("type" in payload)) {
+            return;
+          }
+
+          const type = (payload as { type: unknown }).type;
+
+          if (type === "PARTICIPANT_STATUS_CHANGED") {
+            const msg = payload as ParticipantStatusChangedWsMessage;
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                participants: current.participants.map((participant) =>
+                  participant.userId === msg.userId
+                    ? { ...participant, status: msg.status }
+                    : participant,
+                ),
+              };
+              participantsRef.current = nextRoom.participants;
+              roomStatusRef.current = nextRoom.status;
+              return nextRoom;
+            });
+            return;
+          }
+
+          if (type === "BATTLE_STARTED") {
+            const msg = payload as BattleStartedWsMessage;
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                status: "PLAYING" as const,
+                timerEnd:
+                  typeof msg.timerEnd === "string" || msg.timerEnd === null
+                    ? msg.timerEnd
+                    : current.timerEnd,
+              };
+              participantsRef.current = nextRoom.participants;
+              roomStatusRef.current = nextRoom.status;
+              return nextRoom;
+            });
+            return;
+          }
+
+          if (type === "BATTLE_FINISHED") {
             setBattleFinished(true);
+            setRoom((current) => {
+              if (!current) {
+                return current;
+              }
+
+              const nextRoom = {
+                ...current,
+                status: "FINISHED" as const,
+              };
+              participantsRef.current = nextRoom.participants;
+              roomStatusRef.current = nextRoom.status;
+              return nextRoom;
+            });
           }
         });
 

--- a/src/shared/api/contracts.ts
+++ b/src/shared/api/contracts.ts
@@ -421,6 +421,17 @@ export interface BattleFinishedWsMessage {
   type: "BATTLE_FINISHED";
 }
 
+export interface BattleStartedWsMessage {
+  type: "BATTLE_STARTED";
+  timerEnd?: string | null;
+}
+
+export interface ParticipantStatusChangedWsMessage {
+  type: "PARTICIPANT_STATUS_CHANGED";
+  userId: number;
+  status: "PLAYING" | "SOLVED" | "ABANDONED" | "TIMEOUT" | "QUIT";
+}
+
 export interface ParticipantDoneWsMessage {
   type: "PARTICIPANT_DONE";
   userId: number;


### PR DESCRIPTION
### 배경
배틀룸에서 참가자 상태를 polling으로 갱신하고 있었는데, 불필요한 주기 호출이 발생하고 상태 반영도 즉시성이 떨어지는 문제가 있었습니다. 이를 WebSocket 이벤트 기반으로 전환해 배틀룸, 관전 화면, 사이드바에서 동일한 상태를 실시간으로 동기화하도록 개선했습니다.

### 변경사항
배틀룸 참가자 상태 갱신 방식을 polling에서 WebSocket 구독 방식으로 변경
PARTICIPANT_STATUS_CHANGED 메시지 구독을 추가해 참가자 상태 변화를 실시간 반영
BATTLE_STARTED, BATTLE_FINISHED 이벤트를 반영해 방 상태와 타이머 UI 동기화 처리
관전 화면과 IDE 사이드바도 동일한 이벤트 기반 상태 갱신 로직으로 정리
재연결 시 방 정보를 재조회해 ABANDONED 등 연결 중 누락될 수 있는 상태를 복구하도록 보완

### 기대 효과
불필요한 polling 요청 감소
참가자 상태 변경 시 UI 반영 지연 최소화
배틀룸/관전/사이드바 간 상태 불일치 완화

### 확인 포인트
배틀 시작 시 각 화면의 상태와 타이머가 정상 반영되는지
참가자 상태 변경이 polling 없이 실시간으로 반영되는지
재연결 이후 ABANDONED 상태 참가자가 정상적으로 복구되는지
배틀 종료 시 방 상태가 각 화면에 일관되게 반영되는지