### PR TITLE
feat: 카테고리별 난이도 옵션 필터링 적용

### DIFF
--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
+import type { Difficulty } from "@/shared/api/contracts";
+
 import {
   fetchBackendWithReissue,
   getErrorMessage,
@@ -8,16 +10,35 @@ import {
 } from "@/shared/api/backend";
 import { FRONTEND_ACCESS_TOKEN_COOKIE } from "@/shared/auth/session";
 
+const DIFFICULTY_ORDER: Difficulty[] = ["EASY", "MEDIUM", "HARD"];
+
 interface BackendTagItem {
   code?: string;
   label?: string;
   value?: string;
   name?: string;
+  difficulties?: unknown;
 }
 
 interface TagOption {
   value: string;
   label: string;
+  difficulties?: Difficulty[];
+}
+
+function normalizeDifficulties(raw: unknown): Difficulty[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const incoming = new Set(
+    raw
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim().toUpperCase())
+      .filter((item): item is Difficulty => DIFFICULTY_ORDER.includes(item as Difficulty)),
+  );
+
+  return DIFFICULTY_ORDER.filter((item) => incoming.has(item));
 }
 
 function normalizeTags(payload: unknown): TagOption[] {
@@ -47,30 +68,39 @@ function normalizeTags(payload: unknown): TagOption[] {
       const candidate = item as BackendTagItem;
       const value = (candidate.code ?? candidate.value ?? candidate.name ?? "").trim();
       const label = (candidate.label ?? candidate.name ?? candidate.code ?? value).trim();
+      const difficulties = normalizeDifficulties(candidate.difficulties);
 
       if (!value || !label) {
         return null;
       }
 
-      return { value, label };
+      return { value, label, difficulties };
     })
     .filter((item): item is TagOption => item !== null);
 
