### PR TITLE
[chore] 관리자 문제 템플릿 태그 한글화

### DIFF
--- a/src/features/admin-problems/screen.tsx
+++ b/src/features/admin-problems/screen.tsx
@@ -25,7 +25,7 @@ const SINGLE_TEMPLATE_OBJECT: AdminProblemUpsertRequest = {
   inputFormat:
     "첫 줄에 N, 둘째 줄에 N개의 정수 수열이 공백으로 주어진다. (음수 포함 가능)",
   outputFormat: "최대 부분합을 출력한다.",
-  tags: ["dp", "prefix-sum"],
+  tags: ["동적계획법", "누적합"],
   sampleCases: [
     { input: "5\\n1 -2 3 4 -1", output: "7" },
     { input: "4\\n-1 -2 -3 -4", output: "-1" },


### PR DESCRIPTION
## 작업 개요

- 관리자 문제 등록 템플릿의 태그 예시를 실제 현재 태그 표기(한글)와 맞췄습니다.

## 영향 범위

- route: `/admin/problems`
- feature: 관리자 문제 단건/대량 템플릿
- api/bff: 변경 없음

## 작업 내용

- [x] 단건 템플릿 태그 예시를 한글 값으로 변경
- [x] 대량 템플릿이 단건 템플릿을 참조하므로 동일 값 반영

## 변경 사항

- `tags: ["dp", "prefix-sum"]` -> `tags: ["동적계획법", "누적합"]`

## 테스트 및 확인

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [x] 관리자 문제 템플릿 문자열 수동 확인
- [x] 단건/대량 템플릿 동기 반영 확인

## 관련 이슈

- close #107

## 스크린샷 / 영상

- 없음

## 참고 자료

- 없음
