### PR TITLE
[fix] ready-check 수락 버튼 상태 표현 및 액션 버튼 시인성 개선

### DIFF
--- a/src/features/home/queue-modal.tsx
+++ b/src/features/home/queue-modal.tsx
@@ -512,6 +512,22 @@ export default function QueueModal({
   }, [mode]);
   const actionButtonClass = "rounded-md border border-app-border-strong bg-app-elevated px-3 py-1.5 text-xs font-semibold text-app-primary transition hover:border-app-accent/55 hover:bg-app-accent/10 disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim";
   const actionPrimaryButtonClass = "rounded-md border border-app-accent/45 bg-gradient-to-r from-app-accent to-app-accent-hover px-3 py-1.5 text-xs font-semibold text-white shadow-[0_0_0_1px_var(--app-accent-glow)] transition hover:from-app-accent-hover hover:to-app-accent disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-elevated disabled:text-app-secondary";
+  const readyDecisionButtonBaseClass =
+    "inline-flex items-center justify-center rounded-sm border px-3.5 py-1.5 text-xs font-semibold leading-none transition";
+  const readyDecisionToneStyles = {
+    accept: {
+      active:
+        "border-emerald-300 bg-emerald-400/30 text-emerald-50 shadow-[0_0_0_1px_rgba(52,211,153,0.45),0_0_12px_rgba(16,185,129,0.35)]",
+      inactive:
+        "border-emerald-500/35 bg-emerald-500/8 text-emerald-100/85 shadow-[0_0_0_1px_rgba(16,185,129,0.12)] hover:bg-emerald-500/14 hover:text-emerald-50",
+    },
+    decline: {
+      active:
+        "border-rose-300 bg-rose-400/28 text-rose-50 shadow-[0_0_0_1px_rgba(251,113,133,0.45),0_0_12px_rgba(244,63,94,0.35)]",
+      inactive:
+        "border-rose-500/35 bg-rose-500/8 text-rose-100/85 shadow-[0_0_0_1px_rgba(244,63,94,0.12)] hover:bg-rose-500/14 hover:text-rose-50",
+    },
+  } as const;
   const headerStatusChipClass = "inline-flex items-center rounded-full border border-app-warn/45 bg-app-warn/10 px-2.5 py-0.5 text-[11px] font-semibold text-app-warn";
   const headerMetaChipClass = "inline-flex items-center rounded-full border border-app-border bg-app-base/55 px-2.5 py-0.5 text-[11px] font-medium text-app-muted";
   const headerMetaText = useMemo(() => {
@@ -644,24 +660,30 @@ export default function QueueModal({
       ) : null}
 
       {mode === "READY_CHECK" ? (
-        <>
-          <button
-            type="button"
-            onClick={onDecline}
-            disabled={isPending || !readyCheck}
-            className={actionButtonClass}
-          >
-            거절
-          </button>
+        <div className="flex flex-wrap gap-1 leading-none">
+          {!readyCheck?.acceptedByMe ? (
+            <button
+              type="button"
+              onClick={onDecline}
+              disabled={isPending || !readyCheck}
+              className={`${readyDecisionButtonBaseClass} ${readyDecisionToneStyles.decline.inactive} disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim disabled:shadow-none`}
+            >
+              거절
+            </button>
+          ) : null}
           <button
             type="button"
             onClick={onAccept}
             disabled={isPending || !readyCheck || readyCheck.acceptedByMe}
-            className={actionButtonClass}
+            className={`${readyDecisionButtonBaseClass} ${
+              readyCheck?.acceptedByMe
+                ? `${readyDecisionToneStyles.accept.active} min-w-[102px] justify-center`
+                : `${readyDecisionToneStyles.accept.inactive} disabled:cursor-not-allowed disabled:border-app-border disabled:bg-app-base disabled:text-app-dim disabled:shadow-none`
+            }`}
           >
             {readyCheck?.acceptedByMe ? "수락 완료" : "수락"}
           </button>
-        </>
+        </div>
       ) : null}
 
       {mode === "ROOM_READY" ? (


### PR DESCRIPTION
refs #104 
closes #104  

---
<h2>변경 내용</h2>
<ul>
  <li>READY_CHECK 단계의 액션 버튼 스타일을 홈 difficulty 토글과 어울리는 의미색 기반 톤으로 정리했습니다.</li>
  <li>거절 버튼은 rose 계열, 수락 버튼은 emerald 계열로 구분해 버튼 의미가 즉시 보이도록 했습니다.</li>
  <li>사용자가 수락한 뒤에는 거절 버튼을 숨기고, 초록색 <code>수락 완료</code> 단일 버튼만 남도록 상태 표현을 단순화했습니다.</li>
  <li>수락 완료 상태에서 버튼 정렬과 폭이 과하게 흔들리지 않도록 버튼 레이아웃을 함께 보정했습니다.</li>
</ul>

<h2>주요 파일</h2>
<ul>
  <li><code>src/features/home/queue-modal.tsx</code></li>
</ul>

<h2>테스트</h2>
<ul>
  <li><code>npx.cmd tsc --noEmit</code></li>
</ul>

<h2>확인 포인트</h2>
<ul>
  <li>READY_CHECK 진입 시 거절/수락 버튼이 이전보다 잘 구분되어 보이는지</li>
  <li>수락 전에는 <code>거절</code>, <code>수락</code> 두 버튼이 모두 보이는지</li>
  <li>수락 후에는 거절 버튼이 사라지고 <code>수락 완료</code> 버튼만 남는지</li>
  <li>모바일 또는 좁은 폭에서도 버튼 줄바꿈과 정렬이 자연스러운지</li>
</ul>