-  const deduped: TagOption[] = [];
-  const seen = new Set<string>();
+  const dedupedByValue = new Map<string, TagOption>();
 
   for (const item of mapped) {
     const key = item.value.toLowerCase();
+    const existing = dedupedByValue.get(key);
 
-    if (seen.has(key)) {
+    if (!existing) {
+      dedupedByValue.set(key, item);
       continue;
     }
 
-    seen.add(key);
-    deduped.push(item);
+    if (!item.difficulties || item.difficulties.length === 0) {
+      continue;
+    }
+
+    const merged = new Set([...(existing.difficulties ?? []), ...item.difficulties]);
+    dedupedByValue.set(key, {
+      ...existing,
+      difficulties: DIFFICULTY_ORDER.filter((difficulty) => merged.has(difficulty)),
+    });
   }
 
-  return deduped;
+  return Array.from(dedupedByValue.values());
 }
 
 export async function GET() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,7 +60,9 @@ export default async function RootLayout({
                 href="/"
                 className="text-sm font-semibold tracking-tight text-app-primary"
               >
-                BRACKET C{"{ }"}DE
+                BRACKET C
+                <span className="text-app-accent">{"{ }"}</span>
+                DE
               </Link>
             </div>
           </header>

--- a/src/features/home/components/profile-pane.tsx
+++ b/src/features/home/components/profile-pane.tsx
@@ -349,13 +349,13 @@ export default function ProfilePane({
                 <>
                   <Link
                     href="/signup"
-                    className="block w-full rounded-md border border-app-border bg-app-base px-3 py-2 text-center text-sm font-medium text-app-primary transition hover:bg-app-elevated/90"
+                    className="block w-full rounded-md border border-app-border bg-app-base px-3 py-2 text-center text-sm font-semibold !text-white transition hover:bg-app-elevated/90"
                   >
                     회원가입
                   </Link>
                   <Link
                     href="/login?next=/"
-                    className="block w-full rounded-md bg-app-accent px-3 py-2 text-center text-sm font-semibold text-white transition hover:bg-app-accent-hover"
+                    className="block w-full rounded-md border border-app-accent/45 bg-app-accent px-3 py-2 text-center text-sm font-bold !text-white transition hover:bg-app-accent-hover"
                   >
                     로그인
                   </Link>

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -126,7 +126,7 @@ export default function QueueEditorPane({
             type="button"
             onClick={onStartMatch}
             disabled={!canStartMatch}
-            className="inline-flex h-10 items-center gap-2 rounded-md border border-app-accent/45 bg-app-accent px-3 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary"
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-app-accent/45 bg-app-accent px-3 text-sm font-bold text-[#f8faff] transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary"
             aria-label="매칭 시작"
           >
             <svg viewBox="0 0 16 16" fill="none" className="h-4 w-4 text-app-syntax-icon">

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -28,6 +28,33 @@ interface QueueEditorPaneProps {
   terminalMessage: string | null;
 }
 
+const difficultyToneStyles: Record<
+  Difficulty,
+  {
+    active: string;
+    inactive: string;
+  }
+> = {
+  EASY: {
+    active:
+      "border-emerald-300 bg-emerald-400/30 text-emerald-50 shadow-[0_0_0_1px_rgba(52,211,153,0.45),0_0_12px_rgba(16,185,129,0.35)]",
+    inactive:
+      "border-emerald-500/20 bg-emerald-500/5 text-emerald-200/55 opacity-75 hover:bg-emerald-500/12 hover:opacity-100",
+  },
+  MEDIUM: {
+    active:
+      "border-amber-300 bg-amber-400/28 text-amber-50 shadow-[0_0_0_1px_rgba(251,191,36,0.45),0_0_12px_rgba(245,158,11,0.35)]",
+    inactive:
+      "border-amber-500/20 bg-amber-500/5 text-amber-200/55 opacity-75 hover:bg-amber-500/12 hover:opacity-100",
+  },
+  HARD: {
+    active:
+      "border-rose-300 bg-rose-400/28 text-rose-50 shadow-[0_0_0_1px_rgba(251,113,133,0.45),0_0_12px_rgba(244,63,94,0.35)]",
+    inactive:
+      "border-rose-500/20 bg-rose-500/5 text-rose-200/55 opacity-75 hover:bg-rose-500/12 hover:opacity-100",
+  },
+};
+
 export default function QueueEditorPane({
   editorPaneRef,
   editorContentStyle,
@@ -149,10 +176,10 @@ export default function QueueEditorPane({
                   {difficultyOptions.map((option) => (
                     <label
                       key={option.value}
-                      className={`rounded-sm border px-2 py-1 text-xs transition ${
+                      className={`cursor-pointer select-none rounded-sm border px-2 py-1 text-xs font-medium transition ${
                         difficulty === option.value
-                          ? "border-app-syntax-selected-border/60 bg-app-syntax-selected-bg text-app-syntax-selected-text"
-                          : "border-app-border bg-app-elevated text-app-syntax-value hover:bg-app-elevated/90"
+                          ? `${difficultyToneStyles[option.value].active} translate-y-[-1px] font-semibold`
+                          : difficultyToneStyles[option.value].inactive
                       }`}
                     >
                       <input

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -28,6 +28,12 @@ interface QueueEditorPaneProps {
   terminalMessage: string | null;
 }
 
+function estimateTextWidth(text: string) {
+  return Array.from(text).reduce((total, char) => {
+    return total + (/^[\x20-\x7E]$/.test(char) ? 1 : 1.45);
+  }, 0);
+}
+
 const difficultyToneStyles: Record<
   Difficulty,
   {
@@ -77,6 +83,20 @@ export default function QueueEditorPane({
   error,
   terminalMessage,
 }: QueueEditorPaneProps) {
+  const selectedCategoryLabel =
+    categoryOptions.find((item) => item.value === category)?.label ?? category;
+  const categoryWidthCh = Math.min(
+    36,
+    Math.max(18, Math.ceil(estimateTextWidth(selectedCategoryLabel) + 8)),
+  );
+  const trimmedMemo = queueMemo.trim();
+  const memoSample = trimmedMemo.length > 0 ? trimmedMemo : "메모";
+  const memoContentWidthCh = Math.ceil(estimateTextWidth(memoSample));
+  const memoWidthCh =
+    trimmedMemo.length > 0
+      ? Math.min(72, Math.max(24, memoContentWidthCh + 5))
+      : 24;
+
   return (
     <main className="h-full overflow-hidden border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
       <div className="flex h-full min-h-0 flex-col">
@@ -146,13 +166,14 @@ export default function QueueEditorPane({
                 </span>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-app-syntax-name">QUEUE_CATEGORY</span>
-                <span className="text-app-syntax-operator">=</span>
-                <div className="relative min-w-[11rem] max-w-[18rem] flex-1 leading-none">
+                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_CATEGORY</span>
+                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
+                <div className="relative w-fit max-w-full leading-none">
                   <select
                     value={category}
                     onChange={(event) => onCategoryChange(event.target.value as QueueCategoryValue)}
                     className="h-7 w-full appearance-none rounded-sm border border-app-border bg-app-elevated px-2 pr-6 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
+                    style={{ width: `calc(${categoryWidthCh}ch + 0.75rem)`, maxWidth: "100%" }}
                   >
                     {categoryOptions.map((item) => (
                       <option
@@ -170,8 +191,8 @@ export default function QueueEditorPane({
                 </div>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-app-syntax-name">QUEUE_LEVEL</span>
-                <span className="text-app-syntax-operator">=</span>
+                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_LEVEL</span>
+                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
                 <div className="flex flex-wrap gap-1 leading-none">
                   {difficultyOptions.map((option) => (
                     <label
@@ -196,21 +217,27 @@ export default function QueueEditorPane({
                 </div>
               </div>
               <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 text-app-syntax-name">QUEUE_PARTY_SIZE</span>
-                <span className="text-app-syntax-operator">=</span>
-                <span className="inline-flex min-w-8 items-center justify-center rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-constant">
-                  4
+                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_PARTY_SIZE</span>
+                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
+                <span
+                  title="배틀 규칙상 4인 고정"
+                  className="inline-flex min-w-8 items-center justify-center rounded-sm border border-app-border bg-app-elevated px-2 text-xs font-semibold text-app-syntax-constant"
+                >
+                  4인 고정
                 </span>
               </div>
-              <div className="flex items-start gap-2" style={editorRowStyle}>
-                <span className="w-40 text-app-syntax-name">QUEUE_MEMO</span>
-                <span className="pt-1 text-app-syntax-operator">=</span>
-                <input
-                  type="text"
-                  value={queueMemo}
-                  onChange={(event) => onQueueMemoChange(event.target.value)}
-                  className="mt-0.5 h-7 w-full rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
-                />
+              <div className="flex items-center gap-2" style={editorRowStyle}>
+                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_MEMO</span>
+                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
+                <div className="w-fit max-w-full">
+                  <input
+                    type="text"
+                    value={queueMemo}
+                    onChange={(event) => onQueueMemoChange(event.target.value)}
+                    className="h-7 w-full rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
+                    style={{ width: `calc(${memoWidthCh}ch + 1.25rem)`, maxWidth: "100%" }}
+                  />
+                </div>
               </div>
 
               <div className="mt-2 text-app-syntax-comment" style={editorLineStyle}>

--- a/src/features/home/components/queue-editor-pane.tsx
+++ b/src/features/home/components/queue-editor-pane.tsx
@@ -76,7 +76,6 @@ export default function QueueEditorPane({
   onDifficultyChange,
   difficultyOptions,
   queueMemo,
-  onQueueMemoChange,
   showStopQueueButton,
   onCancelQueue,
   isBusy,
@@ -89,13 +88,17 @@ export default function QueueEditorPane({
     36,
     Math.max(18, Math.ceil(estimateTextWidth(selectedCategoryLabel) + 8)),
   );
-  const trimmedMemo = queueMemo.trim();
-  const memoSample = trimmedMemo.length > 0 ? trimmedMemo : "메모";
-  const memoContentWidthCh = Math.ceil(estimateTextWidth(memoSample));
-  const memoWidthCh =
-    trimmedMemo.length > 0
-      ? Math.min(72, Math.max(24, memoContentWidthCh + 5))
-      : 24;
+  const memoText = queueMemo.trim();
+  const javaSyntaxTone = {
+    "--app-syntax-default": "#a9b7c6",
+    "--app-syntax-comment": "#808080",
+    "--app-syntax-keyword": "#cc7832",
+    "--app-syntax-name": "#3b9ef4",
+    "--app-syntax-operator": "#a9b7c6",
+    "--app-syntax-string": "#6aab73",
+    "--app-syntax-value": "#a9b7c6",
+    "--app-syntax-constant": "#c77dbb",
+  } as CSSProperties;
 
   return (
     <main className="h-full overflow-hidden border-b border-app-border/80 bg-app-base lg:border-b-0 lg:border-r">
@@ -114,7 +117,7 @@ export default function QueueEditorPane({
                   <circle cx="6.4" cy="10.8" r="0.7" fill="currentColor" />
                 </svg>
               </span>
-              <span>.env.queue.match</span>
+              <span>Main.java</span>
               <span className="text-app-dim">×</span>
               <span className="absolute inset-x-0 bottom-0 h-[2px] bg-app-border-strong" />
             </div>
@@ -154,25 +157,67 @@ export default function QueueEditorPane({
                 </div>
               ))}
             </div>
-            <div className="px-4 py-4 text-app-syntax-default">
+            <div className="px-4 py-4 text-app-syntax-default" style={javaSyntaxTone}>
               <div className="whitespace-nowrap text-app-syntax-comment" style={editorLineStyle}>
-                # queue config
+                {"// queue config"}
               </div>
-              <div className="whitespace-nowrap text-app-syntax-comment" style={editorLineStyle}>
-                <span className="font-semibold text-app-syntax-keyword"># TODO:</span>
-                <span className="text-app-syntax-keyword">
+              <div className="whitespace-nowrap" style={editorLineStyle}>
+                <span className="text-app-syntax-comment">{"// "}</span>
+                <span className="font-semibold" style={{ color: "#8cb34a" }}>
+                  {"TODO:"}
+                </span>
+                <span style={{ color: "#8cb34a" }}>
                   {" "}
                   카테고리와 난이도를 선택하고 매칭 시작을 눌러 대기열에 참가합니다.
                 </span>
               </div>
-              <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_CATEGORY</span>
-                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
-                <div className="relative w-fit max-w-full leading-none">
+              <div className="whitespace-nowrap" style={editorLineStyle}>
+                <span style={{ color: "#bbb529" }}>@BracketApplication</span>
+                <span className="ml-3 inline-flex items-center gap-1 text-[11px] text-app-syntax-comment">
+                  <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3">
+                    <circle cx="8" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.2" />
+                    <path d="M3.5 12.5a4.5 4.5 0 0 1 9 0" stroke="currentColor" strokeWidth="1.2" />
+                  </svg>
+                  <span>BracCo *</span>
+                </span>
+              </div>
+              <div className="whitespace-nowrap" style={editorLineStyle}>
+                <span className="text-app-syntax-keyword">public class </span>
+                <span className="text-app-syntax-value">QueueMatchMain </span>
+                <span className="text-app-syntax-operator">{"{"}</span>
+              </div>
+              <div className="whitespace-nowrap pl-6" style={editorLineStyle}>
+                <span className="text-app-syntax-keyword">public static void </span>
+                <span className="text-app-syntax-name">main</span>
+                <span className="text-app-syntax-operator">(</span>
+                <span className="text-app-syntax-value">String</span>
+                <span className="text-app-syntax-operator">[] </span>
+                <span className="text-app-syntax-value">args</span>
+                <span className="text-app-syntax-operator">)</span>
+                <span className="text-app-syntax-operator"> {"{"}</span>
+              </div>
+              <div className="whitespace-nowrap pl-12" style={editorLineStyle}>
+                <span className="text-app-syntax-value">QueueConfig</span>
+                <span className="text-app-syntax-default"> </span>
+                <span className="text-app-syntax-value">queue</span>
+                <span className="text-app-syntax-default"> </span>
+                <span className="text-app-syntax-operator">=</span>
+                <span className="text-app-syntax-default"> </span>
+                <span className="text-app-syntax-value">QueueConfig</span>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default italic">builder</span>
+                <span className="text-app-syntax-operator">()</span>
+              </div>
+              <div className="flex items-center whitespace-nowrap pl-16" style={editorRowStyle}>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default">category</span>
+                <span className="text-app-syntax-operator">(</span>
+                <span className="text-app-syntax-string">{'"'}</span>
+                <div className="relative ml-0.5 w-fit max-w-full leading-none">
                   <select
                     value={category}
                     onChange={(event) => onCategoryChange(event.target.value as QueueCategoryValue)}
-                    className="h-7 w-full appearance-none rounded-sm border border-app-border bg-app-elevated px-2 pr-6 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
+                    className="h-7 w-full cursor-pointer appearance-none rounded-sm border border-app-border/70 bg-app-elevated/35 px-2 pr-6 text-xs text-app-syntax-string outline-none transition hover:border-app-syntax-selected-border/65 focus:border-app-syntax-selected-border/85"
                     style={{ width: `calc(${categoryWidthCh}ch + 0.75rem)`, maxWidth: "100%" }}
                   >
                     {categoryOptions.map((item) => (
@@ -185,15 +230,18 @@ export default function QueueEditorPane({
                       </option>
                     ))}
                   </select>
-                  <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-app-dim">
+                  <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-app-syntax-string/80">
                     ▾
                   </span>
                 </div>
+                <span className="ml-0.5 text-app-syntax-string">{'"'}</span>
+                <span className="text-app-syntax-operator">)</span>
               </div>
-              <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_LEVEL</span>
-                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
-                <div className="flex flex-wrap gap-1 leading-none">
+              <div className="flex items-center whitespace-nowrap pl-16" style={editorRowStyle}>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default">level</span>
+                <span className="text-app-syntax-operator">(</span>
+                <div className="ml-1 flex flex-wrap gap-1 leading-none">
                   {difficultyOptions.map((option) => (
                     <label
                       key={option.value}
@@ -215,29 +263,43 @@ export default function QueueEditorPane({
                     </label>
                   ))}
                 </div>
+                <span className="text-app-syntax-operator">)</span>
               </div>
-              <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_PARTY_SIZE</span>
-                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
+              <div className="flex items-center whitespace-nowrap pl-16" style={editorRowStyle}>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default">partySize</span>
+                <span className="text-app-syntax-operator">(</span>
+                <span className="text-app-syntax-string">{'"'}</span>
                 <span
                   title="배틀 규칙상 4인 고정"
-                  className="inline-flex min-w-8 items-center justify-center rounded-sm border border-app-border bg-app-elevated px-2 text-xs font-semibold text-app-syntax-constant"
+                  className="inline-flex min-w-[8ch] items-center px-0.5 text-xs font-medium text-app-syntax-string"
                 >
                   4인 고정
                 </span>
+                <span className="text-app-syntax-string">{'"'}</span>
+                <span className="text-app-syntax-operator">)</span>
               </div>
-              <div className="flex items-center gap-2" style={editorRowStyle}>
-                <span className="w-40 shrink-0 text-app-syntax-name">QUEUE_MEMO</span>
-                <span className="w-4 shrink-0 text-center text-app-syntax-operator">=</span>
-                <div className="w-fit max-w-full">
-                  <input
-                    type="text"
-                    value={queueMemo}
-                    onChange={(event) => onQueueMemoChange(event.target.value)}
-                    className="h-7 w-full rounded-sm border border-app-border bg-app-elevated px-2 text-xs text-app-syntax-string outline-none transition focus:border-app-accent/60"
-                    style={{ width: `calc(${memoWidthCh}ch + 1.25rem)`, maxWidth: "100%" }}
-                  />
-                </div>
+              <div className="flex items-center whitespace-nowrap pl-16" style={editorRowStyle}>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default">memo</span>
+                <span className="text-app-syntax-operator">(</span>
+                <span className="text-app-syntax-string">{'"'}</span>
+                <span className="text-xs font-medium text-app-syntax-string">
+                  {memoText.length > 0 ? memoText : "메인에서 바로 매칭을 시작할 수 있습니다."}
+                </span>
+                <span className="text-app-syntax-string">{'"'}</span>
+                <span className="text-app-syntax-operator">)</span>
+              </div>
+              <div className="whitespace-nowrap pl-16" style={editorLineStyle}>
+                <span className="text-app-syntax-operator">.</span>
+                <span className="text-app-syntax-default">build</span>
+                <span className="text-app-syntax-operator">();</span>
+              </div>
+              <div className="whitespace-nowrap pl-6 text-app-syntax-operator" style={editorLineStyle}>
+                {"}"}
+              </div>
+              <div className="whitespace-nowrap text-app-syntax-operator" style={editorLineStyle}>
+                {"}"}
               </div>
 
               <div className="mt-2 text-app-syntax-comment" style={editorLineStyle}>

--- a/src/features/home/data.ts
+++ b/src/features/home/data.ts
@@ -6,6 +6,7 @@ export const DEFAULT_REQUIRED_COUNT = 4;
 export interface QueueCategoryOption {
   value: string;
   label: string;
+  difficulties?: Difficulty[];
   disabled?: boolean;
 }
 

--- a/src/features/home/screen.tsx
+++ b/src/features/home/screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Client } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 
@@ -45,6 +45,7 @@ type SubscriptionHandle = { unsubscribe: () => void };
 const DEFAULT_FEEDBACK = "메인에서 바로 매칭을 시작할 수 있습니다.";
 const TAGS_CACHE_TTL_MS = 60_000;
 const MATCHING_PERSONAL_DESTINATION = "/user/queue/matching";
+const DIFFICULTY_ORDER: Difficulty[] = ["EASY", "MEDIUM", "HARD"];
 
 const defaultQueueState: QueueStateResponse = {
   inQueue: false,
@@ -66,6 +67,41 @@ let tagCategoriesCache: {
   categories: QueueCategoryOption[];
 } | null = null;
 let tagCategoriesInFlight: Promise<QueueCategoryOption[] | null> | null = null;
+
+function normalizeDifficultyValues(raw: unknown): Difficulty[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const incoming = new Set(
+    raw
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim().toUpperCase())
+      .filter((item): item is Difficulty => DIFFICULTY_ORDER.includes(item as Difficulty)),
+  );
+
+  return DIFFICULTY_ORDER.filter((item) => incoming.has(item));
+}
+
+function resolveAllowedDifficulties(
+  categories: QueueCategoryOption[],
+  targetCategory: QueueCategoryValue,
+) {
+  const matched = categories.find((item) => item.value === targetCategory);
+
+  if (!matched || !matched.difficulties || matched.difficulties.length === 0) {
+    return DIFFICULTY_ORDER;
+  }
+
+  const allowed = new Set(matched.difficulties);
+  const ordered = DIFFICULTY_ORDER.filter((item) => allowed.has(item));
+
+  if (ordered.length === 0) {
+    return DIFFICULTY_ORDER;
+  }
+
+  return ordered;
+}
 
 async function readQueueState() {
   const response = await fetch("/api/queue/me", {
@@ -118,11 +154,18 @@ async function readTagCategories() {
     }
 
     const normalized = payload
-      .map((item) => ({
-        value: (item.value ?? "").trim(),
-        label: (item.label ?? "").trim(),
-        disabled: item.disabled ?? false,
-      }))
+      .map((item) => {
+        const difficulties = normalizeDifficultyValues(item.difficulties);
+        const disabled =
+          item.disabled ?? (Array.isArray(item.difficulties) && (difficulties?.length ?? 0) === 0);
+
+        return {
+          value: (item.value ?? "").trim(),
+          label: (item.label ?? "").trim(),
+          disabled,
+          difficulties,
+        };
+      })
       .filter((item) => item.value.length > 0 && item.label.length > 0);
 
     if (normalized.length === 0) {
@@ -675,7 +718,7 @@ export default function HomeScreen() {
 
       setCategoryOptions(loadedCategories);
       setCategory((current) => {
-        if (loadedCategories.some((item) => item.value === current)) {
+        if (loadedCategories.some((item) => item.value === current && !item.disabled)) {
           return current;
         }
 
@@ -998,6 +1041,11 @@ export default function HomeScreen() {
       return;
     }
 
+    if (!availableDifficultyOptions.some((option) => option.value === difficulty)) {
+      setError("선택한 카테고리에서는 해당 난이도를 사용할 수 없습니다.");
+      return;
+    }
+
     if (modalMode && modalMode !== "TERMINAL") {
       setError("이미 진행 중인 매칭 흐름이 있습니다.");
       return;
@@ -1138,6 +1186,12 @@ export default function HomeScreen() {
   const countdownSeconds = getRemainingSeconds(matchState.readyCheck?.deadline ?? null, now);
   const canStartMatch = !(isBusy || (modalMode !== null && modalMode !== "TERMINAL"));
   const roomId = matchState.room?.roomId ?? null;
+  const availableDifficultyOptions = useMemo(() => {
+    const allowed = resolveAllowedDifficulties(categoryOptions, category);
+    const allowedSet = new Set(allowed);
+
+    return difficultyOptions.filter((option) => allowedSet.has(option.value));
+  }, [category, categoryOptions]);
   const editorLineNumbers = Array.from({ length: editorLineCount }, (_, index) => 41 + index);
   const editorLineStyle = {
     height: `${editorLineHeight}px`,
@@ -1150,6 +1204,30 @@ export default function HomeScreen() {
   const editorContentStyle = {
     fontSize: `${editorFontSize}px`,
   };
+
+  const handleCategoryChange = useCallback(
+    (nextCategory: QueueCategoryValue) => {
+      setCategory(nextCategory);
+      const allowed = resolveAllowedDifficulties(categoryOptions, nextCategory);
+
+      setDifficulty((current) => {
+        if (allowed.includes(current)) {
+          return current;
+        }
+
+        return allowed[0] ?? "EASY";
+      });
+    },
+    [categoryOptions],
+  );
+
+  useEffect(() => {
+    if (availableDifficultyOptions.some((item) => item.value === difficulty)) {
+      return;
+    }
+
+    setDifficulty(availableDifficultyOptions[0]?.value ?? "EASY");
+  }, [availableDifficultyOptions, difficulty]);
 
   return (
     <div className="relative h-full min-h-0">
@@ -1184,11 +1262,11 @@ export default function HomeScreen() {
           void handleStartMatch();
         }}
         category={category}
-        onCategoryChange={setCategory}
+        onCategoryChange={handleCategoryChange}
         categoryOptions={categoryOptions}
         difficulty={difficulty}
         onDifficultyChange={setDifficulty}
-        difficultyOptions={difficultyOptions}
+        difficultyOptions={availableDifficultyOptions}
         queueMemo={queueMemo}
         onQueueMemoChange={setQueueMemo}
         showStopQueueButton={modalMode === "SEARCHING"}

--- a/src/features/login/screen.tsx
+++ b/src/features/login/screen.tsx
@@ -141,7 +141,7 @@ export default function LoginScreen() {
             <button
               type="submit"
               disabled={isPending}
-              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:bg-app-elevated disabled:text-app-secondary"
+              className="mt-4 inline-flex h-11 w-full items-center justify-center rounded-md border border-app-accent/45 bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary"
             >
               {isPending ? "로그인 중..." : "로그인"}
             </button>

--- a/src/features/my-page/screen.tsx
+++ b/src/features/my-page/screen.tsx
@@ -852,11 +852,11 @@ export default function MyPageScreen() {
 
           {!session.authenticated ? (
             <div className="space-y-4 rounded-2xl border border-app-border bg-app-surface px-4 py-4">
-              <p className="text-sm text-app-secondary">{message}</p>
+              <p className="text-sm text-app-primary/90">{message}</p>
               <div className="flex flex-wrap gap-2">
                 <Link
                   href="/login?next=/mypage"
-                  className="inline-flex h-10 items-center justify-center rounded-md bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover"
+                  className="inline-flex h-10 items-center justify-center rounded-md border border-app-accent/45 bg-app-accent px-4 text-sm font-semibold text-white transition hover:bg-app-accent-hover"
                 >
                   로그인
                 </Link>


### PR DESCRIPTION
## 변경 사항
- 홈 화면에서 선택한 카테고리에 따라 난이도 옵션을 동적으로 필터링
- 카테고리 변경 시 현재 난이도가 허용되지 않으면 가능한 첫 난이도로 자동 보정
- 태그 API 응답의 difficulties 필드를 파싱/정규화하도록 프론트 /api/tags 라우트 확장

## 확인
- npm run lint -- src/app/api/tags/route.ts src/features/home/data.ts src/features/home/screen.tsx
- npm run build